### PR TITLE
feat(bpmn): lint diagrams by default, per execution platform

### DIFF
--- a/apps/demo-webapp/package.json
+++ b/apps/demo-webapp/package.json
@@ -7,7 +7,8 @@
         "build:bpmn": "vite build --mode bpmn",
         "build:dmn": "vite build --mode dmn",
         "build": "npm-run-all -s build:bpmn build:dmn",
-        "serve:bpmn": "vite --mode bpmn"
+        "serve:bpmn": "vite --mode bpmn",
+        "preview": "node serve-demo.mjs"
     },
     "dependencies": {
         "@miragon/bpmn-modeler-shared": "workspace:*",

--- a/apps/demo-webapp/serve-demo.mjs
+++ b/apps/demo-webapp/serve-demo.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 // Dependency-free static server for the built demo (dist/demo).
-// Used by `yarn demo` / the Conductor run target.
+// Used by `yarn demo` / the Conductor run target, via this workspace's
+// `preview` script (the root `preview:demo` delegates here).
 import { createReadStream, statSync } from "node:fs";
 import { extname, join, resolve } from "node:path";
 import { createServer } from "node:http";
 import { fileURLToPath } from "node:url";
 
-const repoRoot = resolve(fileURLToPath(import.meta.url), "..", "..");
+// This file lives in apps/demo-webapp/, so the repo root is three levels up.
+const repoRoot = resolve(fileURLToPath(import.meta.url), "..", "..", "..");
 const webroot = resolve(repoRoot, "dist/demo");
 const port = Number(process.env.PORT ?? 4321);
 const host = process.env.HOST ?? "127.0.0.1";

--- a/apps/modeler-bridge/src/adapters.ts
+++ b/apps/modeler-bridge/src/adapters.ts
@@ -449,6 +449,10 @@ export class RpcStatusBar implements StatusBarPort {
         /* not supported yet for intellij */
     }
 
+    showBpmnlintDefault(): void {
+        /* not supported yet for intellij */
+    }
+
     showBpmnlintNoConfig(): void {
         /* not supported yet for intellij */
     }

--- a/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
+++ b/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
@@ -7,9 +7,10 @@
  * `NodeBpmnLinter` do an actual nearest-`.bpmnlintrc` walk and run bpmnlint.
  * Covers the two branches the webview's `GetBpmnlintConfigCommand` exposes: a
  * discovered config is linted and the findings pushed as `BpmnlintResultsQuery`,
- * and no config pushes `results: null` so the webview deactivates linting. The
- * temp dir has no `node_modules`, so built-in rules resolve from the bundled
- * fallback resolver — the same path a workspace without `bpmnlint` installed hits.
+ * and no config falls back to the bundled default (#1327) rather than deactivating.
+ * The temp dir has no `node_modules`, so built-in and camunda-compat rules resolve
+ * from the bundled resolvers — the same path a workspace without `bpmnlint`
+ * installed hits.
  */
 
 import { promises as fs } from "node:fs";
@@ -114,12 +115,14 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
         expect(Object.keys(results)).toContain("start-event-required");
     });
 
-    it("pushes null results when no .bpmnlintrc exists so linting deactivates", async () => {
+    it("lints against the bundled default when no .bpmnlintrc exists", async () => {
         const { rpc, frames, editorId } = await setup();
 
         await requestConfig(rpc, editorId);
 
         const frame = await waitForFrame(frames, isLintResultsFrame);
-        expect(frame.params.message.results).toBeNull();
+        const results = frame.params.message.results;
+        expect(results).not.toBeNull();
+        expect(Object.keys(results)).toContain("start-event-required");
     });
 });

--- a/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
+++ b/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
@@ -2,6 +2,7 @@ import { Command } from "@miragon/bpmn-modeler-shared";
 import {
     BpmnLintConfigLocator,
     BpmnLintConfigService,
+    DefaultBpmnlintConfigService,
     NodeBpmnLinter,
     NoopDiagnostics,
 } from "@miragon/bpmn-modeler-core";
@@ -33,6 +34,7 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
         new NoopDiagnostics(),
         deps.statusBar,
         deps.notifier,
+        new DefaultBpmnlintConfigService(),
     );
 
     // The webview posts this once on load (fire-and-forget, not part of the

--- a/apps/modeler-bridge/tsconfig.app.json
+++ b/apps/modeler-bridge/tsconfig.app.json
@@ -5,5 +5,11 @@
         "types": ["node"],
         "esModuleInterop": true
     },
-    "include": ["src/**/*.ts", "../../libs/modeler-core/src/types/bpmnlint.d.ts"]
+    "include": [
+        "src/**/*.ts",
+        "../../libs/modeler-core/src/types/bpmnlint.d.ts",
+        "../../libs/modeler-core/src/types/bpmnlint-plugin-camunda-compat.d.ts",
+        "../../libs/modeler-core/src/types/camunda-bpmn-moddle.d.ts",
+        "../../libs/modeler-core/src/types/zeebe-bpmn-moddle.d.ts"
+    ]
 }

--- a/apps/vscode-plugin/src/composition/editorFeature.ts
+++ b/apps/vscode-plugin/src/composition/editorFeature.ts
@@ -11,6 +11,7 @@ import { BpmnClipboardMediator } from "@miragon/bpmn-modeler-core";
 import { BpmnElementTemplatesService } from "@miragon/bpmn-modeler-core";
 import { BpmnLintConfigLocator } from "@miragon/bpmn-modeler-core";
 import { BpmnLintConfigService } from "@miragon/bpmn-modeler-core";
+import { DefaultBpmnlintConfigService } from "@miragon/bpmn-modeler-core";
 import { BpmnPropertiesPanelService } from "@miragon/bpmn-modeler-core";
 import { BpmnSettingsBroadcaster } from "@miragon/bpmn-modeler-core";
 import { DmnModelerService } from "@miragon/bpmn-modeler-core";
@@ -132,6 +133,7 @@ export function register(
         new VsCodeDiagnostics(),
         deps.statusBar,
         deps.notifier,
+        new DefaultBpmnlintConfigService(),
     );
     const clipboardMediator = new BpmnClipboardMediator(
         deps.editorStore,

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeStatusBar.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeStatusBar.ts
@@ -64,6 +64,17 @@ export class VsCodeStatusBar implements StatusBarPort {
         item.show();
     }
 
+    showBpmnlintDefault(platform: Engine | undefined): void {
+        const item = this.getOrCreateBpmnlintStatusItem();
+        // A shield (not the green tick) so a bundled default is never mistaken for
+        // a project's own `.bpmnlintrc`.
+        item.text = "$(shield) BPMNlint (default)";
+        const engine = platform ? ENGINE_LABEL[platform] : "no execution platform";
+        item.tooltip = `Linting against the bundled default (${engine}).\nAdd a .bpmnlintrc to your workspace to override it.`;
+        item.backgroundColor = undefined;
+        item.show();
+    }
+
     showBpmnlintNoConfig(): void {
         const item = this.getOrCreateBpmnlintStatusItem();
         item.text = "$(info) BPMNlint: no .bpmnlintrc";

--- a/apps/vscode-plugin/tsconfig.app.json
+++ b/apps/vscode-plugin/tsconfig.app.json
@@ -9,6 +9,9 @@
   "include": [
     "src/**/*.ts",
     "src/**/*.d.ts",
-    "../../libs/modeler-core/src/types/bpmnlint.d.ts"
+    "../../libs/modeler-core/src/types/bpmnlint.d.ts",
+    "../../libs/modeler-core/src/types/bpmnlint-plugin-camunda-compat.d.ts",
+    "../../libs/modeler-core/src/types/camunda-bpmn-moddle.d.ts",
+    "../../libs/modeler-core/src/types/zeebe-bpmn-moddle.d.ts"
   ]
 }

--- a/docs/vscode/features/linting.md
+++ b/docs/vscode/features/linting.md
@@ -5,14 +5,44 @@ The BPMN Modeler can validate your diagram **while you edit** using
 CI. When a `.bpmnlintrc` is found, rule violations appear as ⚠️/❌ overlays on the
 offending elements, a summary button (error/warning counts) is shown on the
 canvas, and each finding is also published to the VS Code **Problems** panel
-(searchable and clickable, even without the diagram open). If no `.bpmnlintrc`
-exists, the feature stays dormant and the modeler looks exactly as it did before.
+(searchable and clickable, even without the diagram open). Even with **no
+`.bpmnlintrc` at all**, the modeler lints against a bundled default so every
+diagram gets baseline validation for free — see
+[Zero-config default](#zero-config-default). Any `.bpmnlintrc` the workspace adds
+still takes over completely.
 
 The lint runs in the **extension host** (a full Node.js context), not in the
 webview. That is what lets it resolve your workspace's own
 `bpmnlint-plugin-*` packages and `plugin:*` configs against `node_modules` —
 exactly like the `bpmnlint` CLI — so custom rules work in the modeler, not just
 built-ins. See [Custom rules & plugins](#custom-rules-plugins) below.
+
+## Zero-config default
+
+With no `.bpmnlintrc` found anywhere from the diagram's folder up to the
+workspace root, the modeler lints against a **bundled default** instead of
+staying silent. The status bar shows `$(shield) BPMNlint (default)` — distinct
+from the `$(check) BPMNlint` shown for a project's own config — so you always
+know which is in effect.
+
+The default is layered, and its engine layer is chosen from the diagram's
+**detected execution platform** (re-evaluated on every edit, so switching engines
+mid-model switches the rules too):
+
+- **Shared base** — `bpmnlint:recommended`. Catches the execution-breaking basics
+  on every diagram: missing start/end event, disconnected element, fake join,
+  implicit split/join, and so on.
+- **Miragon layer** — a thin, additive slot for Miragon-specific conventions. Wired
+  into the default but currently empty; rules will be added here over time.
+- **Engine layer** — when the diagram targets Camunda 7 or Camunda 8, the
+  matching [`bpmnlint-plugin-camunda-compat`](https://github.com/camunda/bpmnlint-plugin-camunda-compat)
+  deployability rules are added (the same rules the Camunda Modeler ships), so a
+  construct the target engine can't run is flagged while you model instead of at
+  deploy time. A file with no detectable platform gets the structural base only.
+
+Everything resolves from rules bundled into the extension — no workspace
+`bpmnlint` install, and it works offline. To change or silence anything, add a
+`.bpmnlintrc` (below); even an empty `{}` fully overrides the default.
 
 ## Usage
 

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -58,6 +58,7 @@ module.exports = [
             ".github/scripts/**/*.mjs",
             "apps/standalone/scripts/**/*.mjs",
             "libs/standalone-extension/scripts/**/*.mjs",
+            "apps/demo-webapp/serve-demo.mjs",
         ],
         languageOptions: {
             globals: {

--- a/libs/modeler-core/package.json
+++ b/libs/modeler-core/package.json
@@ -12,8 +12,10 @@
     "bpmn-js-differ": "3.2.0",
     "bpmn-moddle": "10.0.0",
     "bpmnlint": "11.12.1",
+    "bpmnlint-plugin-camunda-compat": "2.59.2",
     "camunda-bpmn-moddle": "7.0.1",
-    "tslib": "2.8.1"
+    "tslib": "2.8.1",
+    "zeebe-bpmn-moddle": "1.15.0"
   },
   "devDependencies": {
     "@types/node": "26.1.2",

--- a/libs/modeler-core/src/index.ts
+++ b/libs/modeler-core/src/index.ts
@@ -30,6 +30,7 @@ export * from "./modeler/bpmn/domain/model";
 export * from "./modeler/bpmn/service/BpmnModelerService";
 export * from "./modeler/bpmn/service/BpmnElementTemplatesService";
 export * from "./modeler/bpmn/service/BpmnLintConfigService";
+export * from "./modeler/bpmn/service/DefaultBpmnlintConfigService";
 export * from "./modeler/bpmn/infrastructure/bpmnlint/NodeBpmnLinter";
 export * from "./modeler/bpmn/infrastructure/bpmnlint/NoopDiagnostics";
 export * from "./modeler/bpmn/service/BpmnClipboardMediator";

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/CompositeResolver.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/CompositeResolver.ts
@@ -21,11 +21,14 @@ const NOOP_RULE = () => ({ check: () => undefined });
 const NOOP_CONFIG = { rules: {} };
 
 /**
- * Resolves bpmnlint rules and configs by trying the workspace first (custom
- * `bpmnlint-plugin-*` packages, and the workspace's own `bpmnlint` if installed),
- * then falling back to the built-in rules bundled into the host.
+ * Resolves bpmnlint rules and configs by trying each delegate in order — the
+ * workspace first (custom `bpmnlint-plugin-*` packages, and the workspace's own
+ * `bpmnlint` if installed), then the built-in rules bundled into the host, then
+ * any further fallbacks (e.g. the {@link bundledDefaultResolver}, added only for
+ * the zero-config default run so an explicit workspace config never resolves
+ * against our bundled camunda-compat copy).
  *
- * A rule/config that neither side can resolve is *skipped*, not thrown: its name
+ * A rule/config that no delegate can resolve is *skipped*, not thrown: its name
  * is collected in {@link unresolved} and a no-op is returned so the rest of the
  * lint still runs. This is what turns the old "unknown rule → whole lint fails"
  * (or the webview's silent drop) into a visible, non-fatal "N rules skipped".
@@ -34,10 +37,11 @@ export class CompositeResolver implements Resolver {
     /** Names of rules/configs that could not be resolved this run. */
     readonly unresolved: string[] = [];
 
-    constructor(
-        private readonly workspace: Resolver,
-        private readonly builtin: Resolver,
-    ) {}
+    private readonly resolvers: Resolver[];
+
+    constructor(...resolvers: Resolver[]) {
+        this.resolvers = resolvers;
+    }
 
     resolveRule(pkg: string, ruleName: string): unknown {
         const resolved = this.tryResolve((r) => r.resolveRule(pkg, ruleName));
@@ -58,13 +62,13 @@ export class CompositeResolver implements Resolver {
     }
 
     /**
-     * Workspace-first, built-in-fallback. Each resolver throws (or returns
+     * Tries each delegate in registration order. Each resolver throws (or returns
      * null/undefined) on a miss, so a throw is a normal miss, not an error to
      * propagate. A resolved rule/config is always an object, so only nullish
      * counts as a miss — a hypothetical falsy-but-valid result still passes.
      */
     private tryResolve(resolve: (r: Resolver) => unknown): unknown {
-        for (const resolver of [this.workspace, this.builtin]) {
+        for (const resolver of this.resolvers) {
             try {
                 const resolved = resolve(resolver);
                 if (resolved != null) {

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/NodeBpmnLinter.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/NodeBpmnLinter.spec.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { DefaultBpmnlintConfigService } from "../../service/DefaultBpmnlintConfigService";
 import { NodeBpmnLinter } from "./NodeBpmnLinter";
 
 // A tmp dir has no `node_modules` up its tree, so the workspace NodeResolver
@@ -50,5 +51,46 @@ describe("NodeBpmnLinter", () => {
         });
 
         expect(unresolved).toContain("plugin:bpmnlint-plugin-custom-plugin/recommended");
+    });
+
+    // A connected C8 service task with no `zeebe:taskDefinition` — a canonical
+    // deploy-breaker the camunda-compat `implementation` rule flags.
+    const BPMN_C8_UNIMPLEMENTED_SERVICE_TASK = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="Start_1" />
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Task_1" />
+    <bpmn:serviceTask id="Task_1" name="Do the thing" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="End_1" />
+    <bpmn:endEvent id="End_1" />
+  </bpmn:process>
+</bpmn:definitions>`;
+
+    it("lints against the bundled default and fires a camunda-compat C8 rule with everything resolved", async () => {
+        const config = await new DefaultBpmnlintConfigService().build("c8");
+
+        const { results, unresolved } = await new NodeBpmnLinter().lint(
+            BPMN_C8_UNIMPLEMENTED_SERVICE_TASK,
+            CONFIG_PATH,
+            config,
+            true,
+        );
+
+        expect(unresolved).toEqual([]);
+        expect(Object.keys(results)).toContain("camunda-compat/implementation");
+    });
+
+    it("reports base bpmnlint:recommended findings under the bundled default", async () => {
+        const config = await new DefaultBpmnlintConfigService().build(undefined);
+
+        const { results, unresolved } = await new NodeBpmnLinter().lint(
+            BPMN_WITH_TASK,
+            CONFIG_PATH,
+            config,
+            true,
+        );
+
+        expect(unresolved).toEqual([]);
+        expect(Object.keys(results)).toContain("start-event-required");
     });
 });

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/NodeBpmnLinter.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/NodeBpmnLinter.ts
@@ -4,6 +4,7 @@ import { LintResults } from "@miragon/bpmn-modeler-shared";
 
 import { LintRunnerPort } from "../../../../shared/domain/hostPorts";
 import { builtinResolver } from "./builtinResolver";
+import { bundledDefaultResolver } from "./bundledDefaultResolver";
 import { CompositeResolver } from "./CompositeResolver";
 
 // bpmnlint ships no type declarations; its entry points are typed by the ambient
@@ -41,6 +42,7 @@ export class NodeBpmnLinter implements LintRunnerPort {
         xml: string,
         configPath: string,
         config: Record<string, unknown>,
+        useBundledDefaults = false,
     ): Promise<{ results: LintResults; unresolved: string[] }> {
         const configDir = dirname(uriPathToFsPath(configPath));
         const scopedRequire = createScopedRequire(configDir);
@@ -48,6 +50,7 @@ export class NodeBpmnLinter implements LintRunnerPort {
         const resolver = new CompositeResolver(
             new NodeResolver({ require: scopedRequire, requireLocal: scopedRequire }),
             builtinResolver,
+            ...(useBundledDefaults ? [bundledDefaultResolver] : []),
         );
 
         const moddleExtensions = this.loadModdleExtensions(config, scopedRequire, resolver);
@@ -61,9 +64,14 @@ export class NodeBpmnLinter implements LintRunnerPort {
     }
 
     /**
-     * Resolves the config's `moddleExtensions` (`{ prefix: modulePath }`) against
-     * the workspace so custom rules that inspect Camunda properties see the same
-     * typed model the CLI does. A module that fails to load is skipped and
+     * Resolves the config's `moddleExtensions` (`{ prefix: value }`) so rules that
+     * inspect Camunda/Zeebe properties see the same typed model the CLI does.
+     *
+     * A workspace `.bpmnlintrc` declares each extension as a module-path string,
+     * `require`d from the workspace. The zero-config default instead embeds the
+     * descriptor object directly (see {@link DefaultBpmnlintConfigService}) because
+     * a config-less workspace has no `node_modules` to resolve it from — those
+     * pass straight through. A string module that fails to load is skipped and
      * recorded rather than aborting the lint.
      */
     private loadModdleExtensions(
@@ -77,9 +85,13 @@ export class NodeBpmnLinter implements LintRunnerPort {
         }
 
         const extensions: Record<string, unknown> = {};
-        for (const [prefix, modulePath] of Object.entries(declared as Record<string, unknown>)) {
+        for (const [prefix, value] of Object.entries(declared as Record<string, unknown>)) {
+            if (value && typeof value === "object") {
+                extensions[prefix] = value;
+                continue;
+            }
             try {
-                extensions[prefix] = scopedRequire(String(modulePath));
+                extensions[prefix] = scopedRequire(String(value));
             } catch {
                 resolver.unresolved.push(`moddleExtension:${prefix}`);
             }

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/bundledDefaultResolver.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/bundledDefaultResolver.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import camundaCompat from "bpmnlint-plugin-camunda-compat";
+
+import { bundledDefaultResolver } from "./bundledDefaultResolver";
+
+// bpmnlint normalises a plugin's short name to its full `bpmnlint-plugin-*` name
+// before calling the resolver, so that is the package the cache must answer for.
+const COMPAT = "bpmnlint-plugin-camunda-compat";
+const MIRAGON = "bpmnlint-plugin-miragon";
+
+// The two engine configs the bundled default extends (see DefaultBpmnlintConfigService).
+const PINNED_CONFIGS = ["camunda-platform-7-24", "camunda-cloud-8-10"];
+
+describe("bundledDefaultResolver", () => {
+    it("resolves the pinned per-platform camunda-compat configs", () => {
+        expect(bundledDefaultResolver.resolveConfig(COMPAT, "camunda-platform-7-24")).toBeTruthy();
+        expect(bundledDefaultResolver.resolveConfig(COMPAT, "camunda-cloud-8-10")).toBeTruthy();
+    });
+
+    it("resolves a camunda-compat rule the C8 config references", () => {
+        expect(bundledDefaultResolver.resolveRule(COMPAT, "implementation")).toBeTruthy();
+    });
+
+    it("resolves the miragon layer, which is wired in but currently empty", () => {
+        const config = bundledDefaultResolver.resolveConfig(MIRAGON, "recommended") as {
+            rules: Record<string, unknown>;
+        };
+        expect(config.rules).toEqual({});
+    });
+
+    it("bundles every camunda-compat rule the pinned configs reference (guards plugin bumps)", () => {
+        const referenced = PINNED_CONFIGS.flatMap((name) =>
+            Object.keys((camundaCompat.configs[name] as { rules: Record<string, unknown> }).rules),
+        );
+
+        for (const ruleName of referenced) {
+            if (ruleName.startsWith("bpmnlint/")) {
+                continue; // core rules come from builtinResolver, not this bundle
+            }
+            // A missing rule throws (StaticResolver), so a plugin bump that adds or
+            // renames a referenced rule fails here until the bundle is updated.
+            expect(bundledDefaultResolver.resolveRule(COMPAT, ruleName)).toBeTruthy();
+        }
+    });
+
+    it("misses an unknown entry by throwing, which CompositeResolver treats as fall-through", () => {
+        expect(() => bundledDefaultResolver.resolveRule(COMPAT, "does-not-exist")).toThrow();
+        expect(() => bundledDefaultResolver.resolveConfig(COMPAT, "camunda-cloud-99-9")).toThrow();
+    });
+});

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/bundledDefaultResolver.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/bundledDefaultResolver.ts
@@ -1,0 +1,161 @@
+/**
+ * A `StaticResolver` over the bundled default lint layers, mirroring
+ * {@link builtinResolver} for bpmnlint's own rules. It backs the zero-config
+ * default only (see {@link CompositeResolver}) — never a workspace `.bpmnlintrc`,
+ * so a project's own `plugin:camunda-compat/*` still resolves against its copy.
+ *
+ * Structure mirrors how the default is assembled, grouped so it stays legible:
+ * - MIRAGON — our own (currently empty) opinion layer.
+ * - CONFIGS — the two pinned camunda-compat engine configs, one per platform.
+ *   A config is plain data on the imported plugin index, hence a direct lookup.
+ * - C7_RULES / C8_RULES — the rule *modules* each of those two configs references.
+ *   A rule is a separate module the plugin only names by a require-path string a
+ *   bundler cannot follow, so — like {@link builtinResolver} — each is a static
+ *   import. They are split by engine: `camunda-platform-7-24` references only
+ *   `history-time-to-live`; every other entry belongs to `camunda-cloud-8-10`.
+ *
+ * Staying up to date: this list is hand-maintained, but not by eye — the
+ * `bundledDefaultResolver` spec iterates both pinned configs' referenced rules and
+ * asserts each resolves here, so a `bpmnlint-plugin-camunda-compat` bump that adds
+ * or renames a referenced rule fails the build until this file is updated. Keys use
+ * the full `bpmnlint-plugin-*` name because bpmnlint normalises a plugin's short
+ * name before calling the resolver.
+ */
+import type { Resolver } from "./CompositeResolver";
+
+import StaticResolver from "bpmnlint/lib/resolver/static-resolver";
+
+import camundaCompat from "bpmnlint-plugin-camunda-compat";
+
+import { miragonRecommended } from "./miragonConfig";
+
+// C7 rules — referenced by `camunda-platform-7-24`.
+import rule_history_time_to_live from "bpmnlint-plugin-camunda-compat/rules/camunda-platform/history-time-to-live";
+
+// C8 rules — referenced by `camunda-cloud-8-10`.
+import rule_ad_hoc_sub_process from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/ad-hoc-sub-process";
+import rule_agent_fromai_contract from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-fromai-contract";
+import rule_agent_tool_documentation from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-tool-documentation";
+import rule_agent_tool_output_key from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/agent-tool-output-key";
+import rule_before_all_execution_listener from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/before-all-execution-listener";
+import rule_called_element from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/called-element";
+import rule_cancel_execution_listener from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/cancel-execution-listener";
+import rule_connector_properties from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/connector-properties";
+import rule_duplicate_execution_listener_headers from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-execution-listener-headers";
+import rule_duplicate_execution_listeners from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-execution-listeners";
+import rule_duplicate_task_headers from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/duplicate-task-headers";
+import rule_element_type from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/element-type";
+import rule_error_reference from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/error-reference";
+import rule_escalation_boundary_event_attached_to_ref from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-boundary-event-attached-to-ref";
+import rule_escalation_reference from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/escalation-reference";
+import rule_event_based_gateway_target from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/event-based-gateway-target";
+import rule_executable_process from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/executable-process";
+import rule_execution_listener from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/execution-listener";
+import rule_feel from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel";
+import rule_feel_compatibility from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/feel-compatibility";
+import rule_implementation from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/implementation";
+import rule_io_mapping from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/io-mapping";
+import rule_link_event from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/link-event";
+import rule_loop_characteristics from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/loop-characteristics";
+import rule_message_reference from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/message-reference";
+import rule_no_expression from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-expression";
+import rule_no_interrupting_event_subprocess from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-interrupting-event-subprocess";
+import rule_no_loop from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-loop";
+import rule_no_multiple_none_start_events from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/no-multiple-none-start-events";
+import rule_priority_definition from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/priority-definition";
+import rule_secrets from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/secrets";
+import rule_sequence_flow_condition from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/sequence-flow-condition";
+import rule_signal_reference from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/signal-reference";
+import rule_start_event_form from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form";
+import rule_start_event_form_embedded from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/start-event-form-embedded";
+import rule_subscription from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/subscription";
+import rule_task_listener from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-listener";
+import rule_task_schedule from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/task-schedule";
+import rule_timer from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/timer";
+import rule_user_task_definition from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-definition";
+import rule_user_task_form from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/user-task-form";
+import rule_variable_name from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/variable-name";
+import rule_version_tag from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/version-tag";
+import rule_wait_for_completion from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/wait-for-completion";
+import rule_zeebe_user_task from "bpmnlint-plugin-camunda-compat/rules/camunda-cloud/zeebe-user-task";
+
+/** Our own opinion layer (currently empty; see {@link miragonRecommended}). */
+const MIRAGON: Record<string, unknown> = {
+    "config:bpmnlint-plugin-miragon/recommended": miragonRecommended,
+};
+
+/** The two pinned engine configs — plain data off the imported plugin index. */
+const CONFIGS: Record<string, unknown> = {
+    "config:bpmnlint-plugin-camunda-compat/camunda-platform-7-24":
+        camundaCompat.configs["camunda-platform-7-24"],
+    "config:bpmnlint-plugin-camunda-compat/camunda-cloud-8-10":
+        camundaCompat.configs["camunda-cloud-8-10"],
+};
+
+/** Rule modules `camunda-platform-7-24` (C7) references. */
+const C7_RULES: Record<string, unknown> = {
+    "rule:bpmnlint-plugin-camunda-compat/history-time-to-live": rule_history_time_to_live,
+};
+
+/** Rule modules `camunda-cloud-8-10` (C8) references. */
+const C8_RULES: Record<string, unknown> = {
+    "rule:bpmnlint-plugin-camunda-compat/ad-hoc-sub-process": rule_ad_hoc_sub_process,
+    "rule:bpmnlint-plugin-camunda-compat/agent-fromai-contract": rule_agent_fromai_contract,
+    "rule:bpmnlint-plugin-camunda-compat/agent-tool-documentation": rule_agent_tool_documentation,
+    "rule:bpmnlint-plugin-camunda-compat/agent-tool-output-key": rule_agent_tool_output_key,
+    "rule:bpmnlint-plugin-camunda-compat/before-all-execution-listener":
+        rule_before_all_execution_listener,
+    "rule:bpmnlint-plugin-camunda-compat/called-element": rule_called_element,
+    "rule:bpmnlint-plugin-camunda-compat/cancel-execution-listener": rule_cancel_execution_listener,
+    "rule:bpmnlint-plugin-camunda-compat/connector-properties": rule_connector_properties,
+    "rule:bpmnlint-plugin-camunda-compat/duplicate-execution-listener-headers":
+        rule_duplicate_execution_listener_headers,
+    "rule:bpmnlint-plugin-camunda-compat/duplicate-execution-listeners":
+        rule_duplicate_execution_listeners,
+    "rule:bpmnlint-plugin-camunda-compat/duplicate-task-headers": rule_duplicate_task_headers,
+    "rule:bpmnlint-plugin-camunda-compat/element-type": rule_element_type,
+    "rule:bpmnlint-plugin-camunda-compat/error-reference": rule_error_reference,
+    "rule:bpmnlint-plugin-camunda-compat/escalation-boundary-event-attached-to-ref":
+        rule_escalation_boundary_event_attached_to_ref,
+    "rule:bpmnlint-plugin-camunda-compat/escalation-reference": rule_escalation_reference,
+    "rule:bpmnlint-plugin-camunda-compat/event-based-gateway-target":
+        rule_event_based_gateway_target,
+    "rule:bpmnlint-plugin-camunda-compat/executable-process": rule_executable_process,
+    "rule:bpmnlint-plugin-camunda-compat/execution-listener": rule_execution_listener,
+    "rule:bpmnlint-plugin-camunda-compat/feel": rule_feel,
+    "rule:bpmnlint-plugin-camunda-compat/feel-compatibility": rule_feel_compatibility,
+    "rule:bpmnlint-plugin-camunda-compat/implementation": rule_implementation,
+    "rule:bpmnlint-plugin-camunda-compat/io-mapping": rule_io_mapping,
+    "rule:bpmnlint-plugin-camunda-compat/link-event": rule_link_event,
+    "rule:bpmnlint-plugin-camunda-compat/loop-characteristics": rule_loop_characteristics,
+    "rule:bpmnlint-plugin-camunda-compat/message-reference": rule_message_reference,
+    "rule:bpmnlint-plugin-camunda-compat/no-expression": rule_no_expression,
+    "rule:bpmnlint-plugin-camunda-compat/no-interrupting-event-subprocess":
+        rule_no_interrupting_event_subprocess,
+    "rule:bpmnlint-plugin-camunda-compat/no-loop": rule_no_loop,
+    "rule:bpmnlint-plugin-camunda-compat/no-multiple-none-start-events":
+        rule_no_multiple_none_start_events,
+    "rule:bpmnlint-plugin-camunda-compat/priority-definition": rule_priority_definition,
+    "rule:bpmnlint-plugin-camunda-compat/secrets": rule_secrets,
+    "rule:bpmnlint-plugin-camunda-compat/sequence-flow-condition": rule_sequence_flow_condition,
+    "rule:bpmnlint-plugin-camunda-compat/signal-reference": rule_signal_reference,
+    "rule:bpmnlint-plugin-camunda-compat/start-event-form": rule_start_event_form,
+    "rule:bpmnlint-plugin-camunda-compat/start-event-form-embedded": rule_start_event_form_embedded,
+    "rule:bpmnlint-plugin-camunda-compat/subscription": rule_subscription,
+    "rule:bpmnlint-plugin-camunda-compat/task-listener": rule_task_listener,
+    "rule:bpmnlint-plugin-camunda-compat/task-schedule": rule_task_schedule,
+    "rule:bpmnlint-plugin-camunda-compat/timer": rule_timer,
+    "rule:bpmnlint-plugin-camunda-compat/user-task-definition": rule_user_task_definition,
+    "rule:bpmnlint-plugin-camunda-compat/user-task-form": rule_user_task_form,
+    "rule:bpmnlint-plugin-camunda-compat/variable-name": rule_variable_name,
+    "rule:bpmnlint-plugin-camunda-compat/version-tag": rule_version_tag,
+    "rule:bpmnlint-plugin-camunda-compat/wait-for-completion": rule_wait_for_completion,
+    "rule:bpmnlint-plugin-camunda-compat/zeebe-user-task": rule_zeebe_user_task,
+};
+
+export const bundledDefaultResolver: Resolver = new StaticResolver({
+    ...MIRAGON,
+    ...CONFIGS,
+    ...C7_RULES,
+    ...C8_RULES,
+});

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/miragonConfig.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/miragonConfig.ts
@@ -1,0 +1,15 @@
+/**
+ * The Miragon opinion layer of the bundled default (`plugin:miragon/recommended`) —
+ * the place for genuine, non-engine Miragon conventions.
+ *
+ * Intentionally empty for now. It stays wired into the default (so adding a rule
+ * later is a one-line change here) but ships no rule yet: our first planned
+ * convention — uniform, modeler-default element sizes — is landing in bpmnlint
+ * itself (https://github.com/bpmn-io/bpmnlint/pull/214) and will reach us via
+ * `miragon-rules`, so shipping a throwaway copy now is not worth it.
+ *
+ * Tracked in https://github.com/Miragon/bpmn-modeler/issues/1333.
+ */
+export const miragonRecommended = {
+    rules: {},
+};

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
@@ -8,9 +8,13 @@ vi.mock("vscode", () => ({}));
 import { BpmnlintResultsQuery } from "@miragon/bpmn-modeler-shared";
 
 import { BpmnLintConfigService } from "./BpmnLintConfigService";
+import { DefaultBpmnlintConfigService } from "./DefaultBpmnlintConfigService";
 
 const EDITOR = "file:///work/diagram.bpmn";
+// No platform markers → detectPlatform() throws → structural-only default.
 const XML = "<xml/>";
+const XML_C7 = '<definitions modeler:executionPlatformVersion="7.20.0" />';
+const XML_C8 = '<definitions modeler:executionPlatformVersion="8.6.0" />';
 const RESULTS = {
     "label-required": [{ id: "Task_1", message: "Element requires a label", category: "warn" }],
 };
@@ -32,6 +36,7 @@ function createService() {
     const statusBar = {
         showBpmnlintActive: vi.fn(),
         showBpmnlintUnresolved: vi.fn(),
+        showBpmnlintDefault: vi.fn(),
         showBpmnlintNoConfig: vi.fn(),
         hideBpmnlintStatus: vi.fn(),
     };
@@ -50,6 +55,8 @@ function createService() {
         diagnostics as never,
         statusBar as never,
         notifier as never,
+        // The real builder: the c7/c8 cases assert the exact layered config it emits.
+        new DefaultBpmnlintConfigService(),
     );
 
     return {
@@ -107,20 +114,64 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         expect(notifier.logWarning).toHaveBeenCalledWith(expect.stringContaining("custom/x"));
     });
 
-    it("posts null, clears diagnostics, and shows the no-config status when nothing is found", async () => {
-        const { service, editorStore, locator, lintRunner, diagnostics, statusBar, notifier } =
+    it("lints against the bundled default (structural only) for a platform-less file when no config is found", async () => {
+        const { service, editorStore, locator, lintRunner, diagnostics, statusBar } =
             createService();
         locator.findNearestConfig.mockResolvedValue(undefined);
 
         const result = await service.setBpmnlintConfig(EDITOR);
 
         expect(result).toBe(true);
-        expect(lintRunner.lint).not.toHaveBeenCalled();
-        expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
-        expect(statusBar.showBpmnlintNoConfig).toHaveBeenCalledOnce();
-        expect(notifier.logDebug).toHaveBeenCalledWith("No .bpmnlintrc found; linting inactive");
+        expect(lintRunner.lint).toHaveBeenCalledWith(
+            XML,
+            EDITOR,
+            { extends: ["bpmnlint:recommended", "plugin:miragon/recommended"] },
+            true,
+        );
+        expect(diagnostics.publish).toHaveBeenCalledWith(EDITOR, XML, RESULTS);
+        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith(undefined);
+        expect(statusBar.showBpmnlintNoConfig).not.toHaveBeenCalled();
         const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintResultsQuery;
-        expect(msg.results).toBeNull();
+        expect(msg.results).toEqual(RESULTS);
+    });
+
+    it("adds the C7 engine layer to the default when the document targets Camunda 7", async () => {
+        const { service, locator, lintRunner, statusBar, vsDocument } = createService();
+        locator.findNearestConfig.mockResolvedValue(undefined);
+        vsDocument.getContent.mockReturnValue(XML_C7);
+
+        await service.setBpmnlintConfig(EDITOR);
+
+        const [xml, anchor, config, useBundled] = lintRunner.lint.mock.calls[0];
+        expect(xml).toBe(XML_C7);
+        expect(anchor).toBe(EDITOR);
+        expect(useBundled).toBe(true);
+        expect((config as { extends: string[] }).extends).toEqual([
+            "bpmnlint:recommended",
+            "plugin:miragon/recommended",
+            "plugin:camunda-compat/camunda-platform-7-24",
+        ]);
+        expect((config as { moddleExtensions: Record<string, unknown> }).moddleExtensions).toEqual({
+            camunda: expect.anything(),
+        });
+        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith("c7");
+    });
+
+    it("adds the C8 engine layer to the default when the document targets Camunda 8", async () => {
+        const { service, locator, lintRunner, statusBar, vsDocument } = createService();
+        locator.findNearestConfig.mockResolvedValue(undefined);
+        vsDocument.getContent.mockReturnValue(XML_C8);
+
+        await service.setBpmnlintConfig(EDITOR);
+
+        const [, , config] = lintRunner.lint.mock.calls[0];
+        expect((config as { extends: string[] }).extends).toContain(
+            "plugin:camunda-compat/camunda-cloud-8-10",
+        );
+        expect((config as { moddleExtensions: Record<string, unknown> }).moddleExtensions).toEqual({
+            zeebe: expect.anything(),
+        });
+        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith("c8");
     });
 
     it("still posts results but leaves the status bar untouched when reflectInStatusBar is false", async () => {

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
@@ -1,7 +1,9 @@
 import { posix } from "path";
 
-import { BpmnlintResultsQuery, LintResults } from "@miragon/bpmn-modeler-shared";
+import { BpmnlintResultsQuery, Engine, LintResults } from "@miragon/bpmn-modeler-shared";
 
+import { BpmnDocument } from "../../../shared/domain/BpmnDocument";
+import { ExecutionPlatformNotDetectedError } from "../../../shared/domain/errors";
 import {
     DiagnosticsPort,
     DocumentPort,
@@ -14,6 +16,7 @@ import {
     BpmnLintConfigLocator,
     BpmnlintChangeTarget,
 } from "../../../shared/service/BpmnLintConfigLocator";
+import { DefaultBpmnlintConfigService } from "./DefaultBpmnlintConfigService";
 
 /**
  * Discovers the nearest `.bpmnlintrc` for an open BPMN document, runs bpmnlint
@@ -38,6 +41,7 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
         private readonly diagnostics: DiagnosticsPort,
         private readonly statusBar: StatusBarPort,
         private readonly notifier: NotifierPort,
+        private readonly defaultConfig: DefaultBpmnlintConfigService,
     ) {}
 
     /**
@@ -58,8 +62,10 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
     /**
      * Resolves the nearest `.bpmnlintrc`, lints the current document XML against
      * it, then pushes the findings to the webview and publishes them as
-     * diagnostics. A missing config deactivates linting; a read/parse/lint
-     * failure degrades to the no-config state rather than crashing the editor.
+     * diagnostics. When none is found, lints against a bundled default selected
+     * per execution platform instead of staying dormant (#1327). A read/parse/lint
+     * failure — including a malformed `.bpmnlintrc` — degrades to the no-config
+     * state rather than crashing the editor or silently swapping in the default.
      */
     private async lintAndPush(editorId: string, reflectInStatusBar: boolean): Promise<boolean> {
         let results: LintResults | null;
@@ -68,12 +74,7 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
             const configPath = await this.locator.findNearestConfig(dir);
 
             if (!configPath) {
-                if (reflectInStatusBar) {
-                    this.statusBar.showBpmnlintNoConfig();
-                }
-                this.diagnostics.clear(editorId);
-                this.notifier.logDebug("No .bpmnlintrc found; linting inactive");
-                results = null;
+                results = await this.lintWithBundledDefault(editorId, reflectInStatusBar);
             } else {
                 const config = JSON.parse(await this.locator.readConfig(configPath)) as Record<
                     string,
@@ -121,6 +122,62 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
         }
 
         return this.pushResults(editorId, results);
+    }
+
+    /**
+     * Lints against the host-bundled default when the workspace has no
+     * `.bpmnlintrc`. The engine layer is chosen from the document's detected
+     * execution platform (re-detected here so a mid-edit platform change is
+     * reflected); a platform-less document gets the structural base only.
+     */
+    private async lintWithBundledDefault(
+        editorId: string,
+        reflectInStatusBar: boolean,
+    ): Promise<LintResults> {
+        const xml = this.vsDocument.getContent(editorId);
+        const platform = this.detectPlatform(xml);
+        const config = await this.defaultConfig.build(platform);
+
+        // The default references only host-bundled rules, so the path is a mere
+        // resolution anchor — the document's own path keeps it valid.
+        const anchorPath = this.vsDocument.getFilePath(editorId);
+        const { results, unresolved } = await this.lintRunner.lint(xml, anchorPath, config, true);
+
+        this.diagnostics.publish(editorId, xml, results);
+        if (reflectInStatusBar) {
+            this.statusBar.showBpmnlintDefault(platform);
+        }
+        if (unresolved.length > 0) {
+            // The bundled default should resolve entirely from the host; anything
+            // unresolved is a packaging bug, not a workspace one — flag it loudly.
+            this.notifier.logWarning(
+                `bpmnlint default: ${unresolved.length} bundled rule(s)/config(s) unresolved: ${unresolved.join(
+                    ", ",
+                )}`,
+            );
+        }
+        // Debug-level: this fires on every re-lint (each edit), so it belongs with
+        // the other high-frequency lifecycle noise, not the always-on info log.
+        this.notifier.logDebug(
+            `bpmnlint applied bundled default (platform: ${platform ?? "generic"})`,
+        );
+        return results;
+    }
+
+    /**
+     * Detects the execution platform for engine-layer selection, mapping an
+     * undetectable document to `undefined` (the structural-only default) rather
+     * than propagating {@link ExecutionPlatformNotDetectedError}.
+     */
+    private detectPlatform(xml: string): Engine | undefined {
+        try {
+            return new BpmnDocument(xml).detectPlatform();
+        } catch (error) {
+            if (error instanceof ExecutionPlatformNotDetectedError) {
+                return undefined;
+            }
+            throw error;
+        }
     }
 
     /**

--- a/libs/modeler-core/src/modeler/bpmn/service/DefaultBpmnlintConfigService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/DefaultBpmnlintConfigService.ts
@@ -1,0 +1,66 @@
+import { Engine } from "@miragon/bpmn-modeler-shared";
+
+const BASE_EXTENDS = ["bpmnlint:recommended", "plugin:miragon/recommended"];
+
+const C7_ENGINE_LAYER = "plugin:camunda-compat/camunda-platform-7-24";
+const C8_ENGINE_LAYER = "plugin:camunda-compat/camunda-cloud-8-10";
+
+/**
+ * Builds the zero-config **default** bpmnlint config, used when no `.bpmnlintrc`
+ * is found from the document up to the workspace root, so a diagram gets baseline
+ * validation for free (issue #1327). A workspace `.bpmnlintrc` — even `{}` — is
+ * still nearest-config-wins and never reaches here.
+ *
+ * The config is layered, mirroring Camunda's `@camunda/linting`:
+ * - `bpmnlint:recommended` — shared generic BPMN correctness (missing start/end
+ *   event, disconnected element, fake join, …), identical for every engine;
+ * - `plugin:miragon/recommended` — our thin, non-engine opinion layer, wired in but
+ *   currently empty (see {@link bundledDefaultResolver});
+ * - `plugin:camunda-compat/<platform-version>` — the engine deployability matrix,
+ *   added **only when a platform is detected**. A platform-less file (externally
+ *   authored / legacy, no `zeebe:`/`camunda:` markers) gets the structural base
+ *   alone, since we can't know which engine's rules apply.
+ *
+ * All rules and configs resolve from the host-bundled {@link bundledDefaultResolver}
+ * (the workspace has none installed), and the engine layer's moddle descriptor is
+ * embedded directly so a config-less workspace can still parse the typed
+ * `zeebe:`/`camunda:` properties those rules inspect.
+ */
+export class DefaultBpmnlintConfigService {
+    async build(platform: Engine | undefined): Promise<Record<string, unknown>> {
+        switch (platform) {
+            case "c7":
+                return {
+                    extends: [...BASE_EXTENDS, C7_ENGINE_LAYER],
+                    moddleExtensions: { camunda: await this.loadCamundaModdle() },
+                };
+            case "c8":
+                return {
+                    extends: [...BASE_EXTENDS, C8_ENGINE_LAYER],
+                    moddleExtensions: { zeebe: await this.loadZeebeModdle() },
+                };
+            default:
+                return { extends: [...BASE_EXTENDS] };
+        }
+    }
+
+    private loadZeebeModdle(): Promise<unknown> {
+        return this.unwrapDescriptor(import("zeebe-bpmn-moddle/resources/zeebe.json"));
+    }
+
+    private loadCamundaModdle(): Promise<unknown> {
+        return this.unwrapDescriptor(import("camunda-bpmn-moddle/resources/camunda.json"));
+    }
+
+    /**
+     * Normalises a dynamic moddle-descriptor JSON import — the same shape
+     * {@link ScriptXmlService} uses. The `import(...)` literal stays at the call site
+     * so both bundlers (webpack for VS Code, Bun for the bridge) include the JSON;
+     * `resolveJsonModule` is off, so the module is typed by an ambient shim and may
+     * expose the descriptor under `default` or the module itself depending on interop.
+     */
+    private async unwrapDescriptor(imported: Promise<unknown>): Promise<unknown> {
+        const mod = (await imported) as { default?: unknown };
+        return mod.default ?? mod;
+    }
+}

--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -205,6 +205,13 @@ export interface StatusBarPort {
      * never masks silently-dropped rules — `unresolved` lists them for the tooltip.
      */
     showBpmnlintUnresolved(configPath: string, unresolved: string[]): void;
+    /**
+     * State for the zero-config **bundled default** — visually distinct from a
+     * project's own `.bpmnlintrc` ({@link showBpmnlintActive}) so the two are never
+     * confused. `platform` is the detected engine whose deployability layer is
+     * applied, or `undefined` for the structural-only base on a platform-less file.
+     */
+    showBpmnlintDefault(platform: Engine | undefined): void;
     showBpmnlintNoConfig(): void;
     hideBpmnlintStatus(): void;
 }
@@ -223,8 +230,13 @@ export interface LintRunnerPort {
     /**
      * @param xml the diagram XML to lint.
      * @param configPath absolute path of the resolved `.bpmnlintrc`; its
-     *   directory anchors module resolution for custom rules/plugins.
-     * @param config the parsed `.bpmnlintrc` contents.
+     *   directory anchors module resolution for custom rules/plugins. For the
+     *   zero-config default this is the document's own path (a resolution anchor
+     *   only — the default references no workspace modules).
+     * @param config the parsed `.bpmnlintrc` contents, or the bundled default.
+     * @param useBundledDefaults when true, the host's bundled camunda-compat and
+     *   miragon layers back rule/config resolution — for the zero-config default
+     *   only, so a workspace `.bpmnlintrc` never resolves against them.
      * @returns the findings keyed by rule name, plus the names of any
      *   rules/configs that could not be resolved (skipped, never thrown).
      */
@@ -232,6 +244,7 @@ export interface LintRunnerPort {
         xml: string,
         configPath: string,
         config: Record<string, unknown>,
+        useBundledDefaults?: boolean,
     ): Promise<{ results: LintResults; unresolved: string[] }>;
 }
 

--- a/libs/modeler-core/src/types/bpmnlint-plugin-camunda-compat.d.ts
+++ b/libs/modeler-core/src/types/bpmnlint-plugin-camunda-compat.d.ts
@@ -1,0 +1,22 @@
+/**
+ * `bpmnlint-plugin-camunda-compat` ships no type declarations. The bundled default
+ * lint config imports its `configs` (per-platform rule sets) plus every rule module
+ * by path — see the generated `bundledDefaultResolver.ts`. Both are opaque: they
+ * pass straight through to bpmnlint's `StaticResolver`/`Linter`, so `unknown` is the
+ * honest type.
+ *
+ * Ambient shim (no top-level `import`/`export`) so `declare module` types the
+ * existing untyped JS module; each consuming tsconfig picks it up via `include`.
+ */
+declare module "bpmnlint-plugin-camunda-compat" {
+    const plugin: {
+        configs: Record<string, unknown>;
+        rules: Record<string, unknown>;
+    };
+    export default plugin;
+}
+
+declare module "bpmnlint-plugin-camunda-compat/rules/*" {
+    const rule: unknown;
+    export default rule;
+}

--- a/libs/modeler-core/src/types/zeebe-bpmn-moddle.d.ts
+++ b/libs/modeler-core/src/types/zeebe-bpmn-moddle.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Ambient declaration for the Zeebe (Camunda 8) moddle descriptor JSON.
+ *
+ * `resolveJsonModule` is off in `tsconfig.base.json`, so a bare import of the
+ * `.json` would not typecheck. The bundled default lint config feeds this
+ * descriptor to bpmn-moddle so a host-side parse sees the typed `zeebe:` extension
+ * elements the camunda-compat C8 rules inspect. The shape is opaque to us —
+ * bpmn-moddle consumes it — so a single `unknown` export suffices.
+ */
+declare module "zeebe-bpmn-moddle/resources/zeebe.json" {
+    const descriptors: unknown;
+    export default descriptors;
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "build:demo": "npm-run-all -s build:demo:bpmn-webview build:demo:dmn-webview",
         "build:demo:bpmn-webview": "corepack yarn workspace @miragon/bpmn-modeler-demo-webapp build:bpmn",
         "build:demo:dmn-webview": "corepack yarn workspace @miragon/bpmn-modeler-demo-webapp build:dmn",
-        "preview:demo": "node scripts/serve-demo.mjs",
+        "preview:demo": "corepack yarn workspace @miragon/bpmn-modeler-demo-webapp preview",
         "demo": "portless",
         "demo:app": "npm-run-all -s build:demo preview:demo",
         "build:bridge": "corepack yarn workspace @miragon/bpmn-modeler-bridge build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1746,6 +1746,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bpmn-io/feel-analyzer@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@bpmn-io/feel-analyzer@npm:0.3.0"
+  dependencies:
+    "@bpmn-io/lezer-feel": "npm:^2.1.0"
+  checksum: 10c0/9eec8317150c02d474d3aeff52769f90419d3eca472cc3039bb026ea1353aceeb6ae879c8c4d255071e34e0e4165faf8f47c23da337231b721560f1981275858
+  languageName: node
+  linkType: hard
+
 "@bpmn-io/feel-editor@npm:^2.5.2":
   version: 2.5.2
   resolution: "@bpmn-io/feel-editor@npm:2.5.2"
@@ -1868,6 +1877,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bpmn-io/lezer-feel@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "@bpmn-io/lezer-feel@npm:2.5.0"
+  dependencies:
+    "@lezer/highlight": "npm:^1.2.3"
+    "@lezer/lr": "npm:^1.4.10"
+    min-dash: "npm:^5.0.0"
+  checksum: 10c0/83a40f159be35924845355a04b57c30908865b3226733c70e41f08415946d52ef77c510fff7b5635028d6ceded31fd96a62249f74c6a2993cfac561c57685d3d
+  languageName: node
+  linkType: hard
+
 "@bpmn-io/lezer-feel@npm:^3.0.0":
   version: 3.0.1
   resolution: "@bpmn-io/lezer-feel@npm:3.0.1"
@@ -1939,6 +1959,15 @@ __metadata:
     min-dash: "npm:^5.0.0"
     min-dom: "npm:^5.3.0"
   checksum: 10c0/2220aeb35eba4d35bf318bdc5931a6bfd413518b7d0b6c02ba86ca53d1c54395538e30aae2c218f90dffccf17b9dec0fbddf23049ea7eb95e712d64f4c13f338
+  languageName: node
+  linkType: hard
+
+"@bpmn-io/semver-compat@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@bpmn-io/semver-compat@npm:0.1.0"
+  dependencies:
+    semver: "npm:^7.7.2"
+  checksum: 10c0/de2b07340032903b0a768ed5570b6c98cd9bb6d9b37cd07c8b6a306cb718057c2168cb1a15e5824bfed5dbd0948dca74e88b3bf2a9955b0aaecb3bf4af7ea45c
   languageName: node
   linkType: hard
 
@@ -2018,6 +2047,13 @@ __metadata:
   version: 1.0.0
   resolution: "@camunda/feel-builtins@npm:1.0.0"
   checksum: 10c0/6690b135ebd2560bc8d3282b75877f5d6fe40b8f8a6efaed4e4d32c3dcee8e8f2005c7e28ec63fbb8bbb17fb4002bac42ff65e9825f740021aa4568d1c06113a
+  languageName: node
+  linkType: hard
+
+"@camunda/feel-builtins@npm:^1.2.0":
+  version: 1.4.0
+  resolution: "@camunda/feel-builtins@npm:1.4.0"
+  checksum: 10c0/ba9807eb98c12e14e4fc1a4403e4b01e2fd539ef5501d7e18963f806bc47b16157f8ec37b3eea9d46cd43e909972719416e9662e75b2ca1f24a0ba95ccf9f6db
   languageName: node
   linkType: hard
 
@@ -3603,10 +3639,12 @@ __metadata:
     bpmn-js-differ: "npm:3.2.0"
     bpmn-moddle: "npm:10.0.0"
     bpmnlint: "npm:11.12.1"
+    bpmnlint-plugin-camunda-compat: "npm:2.59.2"
     camunda-bpmn-moddle: "npm:7.0.1"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.3"
     vitest: "npm:4.1.9"
+    zeebe-bpmn-moddle: "npm:1.15.0"
   languageName: unknown
   linkType: soft
 
@@ -9229,6 +9267,24 @@ __metadata:
     vitest: "npm:4.1.9"
   languageName: unknown
   linkType: soft
+
+"bpmnlint-plugin-camunda-compat@npm:2.59.2":
+  version: 2.59.2
+  resolution: "bpmnlint-plugin-camunda-compat@npm:2.59.2"
+  dependencies:
+    "@bpmn-io/feel-analyzer": "npm:^0.3.0"
+    "@bpmn-io/lezer-feel": "npm:^2.5.0"
+    "@bpmn-io/moddle-utils": "npm:^0.3.0"
+    "@bpmn-io/semver-compat": "npm:^0.1.0"
+    "@camunda/feel-builtins": "npm:^1.2.0"
+    bpmnlint-utils: "npm:^1.1.1"
+    min-dash: "npm:^5.0.0"
+    semver-compare: "npm:^1.0.0"
+  peerDependencies:
+    bpmnlint: ">= 11.6.0"
+  checksum: 10c0/db237830ac8bc96d4042d7da96a17f3331b879ca9e552b382dc53bc4590e4b1ba8061434065886fc264242a78439740818e5f3d67d5954167da202fbd7785967
+  languageName: node
+  linkType: hard
 
 "bpmnlint-utils@npm:^1.1.1":
   version: 1.1.1
@@ -19803,7 +19859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.8.1":
+"semver@npm:^7.7.2, semver@npm:^7.8.1":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:


### PR DESCRIPTION
**Issue**

Closes #1327 (builds on #1320 / #1321).

**Description**

Lint every BPMN diagram out of the box — even with **no `.bpmnlintrc`** — against a bundled default, instead of staying dormant. The default is selected per **detected execution platform** (re-evaluated per lint run) and any `.bpmnlintrc` the workspace adds still fully wins (nearest-config-wins; a malformed one still degrades loudly, never silently swaps to the default).

Layered, mirroring Camunda's `@camunda/linting`:
- `bpmnlint:recommended` — shared generic BPMN correctness (start/end event, disconnected, fake join, …).
- `plugin:miragon/recommended` — thin, non-engine Miragon layer. Wired into the default but **currently empty** (first rule — uniform element sizes — lands upstream in bpmnlint, tracked in #1333).
- `plugin:camunda-compat/<platform>` — engine deployability, **reusing `bpmnlint-plugin-camunda-compat`** (C7 → `camunda-platform-7-24`, C8 → `camunda-cloud-8-10`) rather than rebuilding the matrix. Only added when a platform is detected; a platform-less file gets the structural base only.

Implementation notes:
- Rules/configs resolve from a host-bundled `StaticResolver` (webpack for VS Code, Bun for the IntelliJ bridge) — no workspace `bpmnlint` install needed. A spec asserts every rule the two pinned configs reference is bundled, so a plugin bump fails the build until updated.
- The engine layer's `zeebe`/`camunda` moddle is embedded so config-less workspaces still parse the typed properties those rules inspect.
- Status bar distinguishes the bundled default (`$(shield) BPMNlint (default)`) from a project's own config (`$(check) BPMNlint`); IntelliJ bridge stubs it (bridge status bar not wired yet, but default linting still flows to overlays).
- Also moved `serve-demo.mjs` out of the root `scripts/` folder into `apps/demo-webapp/`.

**Checklist**

* [x] Code is easy to understand
* [x] No obvious errors or bugs
* [x] CI/CD Pipelines did run successfully
* [x] Tests were implemented
* [x] Documentation was created
