### PR TITLE
feat(bpmn): lint with a bundled default rule set when no .bpmnlintrc is found

### DIFF
--- a/apps/modeler-bridge/src/adapters.ts
+++ b/apps/modeler-bridge/src/adapters.ts
@@ -443,6 +443,10 @@ export class RpcStatusBar implements StatusBarPort {
         /* not supported yet for intellij */
     }
 
+    showBpmnlintDefault(): void {
+        /* not supported yet for intellij */
+    }
+
     showBpmnlintNoConfig(): void {
         /* not supported yet for intellij */
     }

--- a/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
+++ b/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
@@ -6,10 +6,11 @@
  * temp filesystem, so the `BpmnLintConfigLocator` + `BpmnLintConfigService` +
  * `NodeBpmnLinter` do an actual nearest-`.bpmnlintrc` walk and run bpmnlint.
  * Covers the two branches the webview's `GetBpmnlintConfigCommand` exposes: a
- * discovered config is linted and the findings pushed as `BpmnlintResultsQuery`,
- * and no config pushes `results: null` so the webview deactivates linting. The
- * temp dir has no `node_modules`, so built-in rules resolve from the bundled
- * fallback resolver — the same path a workspace without `bpmnlint` installed hits.
+ * discovered `.bpmnlintrc` is linted and its findings pushed as
+ * `BpmnlintResultsQuery`, and no config falls back to the bundled default rule
+ * set rather than deactivating linting. The temp dir has no `node_modules`, so
+ * built-in rules resolve from the bundled fallback resolver — the same path a
+ * workspace without `bpmnlint` installed hits.
  */
 
 import { promises as fs } from "node:fs";
@@ -114,12 +115,16 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
         expect(Object.keys(results)).toContain("start-event-required");
     });
 
-    it("pushes null results when no .bpmnlintrc exists so linting deactivates", async () => {
+    it("lints with the bundled default rules when no .bpmnlintrc exists", async () => {
         const { rpc, frames, editorId } = await setup();
 
         await requestConfig(rpc, editorId);
 
         const frame = await waitForFrame(frames, isLintResultsFrame);
-        expect(frame.params.message.results).toBeNull();
+        const results = frame.params.message.results;
+        expect(results).not.toBeNull();
+        // The bundled default flags the missing start/end events even with no config.
+        expect(Object.keys(results)).toContain("start-event-required");
+        expect(Object.keys(results)).toContain("end-event-required");
     });
 });

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeStatusBar.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeStatusBar.ts
@@ -64,6 +64,17 @@ export class VsCodeStatusBar implements StatusBarPort {
         item.show();
     }
 
+    showBpmnlintDefault(): void {
+        const item = this.getOrCreateBpmnlintStatusItem();
+        item.text = "$(shield) BPMNlint (default)";
+        item.tooltip =
+            "No .bpmnlintrc found — linting with the bundled default correctness rules" +
+            " (bpmnlint:recommended, minus style-only rules)." +
+            " Add a .bpmnlintrc to customize the rules or opt out.";
+        item.backgroundColor = undefined;
+        item.show();
+    }
+
     showBpmnlintNoConfig(): void {
         const item = this.getOrCreateBpmnlintStatusItem();
         item.text = "$(info) BPMNlint: no .bpmnlintrc";

--- a/docs/vscode/features/linting.md
+++ b/docs/vscode/features/linting.md
@@ -2,11 +2,22 @@
 
 The BPMN Modeler can validate your diagram **while you edit** using
 [bpmnlint](https://github.com/bpmn-io/bpmnlint) — the same linter you can run in
-CI. When a `.bpmnlintrc` is found, rule violations appear as ⚠️/❌ overlays on the
-offending elements, a summary button (error/warning counts) is shown on the
-canvas, and each finding is also published to the VS Code **Problems** panel
-(searchable and clickable, even without the diagram open). If no `.bpmnlintrc`
-exists, the feature stays dormant and the modeler looks exactly as it did before.
+CI. Rule violations appear as ⚠️/❌ overlays on the offending elements, a summary
+button (error/warning counts) is shown on the canvas, and each finding is also
+published to the VS Code **Problems** panel (searchable and clickable, even
+without the diagram open).
+
+**This runs out of the box, with no setup.** If no `.bpmnlintrc` is found, the
+modeler lints against a bundled default — the
+[`bpmnlint:recommended`](https://github.com/bpmn-io/bpmnlint/blob/main/docs/rules/README.md)
+preset, minus its three purely authoring/style rules (`label-required`,
+`no-overlapping-elements`, `global`) — so structural problems that would
+otherwise only surface as a deployment failure (disconnected flows, a missing
+start/end event, a fake join, …) are caught while you model, without opinions
+on labeling or layout you never asked for. The status bar shows `$(shield)
+BPMNlint (default)` in this state. Add a `.bpmnlintrc` at any level (see below)
+to customize the rules or take full control — even an empty `{}` file fully
+replaces the default with your own choices.
 
 The lint runs in the **extension host** (a full Node.js context), not in the
 webview. That is what lets it resolve your workspace's own
@@ -16,21 +27,24 @@ built-ins. See [Custom rules & plugins](#custom-rules-plugins) below.
 
 ## Usage
 
-1. Add a `.bpmnlintrc` at your workspace root (or under your
-   [`configFolder`](/vscode/configuration), default `.camunda/`):
+Open (or reopen) a `.bpmn` file with a structural issue — e.g. a disconnected
+element or a process missing an end event. Violations show up as overlays on
+the diagram, and the in-canvas lint button summarises the counts. The status
+bar shows `$(shield) BPMNlint (default)` while linting against the bundled
+default. Fix the issue and the overlay clears **live** — no save required.
 
-   ```json
-   {
-       "extends": "bpmnlint:recommended"
-   }
-   ```
+To customize the rules (e.g. also enforce labels on every task, or add
+project-specific checks), add a `.bpmnlintrc` at your workspace root or under
+your [`configFolder`](/vscode/configuration) (default `.camunda/`):
 
-2. Open (or reopen) a `.bpmn` file with a known issue — e.g. a task without a
-   label or a process missing an end event. Violations show up as overlays on
-   the diagram, and the in-canvas lint button summarises the counts. The VS Code
-   status bar shows `$(check) BPMNlint` (hover for the config path).
+```json
+{
+    "extends": "bpmnlint:recommended"
+}
+```
 
-3. Fix the issue and the overlay clears **live** — no save required.
+Once a `.bpmnlintrc` is found, it fully replaces the default — the VS Code
+status bar switches to `$(check) BPMNlint` (hover for the config path).
 
 ## Configuring rules
 

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
@@ -7,6 +7,7 @@ vi.mock("vscode", () => ({}));
 
 import { BpmnlintResultsQuery } from "@miragon/bpmn-modeler-shared";
 
+import { DEFAULT_BPMNLINT_CONFIG } from "./defaultBpmnlintConfig";
 import { BpmnLintConfigService } from "./BpmnLintConfigService";
 
 const EDITOR = "file:///work/diagram.bpmn";
@@ -32,6 +33,7 @@ function createService() {
     const statusBar = {
         showBpmnlintActive: vi.fn(),
         showBpmnlintUnresolved: vi.fn(),
+        showBpmnlintDefault: vi.fn(),
         showBpmnlintNoConfig: vi.fn(),
         hideBpmnlintStatus: vi.fn(),
     };
@@ -107,7 +109,7 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         expect(notifier.logWarning).toHaveBeenCalledWith(expect.stringContaining("custom/x"));
     });
 
-    it("posts null, clears diagnostics, and shows the no-config status when nothing is found", async () => {
+    it("lints with the bundled default config and shows the default status when no .bpmnlintrc is found", async () => {
         const { service, editorStore, locator, lintRunner, diagnostics, statusBar, notifier } =
             createService();
         locator.findNearestConfig.mockResolvedValue(undefined);
@@ -115,12 +117,21 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         const result = await service.setBpmnlintConfig(EDITOR);
 
         expect(result).toBe(true);
-        expect(lintRunner.lint).not.toHaveBeenCalled();
-        expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
-        expect(statusBar.showBpmnlintNoConfig).toHaveBeenCalledOnce();
-        expect(notifier.logDebug).toHaveBeenCalledWith("No .bpmnlintrc found; linting inactive");
+        expect(locator.readConfig).not.toHaveBeenCalled();
+        expect(lintRunner.lint).toHaveBeenCalledWith(
+            XML,
+            expect.stringContaining("/work/"),
+            DEFAULT_BPMNLINT_CONFIG,
+        );
+        expect(diagnostics.publish).toHaveBeenCalledWith(EDITOR, XML, RESULTS);
+        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledOnce();
+        expect(statusBar.showBpmnlintActive).not.toHaveBeenCalled();
+        expect(statusBar.showBpmnlintNoConfig).not.toHaveBeenCalled();
+        expect(notifier.logInfo).toHaveBeenCalledWith(
+            "No .bpmnlintrc found; linting with the bundled default correctness rules",
+        );
         const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintResultsQuery;
-        expect(msg.results).toBeNull();
+        expect(msg.results).toEqual(RESULTS);
     });
 
     it("still posts results but leaves the status bar untouched when reflectInStatusBar is false", async () => {

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
@@ -14,6 +14,7 @@ import {
     BpmnLintConfigLocator,
     BpmnlintChangeTarget,
 } from "../../../shared/service/BpmnLintConfigLocator";
+import { DEFAULT_BPMNLINT_CONFIG, defaultConfigPathFor } from "./defaultBpmnlintConfig";
 
 /**
  * Discovers the nearest `.bpmnlintrc` for an open BPMN document, runs bpmnlint
@@ -22,6 +23,13 @@ import {
  * custom `bpmnlint-plugin-*` rules and `plugin:<pkg>/recommended` configs resolve
  * against the workspace `node_modules` — the browser webview only ever saw the
  * built-in rules bundled into it.
+ *
+ * When no `.bpmnlintrc` is found, this does **not** leave linting dormant: it
+ * lints against {@link DEFAULT_BPMNLINT_CONFIG} instead, so every diagram gets
+ * baseline execution-safety checks (disconnected flows, missing start/end
+ * events, fake joins, …) with zero setup — the gap that otherwise only surfaces
+ * as a deployment failure. Any `.bpmnlintrc` the workspace adds — even an empty
+ * `{}` — takes over completely, per the locator's nearest-config-wins semantics.
  *
  * The same findings are also published as host diagnostics (Problems panel) and
  * summarised in the status bar. Filesystem discovery / reading / watching lives
@@ -56,62 +64,68 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
     }
 
     /**
-     * Resolves the nearest `.bpmnlintrc`, lints the current document XML against
-     * it, then pushes the findings to the webview and publishes them as
-     * diagnostics. A missing config deactivates linting; a read/parse/lint
-     * failure degrades to the no-config state rather than crashing the editor.
+     * Resolves the nearest `.bpmnlintrc` — falling back to
+     * {@link DEFAULT_BPMNLINT_CONFIG} when none exists — lints the current
+     * document XML against it, then pushes the findings to the webview and
+     * publishes them as diagnostics. A read/parse/lint failure against a
+     * *found* `.bpmnlintrc` degrades to the no-config state rather than
+     * crashing the editor; it never falls back to the default in that case, so
+     * a broken config fails loudly instead of silently swapping in different
+     * rules than the workspace asked for.
      */
     private async lintAndPush(editorId: string, reflectInStatusBar: boolean): Promise<boolean> {
         let results: LintResults | null;
         try {
             const dir = posix.dirname(this.vsDocument.getFilePath(editorId));
             const configPath = await this.locator.findNearestConfig(dir);
+            const usingDefault = configPath === undefined;
 
-            if (!configPath) {
-                if (reflectInStatusBar) {
-                    this.statusBar.showBpmnlintNoConfig();
-                }
-                this.diagnostics.clear(editorId);
-                this.notifier.logDebug("No .bpmnlintrc found; linting inactive");
-                results = null;
-            } else {
-                const config = JSON.parse(await this.locator.readConfig(configPath)) as Record<
-                    string,
-                    unknown
-                >;
-                const xml = this.vsDocument.getContent(editorId);
-                const { results: lintResults, unresolved } = await this.lintRunner.lint(
-                    xml,
-                    configPath,
-                    config,
-                );
+            const effectiveConfigPath = configPath ?? defaultConfigPathFor(dir);
+            const config = configPath
+                ? (JSON.parse(await this.locator.readConfig(configPath)) as Record<
+                      string,
+                      unknown
+                  >)
+                : DEFAULT_BPMNLINT_CONFIG;
 
-                this.diagnostics.publish(editorId, xml, lintResults);
-                if (reflectInStatusBar) {
-                    if (unresolved.length > 0) {
-                        this.statusBar.showBpmnlintUnresolved(configPath, unresolved);
-                    } else {
-                        this.statusBar.showBpmnlintActive(configPath);
-                    }
-                }
+            const xml = this.vsDocument.getContent(editorId);
+            const { results: lintResults, unresolved } = await this.lintRunner.lint(
+                xml,
+                effectiveConfigPath,
+                config,
+            );
+
+            this.diagnostics.publish(editorId, xml, lintResults);
+            if (reflectInStatusBar) {
                 if (unresolved.length > 0) {
-                    // The finding was previously buried in the output channel while
-                    // the status bar still showed a green tick — surface it plainly.
-                    this.notifier.logWarning(
-                        `bpmnlint: ${unresolved.length} rule(s)/config(s) could not be resolved and were skipped: ${unresolved.join(
-                            ", ",
-                        )}`,
-                    );
+                    this.statusBar.showBpmnlintUnresolved(effectiveConfigPath, unresolved);
+                } else if (usingDefault) {
+                    this.statusBar.showBpmnlintDefault();
+                } else {
+                    this.statusBar.showBpmnlintActive(effectiveConfigPath);
                 }
-                this.notifier.logInfo(`bpmnlint applied from ${configPath}`);
-                results = lintResults;
             }
+            if (unresolved.length > 0) {
+                // The finding was previously buried in the output channel while
+                // the status bar still showed a green tick — surface it plainly.
+                this.notifier.logWarning(
+                    `bpmnlint: ${unresolved.length} rule(s)/config(s) could not be resolved and were skipped: ${unresolved.join(
+                        ", ",
+                    )}`,
+                );
+            }
+            this.notifier.logInfo(
+                usingDefault
+                    ? "No .bpmnlintrc found; linting with the bundled default correctness rules"
+                    : `bpmnlint applied from ${effectiveConfigPath}`,
+            );
+            results = lintResults;
         } catch (error) {
-            // A malformed .bpmnlintrc or a linter blow-up must not crash the
-            // editor — warn, fall back to the no-config state, and tell the
-            // webview to deactivate linting.
+            // A malformed .bpmnlintrc, unparsable diagram XML, or a linter
+            // blow-up must not crash the editor — warn, fall back to the
+            // no-config state, and tell the webview to deactivate linting.
             this.notifier.logError(
-                new Error(`Failed to lint against .bpmnlintrc: ${(error as Error).message}`),
+                new Error(`Failed to lint diagram: ${(error as Error).message}`),
             );
             if (reflectInStatusBar) {
                 this.statusBar.showBpmnlintNoConfig();

--- a/libs/modeler-core/src/modeler/bpmn/service/defaultBpmnlintConfig.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/defaultBpmnlintConfig.ts
@@ -1,0 +1,67 @@
+import { posix } from "path";
+
+/**
+ * Applied when no `.bpmnlintrc` is found anywhere from the document's directory
+ * up to the workspace root, so every diagram gets baseline execution-safety
+ * checks — disconnected flows, missing start/end events, fake joins, and the
+ * like — without any setup.
+ *
+ * This is `bpmnlint:recommended`'s rule set (see
+ * `bpmnlint/config/recommended.js`) with the three purely
+ * authoring/style rules removed: `label-required` (an unlabeled task is bad
+ * practice, not a broken diagram), `no-overlapping-elements` (a canvas-layout
+ * nit), and `global` (warns about elements reachable from multiple processes —
+ * a modelling-convention call, not a correctness one). A diagram that expressed
+ * no `.bpmnlintrc` preference at all should get flagged for things that break
+ * execution or deployment, not for style choices a project hasn't opted into.
+ *
+ * Listed as bare `rules`, not `extends: "bpmnlint:recommended"`, so removing
+ * those three stays a one-line diff against the upstream preset instead of a
+ * second config layering rule overrides on top of it. Every rule name here
+ * resolves against the statically-bundled {@link builtinResolver} (see
+ * `../infrastructure/bpmnlint/builtinResolver.ts`), so this works with no
+ * workspace `bpmnlint` install and no network access.
+ *
+ * Adding *any* `.bpmnlintrc` — even an empty `{}` — fully overrides this default
+ * and hands the workspace complete control again, per
+ * {@link BpmnLintConfigLocator}'s existing nearest-config-wins resolution.
+ */
+export const DEFAULT_BPMNLINT_CONFIG: Record<string, unknown> = {
+    rules: {
+        "ad-hoc-sub-process": "error",
+        "conditional-flows": "error",
+        "end-event-required": "error",
+        "event-based-gateway": "error",
+        "event-sub-process-typed-start-event": "error",
+        "fake-join": "warn",
+        "link-event": "error",
+        "no-bpmndi": "error",
+        "no-complex-gateway": "error",
+        "no-disconnected": "error",
+        "no-duplicate-sequence-flows": "error",
+        "no-gateway-join-fork": "error",
+        "no-implicit-end": "error",
+        "no-implicit-split": "error",
+        "no-implicit-start": "error",
+        "no-inclusive-gateway": "warn",
+        "single-blank-start-event": "error",
+        "single-event-definition": "error",
+        "start-event-required": "error",
+        "sub-process-blank-start-event": "error",
+        "superfluous-gateway": "warn",
+        "superfluous-termination": "warn",
+    },
+};
+
+/**
+ * A virtual `.bpmnlintrc` path used only to anchor {@link NodeBpmnLinter}'s
+ * scoped-require resolution root (`dirname(configPath)`) when linting against
+ * {@link DEFAULT_BPMNLINT_CONFIG}. No file exists at this path — the default
+ * config references no plugins, so nothing is ever read from it — but it must
+ * still look like a config file inside `documentDir` for that resolution to
+ * anchor correctly. The `<...>` name keeps it visibly distinct from a real
+ * `.bpmnlintrc` in logs/tooltips, since no such file is ever written or read.
+ */
+export function defaultConfigPathFor(documentDir: string): string {
+    return posix.join(documentDir, "<bpmnlint-default>");
+}

--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -205,6 +205,13 @@ export interface StatusBarPort {
      * never masks silently-dropped rules — `unresolved` lists them for the tooltip.
      */
     showBpmnlintUnresolved(configPath: string, unresolved: string[]): void;
+    /**
+     * No `.bpmnlintrc` was found, so the bundled default (`bpmnlint:correctness`)
+     * is linting instead — distinct from {@link showBpmnlintActive} so a
+     * project-defined config is never visually confused with the zero-setup
+     * default that runs in its absence.
+     */
+    showBpmnlintDefault(): void;
     showBpmnlintNoConfig(): void;
     hideBpmnlintStatus(): void;
 }


### PR DESCRIPTION
**Issue**

Relates to #1320 (opened alongside this PR, per the contribution guide's "discuss scope before investing effort" process — happy to adjust the approach here based on that discussion).

**Description**

Today, `BpmnLintConfigService` only lints once a `.bpmnlintrc` is found; with none, linting is entirely dormant ("A missing config deactivates linting"). That means a diagram can have structural problems — a disconnected element, a missing start/end event, a fake join — with zero on-canvas feedback, and the first sign of trouble is a deployment failure.

This PR falls back to a small bundled default rule set when no `.bpmnlintrc` is found, instead of staying dormant:

- `libs/modeler-core/.../service/defaultBpmnlintConfig.ts` (new): the default config — `bpmnlint:recommended`'s rules minus the three purely authoring/style ones (`label-required`, `no-overlapping-elements`, `global`) — plus a virtual config-path helper used only to anchor `NodeBpmnLinter`'s module-resolution root (no file is ever read from it).
- `BpmnLintConfigService.lintAndPush`: uses the default config/path when `BpmnLintConfigLocator.findNearestConfig` returns `undefined`, instead of short-circuiting to the no-config state. A **found but broken** `.bpmnlintrc` still degrades to the no-config state as before — a broken config fails loudly rather than silently swapping in different rules than the workspace asked for.
- `StatusBarPort.showBpmnlintDefault()` (new): a status distinct from `showBpmnlintActive`, so the bundled default (`$(shield) BPMNlint (default)`) is never visually confused with a project's own `.bpmnlintrc` (`$(check) BPMNlint`). Implemented in `VsCodeStatusBar`; the IntelliJ bridge's `RpcStatusBar` gets the same no-op stub as its sibling methods (bridge status bar isn't wired up yet).
- No webview changes needed — findings still flow through the existing `BpmnlintResultsQuery` transport, so in-canvas overlays and the Problems panel pick up default findings automatically.
- `docs/vscode/features/linting.md` updated to describe the new zero-setup default and when a `.bpmnlintrc` takes over.

**Any `.bpmnlintrc` the workspace adds — even an empty `{}` — still fully overrides the default**, per the existing nearest-config-wins resolution in `BpmnLintConfigLocator`. This is scoped to BPMN only; DMN linting is still unsupported (see #1320's Additional Context).

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
