### PR TITLE
fix(service): skip element-template load for disposed editors

### DIFF
--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.spec.ts
@@ -17,7 +17,10 @@ const EDITOR = "file:///work/.camunda/diagram.bpmn";
  * resolves whatever JSON text the test stages per path.
  */
 function createService() {
-    const editorStore = { postMessage: vi.fn().mockResolvedValue(true) };
+    const editorStore = {
+        postMessage: vi.fn().mockResolvedValue(true),
+        hasEditor: vi.fn().mockReturnValue(true),
+    };
     const vsDocument = { getFilePath: vi.fn().mockReturnValue(EDITOR) };
     const artifactSvc = {
         getArtifactPaths: vi.fn().mockResolvedValue([[], ".json"]),
@@ -163,5 +166,31 @@ describe("BpmnElementTemplatesService.setElementTemplates", () => {
         expect(result).toBe(false);
         expect(statusBar.hideElementTemplatesStatus).toHaveBeenCalledOnce();
         expect(notifier.notifyError).toHaveBeenCalledOnce();
+    });
+
+    it("skips quietly for a disposed editor without touching the status bar or webview", async () => {
+        const { service, editorStore, statusBar, notifier } = createService();
+        editorStore.hasEditor.mockReturnValue(false);
+
+        const result = await service.setElementTemplates(EDITOR);
+
+        expect(result).toBe(false);
+        expect(notifier.notifyError).not.toHaveBeenCalled();
+        expect(editorStore.postMessage).not.toHaveBeenCalled();
+        expect(statusBar.showElementTemplatesLoading).not.toHaveBeenCalled();
+        expect(notifier.logDebug).toHaveBeenCalledOnce();
+    });
+
+    it("does not notify when the editor is disposed mid-load", async () => {
+        const { service, editorStore, artifactSvc, notifier } = createService();
+        // Editor is present at entry but gone by the time the awaited read throws.
+        editorStore.hasEditor.mockReturnValueOnce(true).mockReturnValue(false);
+        artifactSvc.getArtifactPaths.mockRejectedValue(new Error("read raced a close"));
+
+        const result = await service.setElementTemplates(EDITOR);
+
+        expect(result).toBe(false);
+        expect(notifier.notifyError).not.toHaveBeenCalled();
+        expect(notifier.logDebug).toHaveBeenCalledOnce();
     });
 });

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.ts
@@ -36,6 +36,13 @@ export class BpmnElementTemplatesService implements ArtifactChangeTarget {
     ) {}
 
     async setElementTemplates(editorId: string): Promise<boolean> {
+        if (!this.editorStore.hasEditor(editorId)) {
+            this.notifier.logDebug(
+                `Skipping element-template load for disposed editor: ${editorId}`,
+            );
+            return false;
+        }
+
         this.statusBar.showElementTemplatesLoading();
         try {
             const documentDir = posix.dirname(this.vsDocument.getFilePath(editorId));
@@ -75,10 +82,6 @@ export class BpmnElementTemplatesService implements ArtifactChangeTarget {
             if (await this.editorStore.postMessage(editorId, new ElementTemplatesQuery(sorted))) {
                 this.statusBar.showElementTemplatesReady(sorted.length);
                 if (all.length > 0) {
-                    // Report templates loaded vs. files scanned separately — a
-                    // file can hold several templates, so conflating the two (the
-                    // old message reported the file count as the template count)
-                    // misled anyone cross-checking the status-bar count.
                     this.notifier.logInfo(
                         `${sorted.length} element template(s) loaded from ${all.length} file(s).`,
                     );
@@ -90,6 +93,12 @@ export class BpmnElementTemplatesService implements ArtifactChangeTarget {
             }
         } catch (error) {
             this.statusBar.hideElementTemplatesStatus();
+            if (!this.editorStore.hasEditor(editorId)) {
+                this.notifier.logDebug(
+                    `Element-template load aborted; editor disposed mid-load: ${editorId}`,
+                );
+                return false;
+            }
             return this.handleError(error as Error);
         }
     }

--- a/libs/modeler-core/src/shared/infrastructure/EditorSessionStore.ts
+++ b/libs/modeler-core/src/shared/infrastructure/EditorSessionStore.ts
@@ -66,6 +66,11 @@ export class EditorSessionStore {
         return Array.from(this.editors.keys());
     }
 
+    /** Whether an editor with this id is currently registered (not yet disposed). */
+    hasEditor(editorId: string): boolean {
+        return this.editors.has(editorId);
+    }
+
     getActiveEditorId(): string {
         if (!this.activeEditorId) {
             throw new Error("No active editor.");


### PR DESCRIPTION
## What

`setElementTemplates()` could throw `No editor found for id: file:///…` and surface it to the user as **"A problem occurred while loading element templates."** — even though everything works and the diagram renders fine.

## Why

An async/event-driven caller (marketplace refresh loop, `configFolder` setting change, or the initial `GetElementTemplatesCommand` webview request) can invoke `setElementTemplates` with an `editorId` whose handle was already disposed (editor closed / tab switched, or a refresh loop racing a close). The `EditorSessionStore.requireHandle()` lookup then throws, the outer `try/catch` routes it through `handleError()`, and the user sees a scary notification for a **benign, self-healing race** — the load result had nowhere to be delivered anyway.

The filesystem-watcher path already `.catch`es and only logs this exact case; the other callers should behave the same.

## How

- `EditorSessionStore`: add `hasEditor(editorId): boolean`.
- `BpmnElementTemplatesService.setElementTemplates`:
  - guard at entry — if the editor is already gone, `logDebug` + `return false` (no spinner, no notification);
  - re-check in the `catch` — if the editor was disposed mid-`await`, treat it as benign (`logDebug`) instead of notifying.
- Genuine failures on a **still-open** editor keep the user notification.

Change is confined to `libs/modeler-core` (host-agnostic) → applies to VS Code, IntelliJ, and Standalone.

## Tests

- `BpmnElementTemplatesService.spec.ts`: store double extended with `hasEditor`; two new tests (disposed-at-entry, disposed-mid-load) assert no `notifyError` and no `postMessage`.
- Service spec 9/9 green; `shared` suite 83/83 green. `format:check` clean, `lint` 0 errors.