### PR TITLE
feat(bpmn): enable uniform standard-size lint rule in the miragon layer

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,6 +10,7 @@ nodeLinker: node-modules
 npmPreapprovedPackages:
   - "@emaarco/dmn-js-simulation"
   - "@miragon/create-append-c7"
+  - "bpmnlint"
 
 npmScopes:
   miragon:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,7 +10,6 @@ nodeLinker: node-modules
 npmPreapprovedPackages:
   - "@emaarco/dmn-js-simulation"
   - "@miragon/create-append-c7"
-  - "bpmnlint"
 
 npmScopes:
   miragon:

--- a/apps/bpmn-webview/package.json
+++ b/apps/bpmn-webview/package.json
@@ -30,7 +30,7 @@
         "bpmn-js-properties-panel": "5.60.0",
         "bpmn-js-token-simulation": "0.39.4",
         "bpmn-moddle": "10.0.0",
-        "bpmnlint": "11.12.1",
+        "bpmnlint": "11.13.0",
         "camunda-bpmn-js": "5.28.0",
         "camunda-bpmn-js-behaviors": "1.17.0",
         "camunda-bpmn-moddle": "7.0.1",

--- a/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
+++ b/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
@@ -31,7 +31,24 @@ const BPMN_XML = `<?xml version="1.0" encoding="UTF-8"?>
   </bpmn:process>
 </bpmn:definitions>`;
 
-function registerParams(editorId: string, root: string, fsPath: string) {
+// Same process, now with DI whose task shape is far from the modeler default
+// (100×80) — so the miragon layer's `standard-size` rule fires. Missing DI is
+// valid for that rule, hence the explicit shape here.
+const BPMN_XML_OVERSIZED = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="Task_1" name="Do the thing" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="80" width="200" height="200" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+function registerParams(editorId: string, root: string, fsPath: string, content = BPMN_XML) {
     return {
         editorId,
         uriString: editorId,
@@ -39,7 +56,7 @@ function registerParams(editorId: string, root: string, fsPath: string) {
         fsPath,
         scheme: "file",
         workspaceRoot: root,
-        content: BPMN_XML,
+        content,
     };
 }
 
@@ -69,10 +86,12 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
         }
     });
 
-    async function setup(): Promise<{ rpc: Rpc; frames: any[]; root: string; editorId: string }> {
+    async function setup(
+        content = BPMN_XML,
+    ): Promise<{ rpc: Rpc; frames: any[]; root: string; editorId: string }> {
         const root = await fs.mkdtemp(join(tmpdir(), "modeler-bridge-lint-"));
         const sourcePath = join(root, "source.bpmn");
-        await fs.writeFile(sourcePath, BPMN_XML, "utf8");
+        await fs.writeFile(sourcePath, content, "utf8");
 
         const frames: any[] = [];
         const { rpc } = createBridge((line) => frames.push(JSON.parse(line)));
@@ -81,7 +100,7 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
         await rpc.handleLine(
             JSON.stringify({
                 method: "session/register",
-                params: registerParams(editorId, root, sourcePath),
+                params: registerParams(editorId, root, sourcePath, content),
             }),
         );
 
@@ -124,5 +143,16 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
         const results = frame.params.message.results;
         expect(results).not.toBeNull();
         expect(Object.keys(results)).toContain("start-event-required");
+    });
+
+    it("enforces the miragon standard-size layer through the bundled default", async () => {
+        const { rpc, frames, editorId } = await setup(BPMN_XML_OVERSIZED);
+
+        await requestConfig(rpc, editorId);
+
+        const frame = await waitForFrame(frames, isLintResultsFrame);
+        const results = frame.params.message.results;
+        expect(results).not.toBeNull();
+        expect(Object.keys(results)).toContain("standard-size");
     });
 });

--- a/libs/modeler-core/package.json
+++ b/libs/modeler-core/package.json
@@ -11,7 +11,7 @@
     "@miragon/bpmn-modeler-shared": "workspace:*",
     "bpmn-js-differ": "3.2.0",
     "bpmn-moddle": "10.0.0",
-    "bpmnlint": "11.12.1",
+    "bpmnlint": "11.13.0",
     "bpmnlint-plugin-camunda-compat": "2.59.2",
     "camunda-bpmn-moddle": "7.0.1",
     "tslib": "2.8.1",

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/builtinResolver.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/builtinResolver.ts
@@ -42,6 +42,7 @@ import noInclusiveGateway from "bpmnlint/rules/no-inclusive-gateway";
 import noOverlappingElements from "bpmnlint/rules/no-overlapping-elements";
 import singleBlankStartEvent from "bpmnlint/rules/single-blank-start-event";
 import singleEventDefinition from "bpmnlint/rules/single-event-definition";
+import standardSize from "bpmnlint/rules/standard-size";
 import startEventRequired from "bpmnlint/rules/start-event-required";
 import subProcessBlankStartEvent from "bpmnlint/rules/sub-process-blank-start-event";
 import superfluousGateway from "bpmnlint/rules/superfluous-gateway";
@@ -73,6 +74,7 @@ const cache: Record<string, unknown> = {
     "rule:bpmnlint/no-overlapping-elements": noOverlappingElements,
     "rule:bpmnlint/single-blank-start-event": singleBlankStartEvent,
     "rule:bpmnlint/single-event-definition": singleEventDefinition,
+    "rule:bpmnlint/standard-size": standardSize,
     "rule:bpmnlint/start-event-required": startEventRequired,
     "rule:bpmnlint/sub-process-blank-start-event": subProcessBlankStartEvent,
     "rule:bpmnlint/superfluous-gateway": superfluousGateway,

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/bundledDefaultResolver.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/bundledDefaultResolver.spec.ts
@@ -22,11 +22,11 @@ describe("bundledDefaultResolver", () => {
         expect(bundledDefaultResolver.resolveRule(COMPAT, "implementation")).toBeTruthy();
     });
 
-    it("resolves the miragon layer, which is wired in but currently empty", () => {
+    it("resolves the miragon layer, which enables the standard-size convention", () => {
         const config = bundledDefaultResolver.resolveConfig(MIRAGON, "recommended") as {
             rules: Record<string, unknown>;
         };
-        expect(config.rules).toEqual({});
+        expect(config.rules).toEqual({ "bpmnlint/standard-size": "warn" });
     });
 
     it("bundles every camunda-compat rule the pinned configs reference (guards plugin bumps)", () => {

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/miragonConfig.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/miragonConfig.ts
@@ -1,15 +1,9 @@
 /**
  * The Miragon opinion layer of the bundled default (`plugin:miragon/recommended`) —
  * the place for genuine, non-engine Miragon conventions.
- *
- * Intentionally empty for now. It stays wired into the default (so adding a rule
- * later is a one-line change here) but ships no rule yet: our first planned
- * convention — uniform, modeler-default element sizes — is landing in bpmnlint
- * itself (https://github.com/bpmn-io/bpmnlint/pull/214) and will reach us via
- * `miragon-rules`, so shipping a throwaway copy now is not worth it.
- *
- * Tracked in https://github.com/Miragon/bpmn-modeler/issues/1333.
  */
 export const miragonRecommended = {
-    rules: {},
+    rules: {
+        "bpmnlint/standard-size": "warn",
+    },
 };

--- a/resources/example-process/package.json
+++ b/resources/example-process/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "description": "Example workspace demonstrating custom bpmnlint rules in the BPMN Modeler. Run `npm install` here (or add the plugin to your own node_modules) so the modeler can resolve `bpmnlint-plugin-custom-rules`.",
     "devDependencies": {
-        "bpmnlint": "11.12.1",
+        "bpmnlint": "11.13.0",
         "bpmnlint-plugin-custom-rules": "file:./bpmnlint-custom-rules"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3638,7 +3638,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:4.1.9"
     bpmn-js-differ: "npm:3.2.0"
     bpmn-moddle: "npm:10.0.0"
-    bpmnlint: "npm:11.12.1"
+    bpmnlint: "npm:11.13.0"
     bpmnlint-plugin-camunda-compat: "npm:2.59.2"
     camunda-bpmn-moddle: "npm:7.0.1"
     tslib: "npm:2.8.1"
@@ -3803,7 +3803,7 @@ __metadata:
     bpmn-js-properties-panel: "npm:5.60.0"
     bpmn-js-token-simulation: "npm:0.39.4"
     bpmn-moddle: "npm:10.0.0"
-    bpmnlint: "npm:11.12.1"
+    bpmnlint: "npm:11.13.0"
     camunda-bpmn-js: "npm:5.28.0"
     camunda-bpmn-js-behaviors: "npm:1.17.0"
     camunda-bpmn-moddle: "npm:7.0.1"
@@ -9245,6 +9245,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bpmn-moddle@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "bpmn-moddle@npm:10.1.0"
+  dependencies:
+    min-dash: "npm:^5.1.0"
+    moddle: "npm:^8.2.1"
+    moddle-xml: "npm:^12.1.0"
+  checksum: 10c0/1114c9cf64aebd7afa297e19f176fa4dd3e790682a294debaaba493914a75df36ee37c7b1f077ed64910adc38c9af26d5577d89d3b916d3ae92f70584bc91a8c
+  languageName: node
+  linkType: hard
+
 "bpmn-modeler@workspace:.":
   version: 0.0.0-use.local
   resolution: "bpmn-modeler@workspace:."
@@ -9293,23 +9304,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bpmnlint@npm:11.12.1":
-  version: 11.12.1
-  resolution: "bpmnlint@npm:11.12.1"
+"bpmnlint@npm:11.13.0":
+  version: 11.13.0
+  resolution: "bpmnlint@npm:11.13.0"
   dependencies:
     "@bpmn-io/moddle-utils": "npm:^0.3.0"
     ansi-colors: "npm:^4.1.3"
-    bpmn-moddle: "npm:^10.0.0"
+    bpmn-moddle: "npm:^10.1.0"
     bpmnlint-utils: "npm:^1.1.1"
     cli-table: "npm:^0.3.11"
     color-support: "npm:^1.1.3"
-    min-dash: "npm:^5.0.0"
+    min-dash: "npm:^5.1.0"
     mri: "npm:^1.2.0"
     pluralize: "npm:^8.0.0"
     tiny-glob: "npm:^0.2.9"
   bin:
     bpmnlint: bin/bpmnlint.js
-  checksum: 10c0/e08307b589308b63a3c1dfbaf6241d8d7cda8d4cf72facbdb2ca1207707f2a176979809860603875c4d0c53a22186264426fd3650a8e275837f696aa665233f3
+  checksum: 10c0/4a31fff2ffdeab25bba8620ea93fc9b08278aefab3e5ae226bfdeb2086b22bd3907815fbdab38c40f25dae47f94f8fac73be8281bfd75198dac45eb45f8d63ab
   languageName: node
   linkType: hard
 
@@ -16497,6 +16508,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"min-dash@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "min-dash@npm:5.1.0"
+  checksum: 10c0/44d977d9a8dc45526e3b1badc903adb9d511937d7c895643d252947a7c6371970b89ac48f205a7207eed2f1426d6e538a1d95511d9e815ea48d23d35ef7c0ba5
+  languageName: node
+  linkType: hard
+
 "min-dom@npm:^5.2.0, min-dom@npm:^5.3.0":
   version: 5.3.0
   resolution: "min-dom@npm:5.3.0"
@@ -16856,12 +16874,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"moddle-xml@npm:^12.1.0":
+  version: 12.1.0
+  resolution: "moddle-xml@npm:12.1.0"
+  dependencies:
+    min-dash: "npm:^5.1.0"
+    saxen: "npm:^11.1.0"
+  peerDependencies:
+    moddle: ">= 6.2.0"
+  checksum: 10c0/2686cac13dfa4fbc017e3923c445cc9bcf3290e84995da71dd7c7286b146c5acb48872d7e8a14dc90791d34553cb30f235489d080fb42e74f131e711bf90ddf1
+  languageName: node
+  linkType: hard
+
 "moddle@npm:^8.0.0":
   version: 8.1.0
   resolution: "moddle@npm:8.1.0"
   dependencies:
     min-dash: "npm:^5.0.0"
   checksum: 10c0/6d9b7db4263973ee7f8c1113de3d7f6ed0d55d40154d8b19f2a64579d46abc2d64a710ad6196dfbd351627cd39422f282252992b4b6a1aa5e3d9025ba6d6ba1b
+  languageName: node
+  linkType: hard
+
+"moddle@npm:^8.2.1":
+  version: 8.2.1
+  resolution: "moddle@npm:8.2.1"
+  dependencies:
+    min-dash: "npm:^5.1.0"
+  checksum: 10c0/f68a99b86d328c78d45f2ee60ef4e893c1c9b75c2a1f7b4fa14b6f8f669f7cdaf16060ee71d4e341c50fc29d918cbb711ec57aeef54c4a4d89c73d0f32986cf3
   languageName: node
   linkType: hard
 
@@ -19690,6 +19729,13 @@ __metadata:
   version: 11.0.2
   resolution: "saxen@npm:11.0.2"
   checksum: 10c0/9ca99fb956e57aef2fcf5fe3376343e4ff8bb991475c7320fe741a3b41b24ce077e6a0923be7bae0953ac70ba918f7f87c5d8877dd363506ca8a828a2ca3a0c1
+  languageName: node
+  linkType: hard
+
+"saxen@npm:^11.1.0":
+  version: 11.1.1
+  resolution: "saxen@npm:11.1.1"
+  checksum: 10c0/9bddeec5fe665ac20faaccaddeb7591b1e402c73a919268d4d41fa629a4fb90aabcdda04c66bc3a5fb76147645d04af4897b15bec5b24ad7bb52fc76a1997a0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Issue**

Closes #1333

**Description**

Enables the first Miragon lint convention now that the check has landed upstream: bpmnlint 11.13.0 ships the opt-in core `standard-size` rule ([bpmn-io/bpmnlint#214](https://github.com/bpmn-io/bpmnlint/pull/214)). This bumps the pinned bpmnlint to 11.13.0, registers the rule in `builtinResolver`, and enables it as `warn` in the `plugin:miragon/recommended` layer so shapes keep the modeler's default sizes and diagrams edited by hand or by an agent stay visually uniform. Resolver and bridge end-to-end specs were updated to cover the new rule.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
