### PR TITLE
feat(bpmn-webview): list lint findings in a problems panel

### DIFF
--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
@@ -200,8 +200,9 @@ describe("LintConfigService problems panel", () => {
             "some-rule": [{ id: "Process_1", message: "Process-level problem", category: "error" }],
         });
 
-        const row = document.querySelector<HTMLButtonElement>(".lint-problems__row");
-        expect(row?.disabled).toBe(true);
+        const row = document.querySelector<HTMLElement>(".lint-problems__row");
+        expect(row?.tagName).toBe("DIV");
+        expect(row?.querySelector("button")).toBeNull();
         row?.click();
         expect(selection.select).not.toHaveBeenCalled();
     });

--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
@@ -6,7 +6,7 @@ import { LintConfigService } from "./LintConfigService";
 function fakeLinting() {
     return {
         active: false,
-        lint: undefined as undefined | (() => Promise<unknown>),
+        lint: vi.fn(() => Promise.resolve({})),
         isActive(): boolean {
             return this.active;
         },
@@ -17,27 +17,77 @@ function fakeLinting() {
     };
 }
 
+function fakeCanvas() {
+    const content = document.createElement("div");
+    content.className = "content";
+    const canvasHost = document.createElement("div");
+    canvasHost.className = "canvas";
+    const container = document.createElement("div");
+    container.className = "djs-container";
+    canvasHost.append(container);
+    content.append(canvasHost);
+    document.body.append(content);
+    return {
+        content,
+        canvasHost,
+        getContainer: () => container,
+        resized: vi.fn(),
+        scrollToElement: vi.fn(),
+        viewbox: vi.fn().mockReturnValue({ x: 0, y: 0, width: 800, height: 600 }),
+    };
+}
+
+interface FakeElement {
+    businessObject?: { name?: string };
+    parent?: object;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+    waypoints?: ReadonlyArray<{ x: number; y: number }>;
+}
+
+function fakeElementRegistry(elements: Record<string, FakeElement>) {
+    return { get: (id: string) => elements[id] };
+}
+
+function makeService(
+    linting = fakeLinting(),
+    canvas = fakeCanvas(),
+    elements: Record<string, FakeElement> = {},
+    selection = { select: vi.fn() },
+) {
+    const service = new LintConfigService(
+        linting,
+        canvas,
+        fakeElementRegistry(elements),
+        selection,
+    );
+    return { service, linting, canvas, selection };
+}
+
 beforeEach(() => {
     document.body.className = "";
+    document.body.innerHTML = "";
     vi.clearAllMocks();
 });
 
 describe("LintConfigService.render", () => {
     it("overrides linting.lint to return the host-provided results", async () => {
         const linting = fakeLinting();
-        const svc = new LintConfigService(linting);
+        const { service } = makeService(linting);
 
         const results = { "label-required": [{ id: "Task_1", message: "x", category: "warn" }] };
-        svc.render(results);
+        service.render(results);
 
         expect(linting.lint).toBeDefined();
         await expect(linting.lint!()).resolves.toEqual(results);
     });
 
-    it("activates linting and reveals the button when results arrive", () => {
-        const linting = fakeLinting();
+    it("activates marker overlays when results arrive", () => {
+        const { service, linting } = makeService();
 
-        new LintConfigService(linting).render({});
+        service.render({});
 
         expect(linting.isActive()).toBe(true);
         expect(document.body.classList.contains("bpmnlint-active")).toBe(true);
@@ -46,30 +96,158 @@ describe("LintConfigService.render", () => {
     it("re-renders via update() when already active", () => {
         const linting = fakeLinting();
         linting.active = true;
-        const svc = new LintConfigService(linting);
+        const { service } = makeService(linting);
 
-        svc.render({});
+        service.render({});
 
         expect(linting.update).toHaveBeenCalledTimes(1);
         expect(linting.toggle).not.toHaveBeenCalled();
     });
 
-    it("deactivates linting and hides the button when results are null", () => {
+    it("deactivates linting and hides the panel when results are null", () => {
         const linting = fakeLinting();
         linting.active = true;
         document.body.classList.add("bpmnlint-active");
+        const { service } = makeService(linting);
+        service.render({});
 
-        new LintConfigService(linting).render(null);
+        service.render(null);
 
         expect(linting.toggle).toHaveBeenCalledWith(false);
         expect(document.body.classList.contains("bpmnlint-active")).toBe(false);
+        expect(document.querySelector(".lint-problems--visible")).toBeNull();
     });
 
     it("does not toggle when already inactive and results are null", () => {
-        const linting = fakeLinting();
+        const { service, linting } = makeService();
 
-        new LintConfigService(linting).render(null);
+        service.render(null);
 
         expect(linting.toggle).not.toHaveBeenCalled();
+    });
+});
+
+describe("LintConfigService problems panel", () => {
+    it("docks the panel below the canvas while leaving the properties panel beside it", () => {
+        const canvas = fakeCanvas();
+        const { service } = makeService(fakeLinting(), canvas);
+
+        service.render({});
+
+        const column = canvas.content.querySelector(".lint-problems-column");
+        expect(column).not.toBeNull();
+        expect(column!.children[0]).toBe(canvas.canvasHost);
+        expect(column!.children[1]?.classList.contains("lint-problems")).toBe(true);
+        expect(canvas.resized).toHaveBeenCalled();
+    });
+
+    it("orders problems by severity and navigates to the selected element", () => {
+        const canvas = fakeCanvas();
+        const selection = { select: vi.fn() };
+        const task = {
+            businessObject: { name: "Do work" },
+            parent: {},
+            x: 100,
+            y: 120,
+            width: 100,
+            height: 80,
+        };
+        const { service } = makeService(fakeLinting(), canvas, { Task_1: task }, selection);
+
+        service.render({
+            "label-required": [
+                { id: "Task_1", message: "Element is missing label", category: "warn" },
+            ],
+            "no-implementation": [
+                { id: "Task_1", message: "Missing implementation", category: "error" },
+            ],
+        });
+
+        const rows = [...document.querySelectorAll<HTMLButtonElement>(".lint-problems__row")];
+        expect(rows.map((row) => row.title)).toEqual([
+            "Missing implementation",
+            "Element is missing label",
+        ]);
+        expect(rows[0].querySelector(".lint-problems__row-element")?.textContent).toBe("Do work");
+
+        rows[0].click();
+        expect(selection.select).toHaveBeenCalledWith(task);
+        expect(canvas.scrollToElement).toHaveBeenCalledWith(task);
+        expect(canvas.viewbox).toHaveBeenLastCalledWith({
+            x: -250,
+            y: -140,
+            width: 800,
+            height: 600,
+        });
+        expect(canvas.scrollToElement.mock.invocationCallOrder[0]).toBeLessThan(
+            selection.select.mock.invocationCallOrder[0],
+        );
+    });
+
+    it("renders process-level problems without making them navigable", () => {
+        const process = {
+            businessObject: { name: "Order process" },
+            x: 0,
+            y: 0,
+            width: 1000,
+            height: 800,
+        };
+        const { service, selection } = makeService(fakeLinting(), fakeCanvas(), {
+            Process_1: process,
+        });
+
+        service.render({
+            "some-rule": [{ id: "Process_1", message: "Process-level problem", category: "error" }],
+        });
+
+        const row = document.querySelector<HTMLButtonElement>(".lint-problems__row");
+        expect(row?.disabled).toBe(true);
+        row?.click();
+        expect(selection.select).not.toHaveBeenCalled();
+    });
+
+    it("centers and selects sequence-flow problems from their waypoints", () => {
+        const canvas = fakeCanvas();
+        const selection = { select: vi.fn() };
+        const flow = {
+            businessObject: { name: "Rejected" },
+            parent: {},
+            waypoints: [
+                { x: 20, y: 40 },
+                { x: 120, y: 80 },
+            ],
+        };
+        const { service } = makeService(fakeLinting(), canvas, { Flow_1: flow }, selection);
+
+        service.render({
+            "conditional-flows": [
+                { id: "Flow_1", message: "Condition is missing", category: "error" },
+            ],
+        });
+        document.querySelector<HTMLButtonElement>(".lint-problems__row")!.click();
+
+        expect(canvas.viewbox).toHaveBeenLastCalledWith({
+            x: -330,
+            y: -240,
+            width: 800,
+            height: 600,
+        });
+        expect(selection.select).toHaveBeenCalledWith(flow);
+    });
+
+    it("keeps markers hidden across live result updates", () => {
+        const { service, linting } = makeService();
+        service.render({});
+        expect(linting.isActive()).toBe(true);
+
+        document.querySelector<HTMLButtonElement>(".lint-problems__overlays")!.click();
+        expect(linting.isActive()).toBe(false);
+        linting.update.mockClear();
+
+        service.render({});
+
+        expect(linting.isActive()).toBe(false);
+        expect(linting.update).not.toHaveBeenCalled();
+        expect(document.querySelector(".lint-problems--visible")).not.toBeNull();
     });
 });

--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
@@ -1,5 +1,7 @@
 import { LintResults } from "@miragon/bpmn-modeler-shared";
 
+import { ProblemsPanel, ProblemsPanelIssue } from "./ProblemsPanel";
+
 /**
  * The subset of `bpmn-js-bpmnlint`'s `linting` module this service drives. The
  * package ships no types, so we declare only the members we touch: `lint` is
@@ -13,11 +15,80 @@ interface Linting {
     toggle(active: boolean): void;
 }
 
+interface Canvas {
+    getContainer(): HTMLElement;
+    resized(): void;
+    scrollToElement(element: object): void;
+    viewbox(): Viewbox;
+    viewbox(viewbox: Viewbox): void;
+}
+
+interface DiagramElement {
+    businessObject?: { name?: string };
+    parent?: object;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+    waypoints?: ReadonlyArray<{ x: number; y: number }>;
+}
+
+interface ElementRegistry {
+    get(id: string): DiagramElement | undefined;
+}
+
+interface Selection {
+    select(element: object): void;
+}
+
+interface Viewbox {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+const SEVERITY_RANK: Record<ProblemsPanelIssue["severity"], number> = {
+    error: 0,
+    warn: 1,
+    info: 2,
+};
+
+function toSeverity(category: string): ProblemsPanelIssue["severity"] {
+    switch (category) {
+        case "error":
+        case "rule-error":
+            return "error";
+        case "warn":
+        case "warning":
+            return "warn";
+        default:
+            return "info";
+    }
+}
+
+function centerOf(element: DiagramElement): { x: number; y: number } | undefined {
+    if (typeof element.x === "number" && typeof element.y === "number") {
+        return {
+            x: element.x + (element.width ?? 0) / 2,
+            y: element.y + (element.height ?? 0) / 2,
+        };
+    }
+    const waypoints = element.waypoints;
+    if (!waypoints?.length) {
+        return undefined;
+    }
+    const x = waypoints.map((point) => point.x);
+    const y = waypoints.map((point) => point.y);
+    return {
+        x: (Math.min(...x) + Math.max(...x)) / 2,
+        y: (Math.min(...y) + Math.max(...y)) / 2,
+    };
+}
+
 /**
  * bpmn-js DI service (registered by {@link LintModule}) that renders
- * host-computed bpmnlint results in the canvas. The extension host now runs the
- * linter (a full Node context, so it resolves custom `bpmnlint-plugin-*` rules
- * against the workspace); the webview only paints overlays.
+ * host-computed bpmnlint results as canvas overlays and in the problems panel.
  *
  * It feeds results into `bpmn-js-bpmnlint`'s `linting` module by overriding the
  * module's `lint()` to return whatever the host last sent, instead of running a
@@ -26,11 +97,20 @@ interface Linting {
  * no overlay/rendering code changes.
  */
 export class LintConfigService {
-    static $inject = ["linting"];
+    static $inject = ["linting", "canvas", "elementRegistry", "selection"];
 
     private results: LintResults = {};
 
-    constructor(private readonly linting: Linting) {
+    private overlaysVisible = true;
+
+    private panel: ProblemsPanel | null = null;
+
+    constructor(
+        private readonly linting: Linting,
+        private readonly canvas: Canvas,
+        private readonly elementRegistry: ElementRegistry,
+        private readonly selection: Selection,
+    ) {
         // Replace the browser-side lint run with the host's precomputed results.
         // `update()` calls `this.lint()`; returning the stored results makes every
         // relint (import.done / elements.changed) repaint them until the host,
@@ -51,16 +131,103 @@ export class LintConfigService {
                 this.linting.toggle(false);
             }
             document.body.classList.remove("bpmnlint-active");
+            this.panel?.hide();
             return;
         }
 
         this.results = results;
         document.body.classList.add("bpmnlint-active");
-        if (this.linting.isActive()) {
-            this.linting.update();
-        } else {
-            // Activating fires `linting.toggle`, which triggers the first `update()`.
-            this.linting.toggle(true);
+        if (this.overlaysVisible) {
+            if (this.linting.isActive()) {
+                this.linting.update();
+            } else {
+                // Activating fires `linting.toggle`, which triggers the first `update()`.
+                this.linting.toggle(true);
+            }
         }
+        this.ensurePanel().update(this.flatten(results));
+    }
+
+    /** Mounts the panel below the canvas without changing any host HTML shell. */
+    private ensurePanel(): ProblemsPanel {
+        if (this.panel) {
+            return this.panel;
+        }
+
+        const column = document.createElement("div");
+        column.className = "lint-problems-column";
+        const canvasHost = this.canvas.getContainer().closest(".canvas");
+        const content = canvasHost?.parentElement;
+        if (canvasHost && content) {
+            content.insertBefore(column, canvasHost);
+            column.append(canvasHost);
+        } else {
+            document.body.append(column);
+        }
+
+        this.panel = new ProblemsPanel(
+            column,
+            {
+                onSelectIssue: (elementId) => this.revealElement(elementId),
+                onToggleOverlays: (visible) => this.setOverlaysVisible(visible),
+                onResize: () => this.canvas.resized(),
+            },
+            this.overlaysVisible,
+        );
+        this.canvas.resized();
+        return this.panel;
+    }
+
+    private revealElement(elementId: string): void {
+        const element = this.elementRegistry.get(elementId);
+        const center = element?.parent && centerOf(element);
+        if (!element || !center) {
+            return;
+        }
+
+        // scrollToElement switches to the element's root plane before selection.
+        this.canvas.scrollToElement(element);
+        const viewbox = this.canvas.viewbox();
+        this.canvas.viewbox({
+            x: center.x - viewbox.width / 2,
+            y: center.y - viewbox.height / 2,
+            width: viewbox.width,
+            height: viewbox.height,
+        });
+        this.selection.select(element);
+    }
+
+    private setOverlaysVisible(visible: boolean): void {
+        this.overlaysVisible = visible;
+        if (this.linting.isActive() !== visible) {
+            this.linting.toggle(visible);
+        }
+    }
+
+    private flatten(results: LintResults): ProblemsPanelIssue[] {
+        const issues = Object.entries(results).flatMap(([rule, reports]) =>
+            reports.map((report) => {
+                const element = report.id ? this.elementRegistry.get(report.id) : undefined;
+                const elementId = element?.parent && centerOf(element) ? report.id : undefined;
+                return {
+                    elementId,
+                    elementLabel: report.id ? this.labelFor(report.id) : undefined,
+                    message: report.message,
+                    severity: toSeverity(report.category),
+                    rule: report.rule ?? rule,
+                };
+            }),
+        );
+        return issues.sort(
+            (a, b) =>
+                SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity] ||
+                (a.elementLabel ?? "").localeCompare(b.elementLabel ?? "") ||
+                a.rule.localeCompare(b.rule) ||
+                a.message.localeCompare(b.message),
+        );
+    }
+
+    private labelFor(elementId: string): string {
+        return this.elementRegistry.get(elementId)?.businessObject?.name || elementId;
     }
 }

--- a/apps/bpmn-webview/src/app/bpmnlint/ProblemsPanel.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/ProblemsPanel.spec.ts
@@ -88,10 +88,34 @@ describe("ProblemsPanel", () => {
     it("navigates to the affected element when a problem row is clicked", () => {
         const { panel, parent, callbacks } = makePanel();
         panel.update([issue({ elementId: "Task_7" })]);
+        const row = parent.querySelector<HTMLElement>(".lint-problems__row")!;
 
-        parent.querySelector<HTMLButtonElement>(".lint-problems__row")!.click();
+        expect(row.tagName).toBe("BUTTON");
+        expect((row as HTMLButtonElement).type).toBe("button");
+        row.click();
 
         expect(callbacks.onSelectIssue).toHaveBeenCalledWith("Task_7");
+    });
+
+    it("renders non-navigable problems as static list content", () => {
+        const { panel, parent, callbacks } = makePanel();
+        panel.update([
+            issue({
+                elementId: undefined,
+                elementLabel: "Process_1",
+                message: "Process-level problem",
+            }),
+        ]);
+
+        const list = parent.querySelector(".lint-problems__list");
+        const row = list?.querySelector<HTMLElement>(".lint-problems__row");
+        expect(list?.getAttribute("role")).toBe("list");
+        expect(row?.tagName).toBe("DIV");
+        expect(row?.querySelector("button")).toBeNull();
+        expect(row?.textContent).toContain("Errors: Process-level problem");
+
+        row?.click();
+        expect(callbacks.onSelectIssue).not.toHaveBeenCalled();
     });
 
     it("exposes each problem severity to assistive technology", () => {

--- a/apps/bpmn-webview/src/app/bpmnlint/ProblemsPanel.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/ProblemsPanel.spec.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { i18n } from "@miragon/bpmn-modeler-i18n";
+
+import { ProblemsPanel, ProblemsPanelIssue } from "./ProblemsPanel";
+
+function makePanel() {
+    const parent = document.createElement("div");
+    document.body.append(parent);
+    const callbacks = {
+        onSelectIssue: vi.fn(),
+        onToggleOverlays: vi.fn(),
+        onResize: vi.fn(),
+    };
+    return { panel: new ProblemsPanel(parent, callbacks), parent, callbacks };
+}
+
+const issue = (overrides: Partial<ProblemsPanelIssue> = {}): ProblemsPanelIssue => ({
+    elementId: "Task_1",
+    elementLabel: "Task_1",
+    message: "Something is off",
+    severity: "error",
+    rule: "some-rule",
+    ...overrides,
+});
+
+beforeEach(() => {
+    document.body.innerHTML = "";
+});
+
+afterEach(() => {
+    i18n.setLanguage("en");
+});
+
+describe("ProblemsPanel", () => {
+    it("stays hidden until results arrive", () => {
+        const { panel, parent, callbacks } = makePanel();
+
+        expect(parent.querySelector(".lint-problems--visible")).toBeNull();
+
+        panel.update([issue()]);
+
+        expect(parent.querySelector(".lint-problems--visible")).not.toBeNull();
+        expect(callbacks.onResize).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows counts for each reported severity", () => {
+        const { panel, parent } = makePanel();
+
+        panel.update([issue(), issue({ severity: "warn" }), issue({ severity: "warn" })]);
+
+        const badges = parent.querySelectorAll(".lint-problems__badge");
+        expect(badges).toHaveLength(2);
+        expect(badges[0].className).toContain("--error");
+        expect(badges[0].textContent).toBe("1");
+        expect(badges[1].className).toContain("--warning");
+        expect(badges[1].textContent).toBe("2");
+    });
+
+    it("shows an empty state when no problems are reported", () => {
+        const { panel, parent } = makePanel();
+
+        panel.update([]);
+
+        expect(parent.querySelector(".lint-problems__badge--success")).not.toBeNull();
+        expect(parent.querySelector(".lint-problems__empty")?.textContent).toContain(
+            "No problems found.",
+        );
+    });
+
+    it("expands the problem list without changing marker visibility", () => {
+        const { panel, parent, callbacks } = makePanel();
+        panel.update([issue()]);
+        const toggle = parent.querySelector<HTMLButtonElement>(".lint-problems__toggle")!;
+        const body = parent.querySelector<HTMLElement>(".lint-problems__body")!;
+
+        toggle.click();
+
+        expect(body.hidden).toBe(false);
+        expect(toggle.getAttribute("aria-expanded")).toBe("true");
+        expect(callbacks.onToggleOverlays).not.toHaveBeenCalled();
+        expect(callbacks.onResize).toHaveBeenCalledTimes(2);
+
+        toggle.click();
+        expect(body.hidden).toBe(true);
+        expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("navigates to the affected element when a problem row is clicked", () => {
+        const { panel, parent, callbacks } = makePanel();
+        panel.update([issue({ elementId: "Task_7" })]);
+
+        parent.querySelector<HTMLButtonElement>(".lint-problems__row")!.click();
+
+        expect(callbacks.onSelectIssue).toHaveBeenCalledWith("Task_7");
+    });
+
+    it("exposes each problem severity to assistive technology", () => {
+        const { panel, parent } = makePanel();
+        panel.update([
+            issue({ message: "Broken", severity: "error" }),
+            issue({ message: "Risky", severity: "warn" }),
+            issue({ message: "FYI", severity: "info" }),
+        ]);
+
+        const labels = [...parent.querySelectorAll<HTMLButtonElement>(".lint-problems__row")].map(
+            (row) => row.getAttribute("aria-label"),
+        );
+        expect(labels).toEqual([
+            "Errors: Broken, Task_1, some-rule",
+            "Warnings: Risky, Task_1, some-rule",
+            "Information: FYI, Task_1, some-rule",
+        ]);
+    });
+
+    it("translates lint messages consistently with marker overlays", () => {
+        const { panel, parent } = makePanel();
+        i18n.setLanguage("de");
+
+        panel.update([issue({ message: "Task" })]);
+
+        const row = parent.querySelector<HTMLButtonElement>(".lint-problems__row")!;
+        expect(row.title).toBe("Aufgabe");
+        expect(row.querySelector(".lint-problems__row-message")?.textContent).toBe("Aufgabe");
+    });
+
+    it("toggles marker visibility through the separate eye button", () => {
+        const { panel, parent, callbacks } = makePanel();
+        panel.update([issue()]);
+        const eye = parent.querySelector<HTMLButtonElement>(".lint-problems__overlays")!;
+
+        expect(eye.title).toBe("Hide lint overlays");
+
+        eye.click();
+        expect(callbacks.onToggleOverlays).toHaveBeenCalledWith(false);
+        expect(eye.classList.contains("lint-problems__overlays--off")).toBe(true);
+        expect(eye.title).toBe("Show lint overlays");
+
+        eye.click();
+        expect(callbacks.onToggleOverlays).toHaveBeenLastCalledWith(true);
+    });
+});

--- a/apps/bpmn-webview/src/app/bpmnlint/ProblemsPanel.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/ProblemsPanel.ts
@@ -1,0 +1,265 @@
+import { i18n } from "@miragon/bpmn-modeler-i18n";
+
+/** A bpmnlint finding flattened for rendering in the problems panel. */
+export interface ProblemsPanelIssue {
+    /** Present only when the finding can navigate to a visible diagram element. */
+    readonly elementId?: string;
+    readonly elementLabel?: string;
+    readonly message: string;
+    readonly severity: "error" | "warn" | "info";
+    readonly rule: string;
+}
+
+export interface ProblemsPanelCallbacks {
+    onSelectIssue(elementId: string): void;
+    onToggleOverlays(visible: boolean): void;
+    onResize(): void;
+}
+
+const ICONS = {
+    error: '<svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"><path fill="currentColor" d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1zm2.83 9.13-.7.7L8 8.7l-2.13 2.13-.7-.7L7.3 8 5.17 5.87l.7-.7L8 7.3l2.13-2.13.7.7L8.7 8l2.13 2.13z"/></svg>',
+    warn: '<svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"><path fill="currentColor" d="M8.56 1.45 15.5 13.5a.65.65 0 0 1-.56.97H1.06a.65.65 0 0 1-.56-.97L7.44 1.45a.65.65 0 0 1 1.12 0zM7.35 6v4h1.3V6h-1.3zm0 5.3v1.4h1.3v-1.4h-1.3z"/></svg>',
+    info: '<svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"><path fill="currentColor" d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1zm.7 10.5H7.3V7h1.4v4.5zm0-6H7.3V4.1h1.4v1.4z"/></svg>',
+    success:
+        '<svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"><path fill="currentColor" d="M6.3 12.3 2.5 8.5l1-1 2.8 2.8 6.2-6.2 1 1z"/></svg>',
+    eye: '<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M8 3.5c-3.2 0-5.8 2.4-6.8 4.5 1 2.1 3.6 4.5 6.8 4.5s5.8-2.4 6.8-4.5c-1-2.1-3.6-4.5-6.8-4.5zm0 7.5a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0-4.7a1.7 1.7 0 1 0 0 3.4 1.7 1.7 0 0 0 0-3.4z"/></svg>',
+    chevron:
+        '<svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"><path fill="currentColor" d="M6 4l4 4-4 4z"/></svg>',
+} as const;
+
+function makeElement(tag: string, className: string): HTMLElement {
+    const element = document.createElement(tag);
+    element.className = className;
+    return element;
+}
+
+let nextPanelId = 0;
+
+/**
+ * Full-width problems view docked below the BPMN canvas.
+ *
+ * Expanding the list is intentionally independent from showing the in-canvas
+ * markers; the eye button is the only control that changes marker visibility.
+ */
+export class ProblemsPanel {
+    private readonly root: HTMLElement;
+
+    private readonly toggleButton: HTMLButtonElement;
+
+    private readonly title: HTMLElement;
+
+    private readonly badges: HTMLElement;
+
+    private readonly overlaysButton: HTMLButtonElement;
+
+    private readonly body: HTMLElement;
+
+    private issues: ProblemsPanelIssue[] = [];
+
+    private expanded = false;
+
+    private overlaysVisible: boolean;
+
+    constructor(
+        parent: HTMLElement,
+        private readonly callbacks: ProblemsPanelCallbacks,
+        initialOverlaysVisible = true,
+    ) {
+        this.overlaysVisible = initialOverlaysVisible;
+        this.root = makeElement("section", "lint-problems");
+
+        const header = makeElement("div", "lint-problems__header");
+        this.root.append(header);
+
+        this.toggleButton = makeElement("button", "lint-problems__toggle") as HTMLButtonElement;
+        this.toggleButton.type = "button";
+        this.toggleButton.setAttribute("aria-expanded", "false");
+        this.toggleButton.addEventListener("click", () => this.setExpanded(!this.expanded));
+        header.append(this.toggleButton);
+
+        const chevron = makeElement("span", "lint-problems__chevron");
+        chevron.innerHTML = ICONS.chevron;
+        this.title = makeElement("span", "lint-problems__title");
+        this.badges = makeElement("span", "lint-problems__badges");
+        this.badges.setAttribute("aria-live", "polite");
+        this.toggleButton.append(chevron, this.title, this.badges);
+
+        this.overlaysButton = makeElement("button", "lint-problems__overlays") as HTMLButtonElement;
+        this.overlaysButton.type = "button";
+        this.overlaysButton.innerHTML = ICONS.eye;
+        this.overlaysButton.addEventListener("click", () => {
+            this.setOverlaysVisible(!this.overlaysVisible);
+            this.callbacks.onToggleOverlays(this.overlaysVisible);
+        });
+        header.append(this.overlaysButton);
+
+        this.body = makeElement("div", "lint-problems__body");
+        this.body.id = `lint-problems-body-${++nextPanelId}`;
+        this.body.hidden = true;
+        this.toggleButton.setAttribute("aria-controls", this.body.id);
+        this.root.append(this.body);
+        parent.append(this.root);
+
+        this.renderLabels();
+        i18n.onChange(() => this.renderLabels());
+    }
+
+    update(issues: ProblemsPanelIssue[]): void {
+        this.issues = issues;
+        const wasVisible = this.root.classList.contains("lint-problems--visible");
+        this.root.classList.add("lint-problems--visible");
+        this.renderBadges();
+        this.renderList();
+        if (!wasVisible || this.expanded) {
+            this.callbacks.onResize();
+        }
+    }
+
+    hide(): void {
+        if (!this.root.classList.contains("lint-problems--visible")) {
+            return;
+        }
+        this.root.classList.remove("lint-problems--visible");
+        this.callbacks.onResize();
+    }
+
+    private setExpanded(expanded: boolean): void {
+        this.expanded = expanded;
+        this.root.classList.toggle("lint-problems--expanded", expanded);
+        this.toggleButton.setAttribute("aria-expanded", String(expanded));
+        this.body.hidden = !expanded;
+        this.callbacks.onResize();
+    }
+
+    private setOverlaysVisible(visible: boolean): void {
+        this.overlaysVisible = visible;
+        this.overlaysButton.classList.toggle("lint-problems__overlays--off", !visible);
+        this.overlaysButton.title = i18n.translate(
+            visible ? "Hide lint overlays" : "Show lint overlays",
+        );
+        this.overlaysButton.setAttribute("aria-label", this.overlaysButton.title);
+    }
+
+    private renderBadges(): void {
+        this.badges.replaceChildren();
+
+        const counts = { error: 0, warn: 0, info: 0 };
+        for (const issue of this.issues) {
+            counts[issue.severity] += 1;
+        }
+
+        if (this.issues.length === 0) {
+            this.badges.append(this.makeBadge("success", i18n.translate("No problems found.")));
+            return;
+        }
+        if (counts.error > 0) {
+            this.badges.append(this.makeBadge("error", i18n.translate("Errors"), counts.error));
+        }
+        if (counts.warn > 0) {
+            this.badges.append(this.makeBadge("warning", i18n.translate("Warnings"), counts.warn));
+        }
+        if (counts.info > 0) {
+            this.badges.append(this.makeBadge("info", i18n.translate("Information"), counts.info));
+        }
+    }
+
+    private makeBadge(
+        kind: "error" | "warning" | "info" | "success",
+        title: string,
+        count?: number,
+    ): HTMLElement {
+        const badge = makeElement("span", `lint-problems__badge lint-problems__badge--${kind}`);
+        badge.title = title;
+        badge.setAttribute("aria-label", count === undefined ? title : `${title}: ${count}`);
+        const icon = makeElement("span", "lint-problems__icon");
+        icon.innerHTML = kind === "warning" ? ICONS.warn : ICONS[kind];
+        badge.append(icon);
+        if (count !== undefined) {
+            const label = document.createElement("span");
+            label.textContent = String(count);
+            badge.append(label);
+        }
+        return badge;
+    }
+
+    private renderList(): void {
+        this.body.replaceChildren();
+
+        if (this.issues.length === 0) {
+            const empty = makeElement("div", "lint-problems__empty");
+            const icon = makeElement("span", "lint-problems__icon");
+            icon.innerHTML = ICONS.success;
+            const text = document.createElement("span");
+            text.textContent = i18n.translate("No problems found.");
+            empty.append(icon, text);
+            this.body.append(empty);
+            return;
+        }
+
+        const list = makeElement("ul", "lint-problems__list");
+        for (const issue of this.issues) {
+            const item = document.createElement("li");
+            item.append(this.makeRow(issue));
+            list.append(item);
+        }
+        this.body.append(list);
+    }
+
+    private makeRow(issue: ProblemsPanelIssue): HTMLButtonElement {
+        const row = makeElement("button", "lint-problems__row") as HTMLButtonElement;
+        row.type = "button";
+        const messageText = i18n.translate(issue.message);
+        row.title = messageText;
+        const severityLabel = i18n.translate(
+            issue.severity === "error"
+                ? "Errors"
+                : issue.severity === "warn"
+                  ? "Warnings"
+                  : "Information",
+        );
+        row.setAttribute(
+            "aria-label",
+            [`${severityLabel}: ${messageText}`, issue.elementLabel, issue.rule]
+                .filter(Boolean)
+                .join(", "),
+        );
+
+        const icon = makeElement(
+            "span",
+            `lint-problems__icon lint-problems__icon--${issue.severity}`,
+        );
+        icon.innerHTML = ICONS[issue.severity];
+        const message = makeElement("span", "lint-problems__row-message");
+        message.textContent = messageText;
+        row.append(icon, message);
+
+        if (issue.elementLabel) {
+            const label = makeElement("span", "lint-problems__row-element");
+            label.textContent = issue.elementLabel;
+            row.append(label);
+        }
+        const rule = makeElement("span", "lint-problems__row-rule");
+        rule.textContent = issue.rule;
+        row.append(rule);
+
+        const { elementId } = issue;
+        if (elementId) {
+            row.addEventListener("click", () => this.callbacks.onSelectIssue(elementId));
+        } else {
+            row.disabled = true;
+        }
+        return row;
+    }
+
+    private renderLabels(): void {
+        const title = i18n.translate("Problems");
+        this.root.setAttribute("aria-label", title);
+        this.title.textContent = title;
+        this.setOverlaysVisible(this.overlaysVisible);
+        this.renderBadges();
+        this.renderList();
+        if (this.root.classList.contains("lint-problems--visible")) {
+            this.callbacks.onResize();
+        }
+    }
+}

--- a/apps/bpmn-webview/src/app/bpmnlint/ProblemsPanel.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/ProblemsPanel.ts
@@ -197,6 +197,7 @@ export class ProblemsPanel {
         }
 
         const list = makeElement("ul", "lint-problems__list");
+        list.setAttribute("role", "list");
         for (const issue of this.issues) {
             const item = document.createElement("li");
             item.append(this.makeRow(issue));
@@ -205,9 +206,9 @@ export class ProblemsPanel {
         this.body.append(list);
     }
 
-    private makeRow(issue: ProblemsPanelIssue): HTMLButtonElement {
-        const row = makeElement("button", "lint-problems__row") as HTMLButtonElement;
-        row.type = "button";
+    private makeRow(issue: ProblemsPanelIssue): HTMLElement {
+        const { elementId } = issue;
+        const row = makeElement(elementId ? "button" : "div", "lint-problems__row");
         const messageText = i18n.translate(issue.message);
         row.title = messageText;
         const severityLabel = i18n.translate(
@@ -223,6 +224,16 @@ export class ProblemsPanel {
                 .filter(Boolean)
                 .join(", "),
         );
+
+        if (elementId) {
+            (row as HTMLButtonElement).type = "button";
+            row.addEventListener("click", () => this.callbacks.onSelectIssue(elementId));
+        } else {
+            row.removeAttribute("aria-label");
+            const severity = makeElement("span", "lint-problems__sr-only");
+            severity.textContent = `${severityLabel}: `;
+            row.append(severity);
+        }
 
         const icon = makeElement(
             "span",
@@ -241,13 +252,6 @@ export class ProblemsPanel {
         const rule = makeElement("span", "lint-problems__row-rule");
         rule.textContent = issue.rule;
         row.append(rule);
-
-        const { elementId } = issue;
-        if (elementId) {
-            row.addEventListener("click", () => this.callbacks.onSelectIssue(elementId));
-        } else {
-            row.disabled = true;
-        }
         return row;
     }
 

--- a/apps/bpmn-webview/src/app/bpmnlint/bpmnlint.css
+++ b/apps/bpmn-webview/src/app/bpmnlint/bpmnlint.css
@@ -1,89 +1,270 @@
-/**
- * Hide-until-configured: the bpmn-js-bpmnlint status button is hidden until a
- * `.bpmnlintrc` is applied, so a workspace with no lint config looks exactly as
- * it did before this feature. LintConfigService.apply() toggles
- * `.bpmnlint-active` on <body> (add on config, remove on null).
- */
+/* The docked problems bar replaces the vendor control; marker overlays remain. */
 .bjsl-button {
+    display: none !important;
+}
+
+/* Keep the properties panel beside a canvas-and-problems column. */
+.lint-problems-column {
+    container: lint-problems / inline-size;
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+}
+
+.lint-problems-column .canvas {
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.content:not(.with-diagram) .lint-problems-column {
     display: none;
 }
 
-/**
- * Flat, chip-like restyle of the in-canvas lint summary button.
- *
- * Replaces bpmn-js-bpmnlint's saturated pill (bold white-on-red/amber/green)
- * with a compact tinted chip: soft state-coloured fill, matching text, hairline
- * border, no depth. `inline-flex` (not the vendor's `flex`, and crucially not
- * `block`, which stacked the icon above the count) keeps icon and count on one
- * row and shrink-wraps the chip to its content. The icon is a `currentColor`
- * SVG, so the per-state text colour repaints it for free. The canvas stays white
- * in every VS Code theme, so the palette is tuned for a light background and
- * needs no dark-mode variant.
- */
-body.bpmnlint-active .bjsl-button {
+.lint-problems {
+    --lint-panel-border-color: #e4e4e4;
+    --lint-panel-bg: #fff;
+    --lint-panel-fg: #444;
+    --lint-panel-hover-bg: #f5f5f5;
+    --lint-panel-muted-fg: #666;
+    --lint-panel-faint-fg: #666;
+    --lint-error-fg: #c0392b;
+    --lint-error-bg: #fbe6e6;
+    --lint-error-border: #f1c2c0;
+    --lint-warn-fg: #7a5d10;
+    --lint-warn-bg: #fbf1d3;
+    --lint-warn-border: #f0dfa3;
+    --lint-info-fg: #1f5fa8;
+    --lint-info-bg: #e8f0fb;
+    --lint-info-border: #c5d8f0;
+    --lint-success-fg: #2e7d22;
+    --lint-success-bg: #eaf6ea;
+    --lint-success-border: #cbe7c4;
+
+    display: none;
+    flex: none;
+    flex-direction: column;
+    border-top: 1px solid var(--lint-panel-border-color);
+    background-color: var(--lint-panel-bg);
+    color: var(--lint-panel-fg);
+    font-size: 12px;
+}
+
+.lint-problems--visible {
+    display: flex;
+}
+
+.lint-problems__header {
+    display: flex;
+    align-items: center;
+    min-height: 30px;
+}
+
+.lint-problems__toggle {
+    display: inline-flex;
+    flex: 1 1 auto;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    padding: 5px 10px;
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
+    font-weight: 500;
+    text-align: left;
+    cursor: pointer;
+}
+
+.lint-problems__toggle:hover,
+.lint-problems__overlays:hover,
+.lint-problems__row:hover:not(:disabled) {
+    background-color: var(--lint-panel-hover-bg);
+}
+
+.lint-problems__chevron {
+    display: inline-flex;
+    flex: none;
+    transition: transform 0.12s ease;
+}
+
+.lint-problems--expanded .lint-problems__chevron {
+    transform: rotate(90deg);
+}
+
+.lint-problems__title {
+    flex: none;
+}
+
+.lint-problems__badges {
+    display: inline-flex;
+    gap: 6px;
+    min-width: 0;
+}
+
+.lint-problems__badge {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    bottom: 16px;
-    padding: 4px 10px;
+    gap: 4px;
+    padding: 1px 7px;
     border: 1px solid transparent;
     border-radius: 6px;
-    background-color: #f0f0f0;
-    color: #555;
     font-weight: 500;
-    font-size: 12px;
-    line-height: 1.4;
-    transition:
-        background-color 0.12s ease,
-        border-color 0.12s ease,
-        color 0.12s ease;
 }
 
-body.bpmnlint-active .bjsl-button .icon {
+.lint-problems__badge--error {
+    border-color: var(--lint-error-border);
+    background-color: var(--lint-error-bg);
+    color: var(--lint-error-fg);
+}
+
+.lint-problems__badge--warning {
+    border-color: var(--lint-warn-border);
+    background-color: var(--lint-warn-bg);
+    color: var(--lint-warn-fg);
+}
+
+.lint-problems__badge--info {
+    border-color: var(--lint-info-border);
+    background-color: var(--lint-info-bg);
+    color: var(--lint-info-fg);
+}
+
+.lint-problems__badge--success {
+    border-color: var(--lint-success-border);
+    background-color: var(--lint-success-bg);
+    color: var(--lint-success-fg);
+}
+
+.lint-problems__overlays {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: none;
+    margin-right: 6px;
+    padding: 4px;
+    border: none;
+    border-radius: 4px;
+    background: none;
+    color: var(--lint-panel-muted-fg);
+    cursor: pointer;
+}
+
+.lint-problems__overlays--off::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    right: 4px;
+    left: 4px;
+    height: 1.5px;
+    background-color: currentColor;
+    transform: rotate(-45deg);
+}
+
+.lint-problems__toggle:focus-visible,
+.lint-problems__overlays:focus-visible,
+.lint-problems__row:focus-visible {
+    outline: 2px solid var(--vscode-focusBorder, rgba(0, 120, 212, 0.7));
+    outline-offset: -2px;
+}
+
+.lint-problems__body {
+    max-height: min(220px, 40vh);
+    overflow-y: auto;
+    border-top: 1px solid var(--lint-panel-border-color);
+}
+
+.lint-problems__list {
     margin: 0;
-    width: 13px;
-    height: 13px;
+    padding: 4px 0;
+    list-style: none;
 }
 
-body.bpmnlint-active .bjsl-button-success {
-    background-color: #eaf6ea;
-    border-color: #cbe7c4;
-    color: #2e7d22;
+.lint-problems__row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    width: 100%;
+    padding: 5px 10px 5px 14px;
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
 }
 
-body.bpmnlint-active .bjsl-button-warning {
-    background-color: #fbf1d3;
-    border-color: #f0dfa3;
-    color: #7a5d10;
+.lint-problems__row:disabled {
+    color: inherit;
+    opacity: 1;
+    cursor: default;
 }
 
-body.bpmnlint-active .bjsl-button-error {
-    background-color: #fbe6e6;
-    border-color: #f1c2c0;
-    color: #c0392b;
+.lint-problems__icon {
+    display: inline-flex;
+    flex: none;
+    margin-top: 2px;
 }
 
-body.bpmnlint-active .bjsl-button-success:hover {
-    background-color: #e0f0df;
+.lint-problems__icon--error {
+    color: var(--lint-error-fg);
 }
 
-body.bpmnlint-active .bjsl-button-warning:hover {
-    background-color: #f7e9bf;
+.lint-problems__icon--warn {
+    color: var(--lint-warn-fg);
 }
 
-body.bpmnlint-active .bjsl-button-error:hover {
-    background-color: #f7d9d7;
+.lint-problems__icon--info {
+    color: var(--lint-info-fg);
 }
 
-body.bpmnlint-active .bjsl-button:focus-visible {
-    outline: 2px solid rgba(0, 120, 212, 0.7);
-    outline-offset: 1px;
+.lint-problems__row-message {
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
-/**
- * Match the issues dropdown to the chip: flat panel, soft hairline border, and a
- * gentle lift so it stays legible floating over the diagram.
- */
+.lint-problems__row-element,
+.lint-problems__row-rule {
+    overflow: hidden;
+    flex: none;
+    max-width: 180px;
+    color: var(--lint-panel-muted-fg);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.lint-problems__row-rule {
+    color: var(--lint-panel-faint-fg);
+    font-size: 11px;
+}
+
+.lint-problems__empty {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    color: var(--lint-success-fg);
+}
+
+@container lint-problems (max-width: 700px) {
+    .lint-problems__row-rule {
+        display: none;
+    }
+
+    .lint-problems__row-element {
+        max-width: 120px;
+    }
+}
+
+@container lint-problems (max-width: 480px) {
+    .lint-problems__row-element {
+        display: none;
+    }
+}
+
+/* Retain the vendor hover details attached to each in-canvas marker. */
 body.bpmnlint-active .bjsl-issues {
     padding: 10px 12px;
     border: 1px solid #e4e4e4;
@@ -93,8 +274,8 @@ body.bpmnlint-active .bjsl-issues {
 
 body.bpmnlint-active .bjsl-id-hint {
     padding: 1px 6px;
+    border-radius: 4px;
     background-color: #ededed;
     color: #555;
     font-weight: 500;
-    border-radius: 4px;
 }

--- a/apps/bpmn-webview/src/app/bpmnlint/bpmnlint.css
+++ b/apps/bpmn-webview/src/app/bpmnlint/bpmnlint.css
@@ -79,7 +79,7 @@
 
 .lint-problems__toggle:hover,
 .lint-problems__overlays:hover,
-.lint-problems__row:hover:not(:disabled) {
+button.lint-problems__row:hover {
     background-color: var(--lint-panel-hover-bg);
 }
 
@@ -165,7 +165,7 @@
 
 .lint-problems__toggle:focus-visible,
 .lint-problems__overlays:focus-visible,
-.lint-problems__row:focus-visible {
+button.lint-problems__row:focus-visible {
     outline: 2px solid var(--vscode-focusBorder, rgba(0, 120, 212, 0.7));
     outline-offset: -2px;
 }
@@ -193,13 +193,23 @@
     color: inherit;
     font: inherit;
     text-align: left;
+    cursor: default;
+}
+
+button.lint-problems__row {
     cursor: pointer;
 }
 
-.lint-problems__row:disabled {
-    color: inherit;
-    opacity: 1;
-    cursor: default;
+.lint-problems__sr-only {
+    position: absolute;
+    overflow: hidden;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
 }
 
 .lint-problems__icon {

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -37,6 +37,7 @@ import { ViewportManager } from "./viewport";
 import { SelectionManager } from "./selection";
 import { deriveEngines } from "./engines";
 import LintModule from "./bpmnlint";
+import { PaletteLayoutFixModule } from "./palette/PaletteLayoutFix";
 import { setColorThemeMode } from "@miragon/bpmn-modeler-shared";
 
 const DEFAULT_SETTINGS: BpmnModelerSetting = {
@@ -121,6 +122,7 @@ export class BpmnModeler {
         const commonModules = [
             TokenSimulationModule,
             LintModule,
+            PaletteLayoutFixModule,
             ElementTemplateChooserModule,
             AppendMenuModule,
             NavigateToReferencedModelModule,

--- a/apps/bpmn-webview/src/app/palette/PaletteLayoutFix.spec.ts
+++ b/apps/bpmn-webview/src/app/palette/PaletteLayoutFix.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import DiagramPalette from "diagram-js/lib/features/palette/Palette";
+
+import { needsPaletteCollapse, PaletteLayoutFix } from "./PaletteLayoutFix";
+
+const entries = Object.fromEntries([
+    ...Array.from({ length: 15 }, (_, index) => [`entry-${index}`, {}]),
+    ["tool-separator", { separator: true }],
+]);
+
+describe("needsPaletteCollapse", () => {
+    it("keeps the full-height palette while all rendered entries still fit", () => {
+        expect(needsPaletteCollapse(769, entries)).toBe(false);
+        expect(needsPaletteCollapse(756, entries)).toBe(false);
+    });
+
+    it("uses two columns once the rendered entries no longer fit", () => {
+        expect(needsPaletteCollapse(755, entries)).toBe(true);
+    });
+});
+
+describe("PaletteLayoutFix", () => {
+    it("replaces the vendor collapse heuristic", () => {
+        const palette: ConstructorParameters<typeof PaletteLayoutFix>[0] = {
+            _needsCollapse: (_availableHeight, _entries) => true,
+        };
+
+        new PaletteLayoutFix(palette);
+
+        expect(palette._needsCollapse!(769, entries)).toBe(false);
+    });
+
+    it("matches the installed diagram-js palette contract", () => {
+        const eventBus = { on: vi.fn() };
+        const palette = new DiagramPalette(
+            eventBus as never,
+            {} as never,
+        ) as unknown as ConstructorParameters<typeof PaletteLayoutFix>[0];
+
+        expect(typeof palette._needsCollapse).toBe("function");
+        new PaletteLayoutFix(palette);
+        expect(palette._needsCollapse!(769, entries)).toBe(false);
+    });
+
+    it("warns without breaking modeler startup when the private hook changes", () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        new PaletteLayoutFix({} as ConstructorParameters<typeof PaletteLayoutFix>[0]);
+
+        expect(warn).toHaveBeenCalledWith(
+            "[bpmn-modeler] Unable to apply the palette layout correction.",
+        );
+        warn.mockRestore();
+    });
+});

--- a/apps/bpmn-webview/src/app/palette/PaletteLayoutFix.ts
+++ b/apps/bpmn-webview/src/app/palette/PaletteLayoutFix.ts
@@ -1,3 +1,23 @@
+/**
+ * Per-modeler correction for diagram-js's palette collapse threshold.
+ *
+ * The Problems bar reduces the canvas by 31px and exposed that diagram-js
+ * counts every palette descriptor as a 46px tool, although a separator renders
+ * at 16px. With the current 15 tools and one separator, the vendor threshold is
+ * 786px while the rendered palette only needs 756px. The corrected calculation
+ * still switches to two columns whenever the one-column palette no longer fits.
+ *
+ * This module replaces the predicate on each injected C7/C8 palette instance;
+ * it does not mutate Palette.prototype or affect DMN/viewer canvases. Applying
+ * the accurate calculation consistently also avoids changing palette geometry
+ * merely because linting is configured. `_needsCollapse` is not in diagram-js's
+ * public types, but its implementation explicitly directs style implementors to
+ * override it and exposes no public sizing hook. The runtime guard and contract
+ * test make dependency drift visible without preventing modeler startup.
+ *
+ * The constants mirror the pinned diagram-js palette CSS and must be checked
+ * whenever that dependency or its palette styles change.
+ */
 interface PaletteEntry {
     readonly separator?: boolean;
 }
@@ -12,13 +32,7 @@ const ENTRY_HEIGHT = 46;
 const SEPARATOR_HEIGHT = 16;
 const VERTICAL_MARGIN = 50;
 
-/**
- * Matches diagram-js's palette sizing but accounts for the shorter separator.
- *
- * The vendor heuristic treats every descriptor as a 46px tool. Separators only
- * occupy 16px, which otherwise makes the palette switch to two columns while
- * the full one-column layout still fits.
- */
+/** Matches diagram-js's palette sizing while accounting for separators. */
 export function needsPaletteCollapse(availableHeight: number, entries: PaletteEntries): boolean {
     const entriesHeight = Object.values(entries).reduce(
         (height, entry) => height + (entry.separator ? SEPARATOR_HEIGHT : ENTRY_HEIGHT),
@@ -27,7 +41,7 @@ export function needsPaletteCollapse(availableHeight: number, entries: PaletteEn
     return availableHeight < entriesHeight + VERTICAL_MARGIN;
 }
 
-/** Applies the corrected calculation to the palette instance before diagram init. */
+/** Applies the corrected calculation to one palette instance before diagram init. */
 export class PaletteLayoutFix {
     static $inject = ["palette"];
 

--- a/apps/bpmn-webview/src/app/palette/PaletteLayoutFix.ts
+++ b/apps/bpmn-webview/src/app/palette/PaletteLayoutFix.ts
@@ -1,0 +1,46 @@
+interface PaletteEntry {
+    readonly separator?: boolean;
+}
+
+type PaletteEntries = Record<string, PaletteEntry>;
+
+interface Palette {
+    _needsCollapse?: (availableHeight: number, entries: PaletteEntries) => boolean;
+}
+
+const ENTRY_HEIGHT = 46;
+const SEPARATOR_HEIGHT = 16;
+const VERTICAL_MARGIN = 50;
+
+/**
+ * Matches diagram-js's palette sizing but accounts for the shorter separator.
+ *
+ * The vendor heuristic treats every descriptor as a 46px tool. Separators only
+ * occupy 16px, which otherwise makes the palette switch to two columns while
+ * the full one-column layout still fits.
+ */
+export function needsPaletteCollapse(availableHeight: number, entries: PaletteEntries): boolean {
+    const entriesHeight = Object.values(entries).reduce(
+        (height, entry) => height + (entry.separator ? SEPARATOR_HEIGHT : ENTRY_HEIGHT),
+        0,
+    );
+    return availableHeight < entriesHeight + VERTICAL_MARGIN;
+}
+
+/** Applies the corrected calculation to the palette instance before diagram init. */
+export class PaletteLayoutFix {
+    static $inject = ["palette"];
+
+    constructor(palette: Palette) {
+        if (typeof palette._needsCollapse !== "function") {
+            console.warn("[bpmn-modeler] Unable to apply the palette layout correction.");
+            return;
+        }
+        palette._needsCollapse = needsPaletteCollapse;
+    }
+}
+
+export const PaletteLayoutFixModule = {
+    __init__: ["paletteLayoutFix"],
+    paletteLayoutFix: ["type", PaletteLayoutFix],
+};

--- a/apps/bpmn-webview/src/styles/dark-theme/bpmnlint.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/bpmnlint.css
@@ -1,0 +1,24 @@
+:root .lint-problems {
+    --lint-panel-border-color: var(--dt-surface-a20);
+    --lint-panel-bg: var(--dt-surface-a10);
+    --lint-panel-fg: var(--dt-surface-a60);
+    --lint-panel-hover-bg: var(--dt-surface-a20);
+    --lint-panel-muted-fg: var(--vscode-descriptionForeground, var(--dt-surface-a60));
+    --lint-panel-faint-fg: var(--vscode-descriptionForeground, var(--dt-surface-a60));
+    --lint-error-fg: var(--vscode-errorForeground, #e65c57);
+    --lint-error-bg: color-mix(
+        in srgb,
+        var(--vscode-errorForeground, #e65c57) 22%,
+        var(--dt-surface-a10)
+    );
+    --lint-error-border: transparent;
+    --lint-warn-fg: #e2b23e;
+    --lint-warn-bg: color-mix(in srgb, #e2b23e 22%, var(--dt-surface-a10));
+    --lint-warn-border: transparent;
+    --lint-info-fg: var(--dt-color-blue-a50);
+    --lint-info-bg: color-mix(in srgb, var(--dt-color-blue-a50) 22%, var(--dt-surface-a10));
+    --lint-info-border: transparent;
+    --lint-success-fg: #6cc06c;
+    --lint-success-bg: color-mix(in srgb, #6cc06c 22%, var(--dt-surface-a10));
+    --lint-success-border: transparent;
+}

--- a/apps/bpmn-webview/src/styles/dark-theme/index.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/index.css
@@ -8,3 +8,4 @@
 @import "./append-menu.css";
 @import "./token-sim.css";
 @import "./minimap.css";
+@import "./bpmnlint.css";

--- a/apps/bpmn-webview/vitest.config.ts
+++ b/apps/bpmn-webview/vitest.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
 
 export default defineConfig({
     test: {
         name: "bpmn-webview",
         environment: "jsdom",
         include: ["src/**/*.{spec,test}.ts"],
+        alias: {
+            "@miragon/bpmn-modeler-i18n": resolve(__dirname, "../../libs/bpmn-i18n/src/index.ts"),
+        },
         coverage: {
             provider: "v8",
             reportsDirectory: "../../coverage/apps/bpmn-webview",

--- a/docs/vscode/features/linting.md
+++ b/docs/vscode/features/linting.md
@@ -3,10 +3,10 @@
 The BPMN Modeler can validate your diagram **while you edit** using
 [bpmnlint](https://github.com/bpmn-io/bpmnlint) — the same linter you can run in
 CI. When a `.bpmnlintrc` is found, rule violations appear as ⚠️/❌ overlays on the
-offending elements, a summary button (error/warning counts) is shown on the
-canvas, and each finding is also published to the VS Code **Problems** panel
-(searchable and clickable, even without the diagram open). If no `.bpmnlintrc`
-exists, the feature stays dormant and the modeler looks exactly as it did before.
+offending elements and in a full-width **Problems** bar below the canvas. Each
+finding is also published to the VS Code **Problems** panel (searchable and
+clickable, even without the diagram open). If no `.bpmnlintrc` exists, the feature
+stays dormant and the modeler looks exactly as it did before.
 
 The lint runs in the **extension host** (a full Node.js context), not in the
 webview. That is what lets it resolve your workspace's own
@@ -27,10 +27,14 @@ built-ins. See [Custom rules & plugins](#custom-rules-plugins) below.
 
 2. Open (or reopen) a `.bpmn` file with a known issue — e.g. a task without a
    label or a process missing an end event. Violations show up as overlays on
-   the diagram, and the in-canvas lint button summarises the counts. The VS Code
-   status bar shows `$(check) BPMNlint` (hover for the config path).
+   the diagram, and the Problems bar summarises the counts. The VS Code status
+   bar shows `$(check) BPMNlint` (hover for the config path).
 
-3. Fix the issue and the overlay clears **live** — no save required.
+3. Click the Problems bar to expand the finding list. Clicking a finding selects
+   and centers its BPMN element. The eye button independently shows or hides the
+   diagram overlays.
+
+4. Fix the issue and the overlay and list entry clear **live** — no save required.
 
 ## Configuring rules
 

--- a/libs/bpmn-i18n/src/languages/de/other.ts
+++ b/libs/bpmn-i18n/src/languages/de/other.ts
@@ -270,6 +270,13 @@ const translations: Record<string, string> = {
     "Copy": "Kopieren",
     "Paste": "Einfügen",
     "No errors defined.": "Keine Fehler definiert.",
+    // bpmnlint problems panel
+    "Problems": "Probleme",
+    "No problems found.": "Keine Probleme gefunden.",
+    "Warnings": "Warnungen",
+    "Information": "Informationen",
+    "Show lint overlays": "Lint-Markierungen einblenden",
+    "Hide lint overlays": "Lint-Markierungen ausblenden",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/en/other.ts
+++ b/libs/bpmn-i18n/src/languages/en/other.ts
@@ -224,6 +224,13 @@ const translations: Record<string, string> = {
     "Copy": "Copy",
     "Paste": "Paste",
     "No errors defined.": "No errors defined.",
+    // bpmnlint problems panel
+    "Problems": "Problems",
+    "No problems found.": "No problems found.",
+    "Warnings": "Warnings",
+    "Information": "Information",
+    "Show lint overlays": "Show lint overlays",
+    "Hide lint overlays": "Hide lint overlays",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/es/other.ts
+++ b/libs/bpmn-i18n/src/languages/es/other.ts
@@ -267,6 +267,13 @@ const translations: Record<string, string> = {
     "Copy": "Copiar",
     "Paste": "Pegar",
     "No errors defined.": "No hay errores definidos.",
+    // bpmnlint problems panel
+    "Problems": "Problemas",
+    "No problems found.": "No se encontraron problemas.",
+    "Warnings": "Advertencias",
+    "Information": "Información",
+    "Show lint overlays": "Mostrar superposiciones de lint",
+    "Hide lint overlays": "Ocultar superposiciones de lint",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/fr/other.ts
+++ b/libs/bpmn-i18n/src/languages/fr/other.ts
@@ -229,6 +229,13 @@ const translations: Record<string, string> = {
     "Copy": "Copier",
     "Paste": "Coller",
     "No errors defined.": "Aucune erreur définie.",
+    // bpmnlint problems panel
+    "Problems": "Problèmes",
+    "No problems found.": "Aucun problème trouvé.",
+    "Warnings": "Avertissements",
+    "Information": "Informations",
+    "Show lint overlays": "Afficher les superpositions de lint",
+    "Hide lint overlays": "Masquer les superpositions de lint",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/nl-nl/other.ts
+++ b/libs/bpmn-i18n/src/languages/nl-nl/other.ts
@@ -226,6 +226,13 @@ const translations: Record<string, string> = {
     "Copy": "Copiar",
     "Paste": "Colar",
     "No errors defined.": "Nenhum erro definido.",
+    // bpmnlint problems panel
+    "Problems": "Problemen",
+    "No problems found.": "Geen problemen gevonden.",
+    "Warnings": "Waarschuwingen",
+    "Information": "Informatie",
+    "Show lint overlays": "Lint-overlays tonen",
+    "Hide lint overlays": "Lint-overlays verbergen",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/pt-br/other.ts
+++ b/libs/bpmn-i18n/src/languages/pt-br/other.ts
@@ -225,6 +225,13 @@ const translations: Record<string, string> = {
     "Copy": "Copiar",
     "Paste": "Colar",
     "No errors defined.": "Nenhum erro definido.",
+    // bpmnlint problems panel
+    "Problems": "Problemas",
+    "No problems found.": "Nenhum problema encontrado.",
+    "Warnings": "Avisos",
+    "Information": "Informações",
+    "Show lint overlays": "Mostrar sobreposições de lint",
+    "Hide lint overlays": "Ocultar sobreposições de lint",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/ru/other.ts
+++ b/libs/bpmn-i18n/src/languages/ru/other.ts
@@ -221,6 +221,13 @@ const translations: Record<string, string> = {
     "Copy": "Копировать",
     "Paste": "Вставить",
     "No errors defined.": "Ошибки не определены.",
+    // bpmnlint problems panel
+    "Problems": "Проблемы",
+    "No problems found.": "Проблем не найдено.",
+    "Warnings": "Предупреждения",
+    "Information": "Информация",
+    "Show lint overlays": "Показать наложения линтера",
+    "Hide lint overlays": "Скрыть наложения линтера",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/zh-Hans/other.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hans/other.ts
@@ -219,6 +219,13 @@ const translations: Record<string, string> = {
     "Variable Listener": "变量监听器",
     "Variable Listeners": "变量监听器",
     "Create new BPMN Diagram (Camunda Platform)": "新建 BPMN 流程图（Camunda Platform）",
+    // bpmnlint problems panel
+    "Problems": "问题",
+    "No problems found.": "未发现问题。",
+    "Warnings": "警告",
+    "Information": "信息",
+    "Show lint overlays": "显示 lint 标记",
+    "Hide lint overlays": "隐藏 lint 标记",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/zh-Hant/other.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hant/other.ts
@@ -219,6 +219,13 @@ const translations: Record<string, string> = {
     "Variable Listener": "變數監聽器",
     "Variable Listeners": "變數監聽器",
     "Create new BPMN Diagram (Camunda Platform)": "建立新的 BPMN 流程圖（Camunda Platform）",
+    // bpmnlint problems panel
+    "Problems": "問題",
+    "No problems found.": "未發現問題。",
+    "Warnings": "警告",
+    "Information": "資訊",
+    "Show lint overlays": "顯示 lint 標記",
+    "Hide lint overlays": "隱藏 lint 標記",
 };
 
 export default translations;


### PR DESCRIPTION
**Issue**

N/A

**Description**

Replace the `bpmn-js-bpmnlint` summary button with a docked Problems panel below the BPMN canvas.

- Show error, warning, and information counts, plus a success state when no findings remain.
- Expand or collapse the finding list independently from the in-canvas lint overlays.
- Keep overlay visibility behind a separate eye button and retain that choice across live lint-result updates.
- Keep existing yellow/red element markers and their hover details.
- Navigate renderable shape and sequence-flow findings by switching to their plane, centering them without changing zoom, and selecting them.
- Render process/root and otherwise non-renderable findings as static list content rather than disabled controls.
- Resize the canvas as the panel appears or changes height while leaving the properties panel beside it.
- Support responsive light, dark, and high-contrast styling and translated panel labels across all nine locales.
- Keep linting dormant when no `.bpmnlintrc` is available.
- Update the linting documentation.

No host protocol or lint-engine change is required; the panel renders the existing host-computed `BpmnlintResultsQuery` payload.

**Palette layout correction**

The Problems bar reduces the canvas height by 31px and exposed an existing diagram-js sizing error: `_needsCollapse` counts every palette descriptor as a 46px tool even though the separator renders at 16px. With the current 15 tools and one separator, the vendor threshold is `16 × 46 + 50 = 786px`, while the rendered one-column palette needs `15 × 46 + 16 + 50 = 756px`.

This PR keeps the correction because the premature two-column switch is directly visible when opening the new panel. It replaces the predicate on each injected editable C7/C8 palette instance; it does not modify `Palette.prototype`, DMN, or viewer canvases. The corrected predicate still switches to two columns whenever the full palette genuinely does not fit and is applied consistently instead of making palette geometry depend on whether linting is configured.

`_needsCollapse` is not part of diagram-js's public types, but its implementation explicitly directs style implementors to override it and exposes no public sizing hook. A runtime guard preserves modeler startup if the hook changes, and a contract test verifies the installed diagram-js implementation. The copied dimensions are tied to the pinned palette CSS and must be revalidated on dependency upgrades.

**Test plan**

Automated validation:

- [x] BPMN webview tests: 13 files, 99 tests
- [x] BPMN i18n tests: 3 files, 31 tests
- [x] BPMN webview production build
- [x] Documentation tests: 21 tests
- [x] Documentation production build
- [x] Formatting and `git diff --check`
- [x] ESLint: 0 errors (existing warnings only)
- [x] Required GitHub CI jobs at `8fe3cf6`, including VS Code build/tests/E2E, audit, knip, docs, and CodeQL

Manual validation:

- [ ] Verify C7 and C8 with errors, warnings, no findings, and no lint configuration.
- [ ] Verify task and sequence-flow navigation plus static process/root findings.
- [ ] Verify keyboard order and screen-reader semantics for actionable and static rows.
- [ ] Verify overlay toggling across live lint-result updates.
- [ ] Verify light, dark, and high-contrast themes at narrow widths and short heights.
- [ ] Verify the palette remains one column at 756px and switches below that threshold for C7 and C8.
- [ ] Smoke-test non-VS-Code hosts that consume the shared BPMN webview.

**Checklist**

- [x] Code is easy to understand
- [x] No obvious errors or bugs
- [x] CI/CD pipelines ran successfully
- [x] Tests were implemented
- [x] Documentation was created
