### PR TITLE
chore(release): gate release publishing behind a single approval

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,10 +20,6 @@ jobs:
     name: Maintain release PR
     runs-on: ubuntu-latest
     outputs:
-      # The action prefixes per-path outputs with "<path>--" EXCEPT for the
-      # root path ".", whose outputs are unprefixed (setPathOutput in
-      # release-please-action). ".--release_created" never exists, which
-      # silently skips every downstream job via the empty-string comparison.
       vscode_released: ${{ steps.release.outputs.release_created }}
       vscode_tag: ${{ steps.release.outputs.tag_name }}
       vscode_version: ${{ steps.release.outputs.version }}
@@ -43,8 +39,18 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  vscode:
+  approve-release:
+    name: Approve release publish
     needs: release-please
+    if: needs.release-please.outputs.vscode_released == 'true' || needs.release-please.outputs.intellij_released == 'true'
+    runs-on: ubuntu-latest
+    environment: release-approval
+    steps:
+      - name: Record approval
+        run: echo "Release approved — vscode=${{ needs.release-please.outputs.vscode_tag }} intellij=${{ needs.release-please.outputs.intellij_tag }}"
+
+  vscode:
+    needs: [release-please, approve-release]
     if: needs.release-please.outputs.vscode_released == 'true'
     uses: ./.github/workflows/publish-vscode-modeler.yml
     with:
@@ -53,7 +59,7 @@ jobs:
     secrets: inherit
 
   open-vsx:
-    needs: release-please
+    needs: [release-please, approve-release]
     if: needs.release-please.outputs.vscode_released == 'true'
     uses: ./.github/workflows/publish-open-vsx-modeler.yml
     with:
@@ -62,7 +68,7 @@ jobs:
     secrets: inherit
 
   standalone:
-    needs: release-please
+    needs: [release-please, approve-release]
     if: needs.release-please.outputs.vscode_released == 'true'
     uses: ./.github/workflows/release-standalone.yml
     with:
@@ -71,7 +77,7 @@ jobs:
     secrets: inherit
 
   intellij:
-    needs: release-please
+    needs: [release-please, approve-release]
     if: needs.release-please.outputs.intellij_released == 'true'
     uses: ./.github/workflows/publish-intellij.yml
     with:


### PR DESCRIPTION
## Why

A release fanned out into four per-marketplace publish lines, each entering its own GitHub Environment with a required-reviewers rule (`vscode-marketplace`, `open-vsx-marketplace`, `standalone`, `jetbrains-marketplace`). GitHub cannot batch approvals across environments, so a single release had to be approved up to four times — and the prompts were staggered (the `standalone` gate only appears after its build stage runs), so they never even showed up together.

## What

- Add one upstream `approve-release` gate job (environment `release-approval`) to `release-please.yml`.
- Every publish line now `needs: [release-please, approve-release]`, so the whole fan-out waits on a single approval up front, before any build runs.

The per-marketplace environments keep their publishing secrets but drop their required-reviewers rule — approval is consolidated into `release-approval`. Those environment protection rules are repo settings, applied separately:

- `release-approval` created with the same two reviewers and the `main` branch / `v*` tag deployment policy the other environments use.
- Required reviewers removed from the four marketplace environments (secrets untouched).

## Result

After merging a release PR: `release-please` runs → one **Approve release publish** gate → after one approval, `vscode`, `open-vsx`, `standalone` and `intellij` all proceed.

## Trade-off

Triggering a publish workflow on its own via `workflow_dispatch` with `dry-run: false` no longer hits an approval gate. Manual dispatches default `dry-run` to `true`, so this does not enable an accidental real publish.