### PR TITLE
refactor(shared): centralize engine label and execution-platform mappings

### DIFF
--- a/apps/modeler-bridge/src/adapters.spec.ts
+++ b/apps/modeler-bridge/src/adapters.spec.ts
@@ -572,9 +572,9 @@ describe("RpcPicker", () => {
         return { ...h, finder, picker: new RpcPicker(h.rpc, finder) };
     }
 
-    it("pickExecutionPlatform maps the chosen label to an engine", async () => {
+    it("pickExecutionPlatform maps the chosen engine to a label and returns the id", async () => {
         const { frames, picker, answerLast } = setup();
-        const pending = picker.pickExecutionPlatform("Pick a platform", ["Camunda 7", "Camunda 8"]);
+        const pending = picker.pickExecutionPlatform("Pick a platform", ["c7", "c8"]);
         expect(last(frames)).toMatchObject({
             method: "picker/show",
             params: {
@@ -589,7 +589,7 @@ describe("RpcPicker", () => {
 
     it("pickExecutionPlatform throws UserCancelledError on dismissal", async () => {
         const { picker, answerLast } = setup();
-        const pending = picker.pickExecutionPlatform("Pick", ["Camunda 7"]);
+        const pending = picker.pickExecutionPlatform("Pick", ["c7"]);
         await answerLast({ selected: null });
         await expect(pending).rejects.toBeInstanceOf(UserCancelledError);
     });

--- a/apps/modeler-bridge/src/adapters.ts
+++ b/apps/modeler-bridge/src/adapters.ts
@@ -16,7 +16,13 @@
 
 import { posix } from "node:path";
 
-import { AuthTypePayload, Command, Engine, Query } from "@miragon/bpmn-modeler-shared";
+import {
+    AuthTypePayload,
+    Command,
+    Engine,
+    ENGINE_LABEL,
+    Query,
+} from "@miragon/bpmn-modeler-shared";
 import {
     ClipboardPort,
     DeploymentStatePort,
@@ -694,28 +700,26 @@ export class RpcPicker implements PickerPort {
         return result?.selected ?? null;
     }
 
-    async pickExecutionPlatform(placeHolder: string, items: string[]): Promise<Engine> {
+    async pickExecutionPlatform(placeHolder: string, engines: Engine[]): Promise<Engine> {
         const selected = await this.show({
             placeholder: placeHolder,
             canPickMany: false,
-            items: items.map((label) => ({ label })),
+            items: engines.map((engine) => ({ label: ENGINE_LABEL[engine] })),
         });
         if (selected === null) {
             throw new UserCancelledError();
         }
-        const result = items[selected[0]];
-        if (result === "Camunda 7") {
-            return "c7";
-        } else if (result === "Camunda 8") {
-            return "c8";
+        const engine = engines[selected[0]];
+        if (!engine) {
+            throw new Error(`No engine at index ${selected[0]}`);
         }
-        throw new Error(`Unknown execution platform version: "${result}"`);
+        return engine;
     }
 
     async pickMigrationScope(c7Count: number, c8Count: number): Promise<MigrationScope> {
         const items = [
-            `Camunda 7 only (${c7Count} diagram${c7Count !== 1 ? "s" : ""})`,
-            `Camunda 8 only (${c8Count} diagram${c8Count !== 1 ? "s" : ""})`,
+            `${ENGINE_LABEL.c7} only (${c7Count} diagram${c7Count !== 1 ? "s" : ""})`,
+            `${ENGINE_LABEL.c8} only (${c8Count} diagram${c8Count !== 1 ? "s" : ""})`,
             `Both (${c7Count + c8Count} diagram${c7Count + c8Count !== 1 ? "s" : ""})`,
         ];
         const selected = await this.show({
@@ -727,16 +731,16 @@ export class RpcPicker implements PickerPort {
             throw new UserCancelledError();
         }
         const result = items[selected[0]];
-        if (result.startsWith("Camunda 7")) {
+        if (result.startsWith(ENGINE_LABEL.c7)) {
             return "c7";
-        } else if (result.startsWith("Camunda 8")) {
+        } else if (result.startsWith(ENGINE_LABEL.c8)) {
             return "c8";
         }
         return "both";
     }
 
     async pickEngineVersion(platform: Engine, versions: readonly string[]): Promise<string> {
-        const label = platform === "c7" ? "Camunda 7" : "Camunda 8";
+        const label = ENGINE_LABEL[platform];
         const selected = await this.show({
             placeholder: `Select ${label} engine version`,
             canPickMany: false,

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/CommandController.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/CommandController.ts
@@ -202,8 +202,8 @@ export class CommandController {
             let doc: BpmnDocument;
             try {
                 const engine = await this.picker.pickExecutionPlatform("Select the engine.", [
-                    "Camunda 7",
-                    "Camunda 8",
+                    "c7",
+                    "c8",
                 ]);
                 doc = BpmnDocument.empty(engine, getLatestVersion(engine));
             } catch (error) {

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodePicker.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodePicker.ts
@@ -8,7 +8,7 @@ import { MigrationScope } from "@miragon/bpmn-modeler-core";
 import { ScriptLanguage } from "@miragon/bpmn-modeler-core";
 import { VsCodeWorkspace } from "./VsCodeWorkspace";
 
-import { Engine } from "@miragon/bpmn-modeler-shared";
+import { Engine, ENGINE_LABEL } from "@miragon/bpmn-modeler-shared";
 
 /**
  * Adapter around `window.showQuickPick` for the domain-aware prompts the
@@ -24,21 +24,20 @@ export class VsCodePicker implements PickerPort {
     /**
      * @throws {UserCancelledError} If the user dismisses the quick pick.
      */
-    async pickExecutionPlatform(placeHolder: string, items: string[]): Promise<Engine> {
-        const result = await window.showQuickPick(items, {
-            placeHolder,
-            onDidSelectItem: (item) => item,
-        });
+    async pickExecutionPlatform(placeHolder: string, engines: Engine[]): Promise<Engine> {
+        interface EngineItem extends QuickPickItem {
+            engine: Engine;
+        }
+        const qpItems: EngineItem[] = engines.map((engine) => ({
+            label: ENGINE_LABEL[engine],
+            engine,
+        }));
+        const result = await window.showQuickPick(qpItems, { placeHolder });
 
         if (result === undefined) {
             throw new UserCancelledError();
-        } else if (result === "Camunda 7") {
-            return "c7";
-        } else if (result === "Camunda 8") {
-            return "c8";
-        } else {
-            throw new Error(`Unknown execution platform version: "${result}"`);
         }
+        return result.engine;
     }
 
     /**
@@ -46,8 +45,8 @@ export class VsCodePicker implements PickerPort {
      */
     async pickMigrationScope(c7Count: number, c8Count: number): Promise<MigrationScope> {
         const items = [
-            `Camunda 7 only (${c7Count} diagram${c7Count !== 1 ? "s" : ""})`,
-            `Camunda 8 only (${c8Count} diagram${c8Count !== 1 ? "s" : ""})`,
+            `${ENGINE_LABEL.c7} only (${c7Count} diagram${c7Count !== 1 ? "s" : ""})`,
+            `${ENGINE_LABEL.c8} only (${c8Count} diagram${c8Count !== 1 ? "s" : ""})`,
             `Both (${c7Count + c8Count} diagram${c7Count + c8Count !== 1 ? "s" : ""})`,
         ];
 
@@ -57,9 +56,9 @@ export class VsCodePicker implements PickerPort {
 
         if (result === undefined) {
             throw new UserCancelledError();
-        } else if (result.startsWith("Camunda 7")) {
+        } else if (result.startsWith(ENGINE_LABEL.c7)) {
             return "c7";
-        } else if (result.startsWith("Camunda 8")) {
+        } else if (result.startsWith(ENGINE_LABEL.c8)) {
             return "c8";
         } else {
             return "both";
@@ -70,7 +69,7 @@ export class VsCodePicker implements PickerPort {
      * @throws {UserCancelledError} If the user dismisses the quick pick.
      */
     async pickEngineVersion(platform: Engine, versions: readonly string[]): Promise<string> {
-        const label = platform === "c7" ? "Camunda 7" : "Camunda 8";
+        const label = ENGINE_LABEL[platform];
         const result = await window.showQuickPick([...versions], {
             placeHolder: `Select ${label} engine version`,
         });

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeStatusBar.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeStatusBar.ts
@@ -1,6 +1,6 @@
 import { StatusBarAlignment, StatusBarItem, ThemeColor, window } from "vscode";
 
-import { Engine } from "@miragon/bpmn-modeler-shared";
+import { Engine, ENGINE_LABEL } from "@miragon/bpmn-modeler-shared";
 
 import { StatusBarPort } from "@miragon/bpmn-modeler-core";
 const CHANGE_ENGINE_VERSION_CMD = "bpmn-modeler.changeEngineVersion";
@@ -31,7 +31,7 @@ export class VsCodeStatusBar implements StatusBarPort {
 
     showEngineVersion(platform: Engine, version: string): void {
         const item = this.getOrCreateEngineVersionStatusItem();
-        const label = platform === "c7" ? "Camunda 7" : "Camunda 8";
+        const label = ENGINE_LABEL[platform];
         item.text = `$(server-environment) ${label} (${version})`;
         item.tooltip = "Click to change engine version";
         item.show();

--- a/libs/modeler-core/src/migration/service/BpmnMigrationService.ts
+++ b/libs/modeler-core/src/migration/service/BpmnMigrationService.ts
@@ -1,4 +1,4 @@
-import { Engine } from "@miragon/bpmn-modeler-shared";
+import { Engine, ENGINE_EXECUTION_PLATFORM } from "@miragon/bpmn-modeler-shared";
 
 import { BpmnDocument } from "../../shared/domain/BpmnDocument";
 import { UserCancelledError } from "../../shared/domain/errors";
@@ -150,7 +150,7 @@ export class BpmnMigrationService {
 
             let updatedDoc: BpmnDocument;
             if (currentVersion === undefined) {
-                const platformName = platform === "c7" ? "Camunda Platform" : "Camunda Cloud";
+                const platformName = ENGINE_EXECUTION_PLATFORM[platform];
                 const schema =
                     platform === "c7"
                         ? `xmlns:camunda="http://camunda.org/schema/1.0/bpmn"`

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnModelerService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnModelerService.ts
@@ -1,4 +1,4 @@
-import { BpmnFileQuery } from "@miragon/bpmn-modeler-shared";
+import { BpmnFileQuery, ENGINE_EXECUTION_PLATFORM } from "@miragon/bpmn-modeler-shared";
 
 import { ModelerSession } from "../../../shared/domain/session";
 import {
@@ -53,8 +53,8 @@ export class BpmnModelerService {
 
             if (doc.isEmpty()) {
                 const ep = await this.picker.pickExecutionPlatform("Select the engine.", [
-                    "Camunda 7",
-                    "Camunda 8",
+                    "c7",
+                    "c8",
                 ]);
 
                 doc = BpmnDocument.empty(ep, getLatestVersion(ep));
@@ -81,22 +81,17 @@ export class BpmnModelerService {
                 } else if (error instanceof ExecutionPlatformNotDetectedError) {
                     const ep = await this.picker.pickExecutionPlatform(
                         "Select the execution platform.",
-                        ["Camunda 7", "Camunda 8"],
+                        ["c7", "c8"],
                     );
 
                     const latestVersion = getLatestVersion(ep);
-                    const newDoc =
+                    const newDoc = doc.withExecutionPlatform(
+                        ENGINE_EXECUTION_PLATFORM[ep],
+                        latestVersion,
                         ep === "c7"
-                            ? doc.withExecutionPlatform(
-                                  "Camunda Platform",
-                                  latestVersion,
-                                  `xmlns:camunda="http://camunda.org/schema/1.0/bpmn"`,
-                              )
-                            : doc.withExecutionPlatform(
-                                  "Camunda Cloud",
-                                  latestVersion,
-                                  `xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"`,
-                              );
+                            ? `xmlns:camunda="http://camunda.org/schema/1.0/bpmn"`
+                            : `xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"`,
+                    );
 
                     await this.editorStore.postMessage(editorId, new BpmnFileQuery(newDoc.xml, ep));
                     this.statusBar.showEngineVersion(ep, latestVersion);

--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -62,7 +62,7 @@ export interface NotifierPort extends LoggerPort {
  */
 export interface PickerPort {
     /** @throws {UserCancelledError} on dismissal. */
-    pickExecutionPlatform(placeHolder: string, items: string[]): Promise<Engine>;
+    pickExecutionPlatform(placeHolder: string, engines: Engine[]): Promise<Engine>;
     /** @throws {UserCancelledError} on dismissal. */
     pickMigrationScope(c7Count: number, c8Count: number): Promise<MigrationScope>;
     /** @throws {UserCancelledError} on dismissal. */

--- a/libs/shared/src/lib/modeler.ts
+++ b/libs/shared/src/lib/modeler.ts
@@ -57,6 +57,21 @@ export type BpmnViewerMode = "modeler" | "viewer";
  */
 export type Engine = "c7" | "c8";
 
+/** Display names for UI surfaces (status bar, pickers, labels). */
+export const ENGINE_LABEL: Record<Engine, string> = {
+    c7: "Camunda 7",
+    c8: "Camunda 8",
+};
+
+/**
+ * Execution-platform names written into BPMN XML (`modeler:executionPlatform`).
+ * These are spec-defined strings — do not change them independently of the BPMN spec.
+ */
+export const ENGINE_EXECUTION_PLATFORM: Record<Engine, string> = {
+    c7: "Camunda Platform",
+    c8: "Camunda Cloud",
+};
+
 export class BpmnFileQuery extends Query {
     public readonly content: string;
 


### PR DESCRIPTION
## Summary

- Add `ENGINE_LABEL` and `ENGINE_EXECUTION_PLATFORM` constants to `libs/shared` as the single source of truth for Camunda engine display names and BPMN XML platform strings
- Change `PickerPort.pickExecutionPlatform` to accept `Engine[]` instead of `string[]` — implementations render labels themselves and return the id directly, eliminating label-to-id reverse mapping
- Replace all scattered ternaries (`platform === "c7" ? "Camunda 7" : "Camunda 8"`) and hard-coded strings across `VsCodePicker`, `VsCodeStatusBar`, `CommandController`, `BpmnModelerService`, `BpmnMigrationService`, and the modeler-bridge adapter

## Test plan

- [ ] `corepack yarn build` passes
- [ ] `corepack yarn test` passes
- [ ] `corepack yarn format:check` passes
- [ ] Engine picker shows correct labels in VS Code status bar and QuickPick