### PR TITLE
chore(deps): bump @emaarco/dmn-js-simulation to 0.2.0

### DIFF
--- a/apps/dmn-webview/package.json
+++ b/apps/dmn-webview/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@bpmn-io/cm-theme": "0.2.2",
         "@bpmn-io/properties-panel": "3.46.0",
-        "@emaarco/dmn-js-simulation": "0.1.0",
+        "@emaarco/dmn-js-simulation": "0.2.0",
         "@miragon/bpmn-modeler-i18n": "workspace:*",
         "@miragon/bpmn-modeler-shared": "workspace:*",
         "camunda-dmn-moddle": "1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2488,9 +2488,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emaarco/dmn-js-simulation@npm:0.1.0":
-  version: 0.1.0
-  resolution: "@emaarco/dmn-js-simulation@npm:0.1.0"
+"@emaarco/dmn-js-simulation@npm:0.2.0":
+  version: 0.2.0
+  resolution: "@emaarco/dmn-js-simulation@npm:0.2.0"
   dependencies:
     feelin: "npm:7.0.1"
   peerDependencies:
@@ -2504,7 +2504,7 @@ __metadata:
       optional: true
     inferno:
       optional: true
-  checksum: 10c0/f175d496ff1ce351e26d155bba192f7f3dbbde78154c9a5a6cdfd44e9f298320d6f4085e7f252175976036fbc6bb28804639d15df86fa5cc656e336c26f3d14e
+  checksum: 10c0/f43e95572732116325397aab7c68bd5f3f9fce67b0d7996cd12cb1f6e62ea8afe664697013b8eaa78f7d70cecafa5c764d9e7867d733e59370a2b04acd2a9a7f
   languageName: node
   linkType: hard
 
@@ -3799,7 +3799,7 @@ __metadata:
   dependencies:
     "@bpmn-io/cm-theme": "npm:0.2.2"
     "@bpmn-io/properties-panel": "npm:3.46.0"
-    "@emaarco/dmn-js-simulation": "npm:0.1.0"
+    "@emaarco/dmn-js-simulation": "npm:0.2.0"
     "@miragon/bpmn-modeler-i18n": "workspace:*"
     "@miragon/bpmn-modeler-shared": "workspace:*"
     "@types/vscode-webview": "npm:1.57.5"


### PR DESCRIPTION
## What

Bumps the DMN decision-simulation add-on `@emaarco/dmn-js-simulation`
from `0.1.0` to `0.2.0` in `apps/dmn-webview`.

## Why

`0.2.0` is the current `latest` release. It ships:

- **Features:** temporal & duration inputs, native pickers, and rule-derived bounds.
- **Fixes:** simulation lifecycle, DRD chaining, hit-policy and format correctness.

## Simple dependency update — no code changes

Verified the public API surface is unchanged between `0.1.0` and `0.2.0`:

- Entry points (`main`/`module`/`types`), `dependencies` and `peerDependencies` are identical.
- The `default` export (`DmnSimulationModule`) still exposes the two keys this repo consumes — `.decisionRequirementsDiagram` and `.decisionTable` (`apps/dmn-webview/src/app/modeler.ts`).

Only `package.json` (exact pin `0.1.0` → `0.2.0`) and the regenerated `yarn.lock` change.

## Verification

- `corepack yarn install` — lockfile regenerated cleanly.
- `corepack yarn workspace @miragon/dmn-modeler-webview build` — builds clean.
- `corepack yarn format:check` — passes.