### PR TITLE
fix(bpmn-webview): render diagrams when the canvas mounts at zero size

### DIFF
--- a/apps/bpmn-webview/src/app/diff/DiffViewer.ts
+++ b/apps/bpmn-webview/src/app/diff/DiffViewer.ts
@@ -1,7 +1,12 @@
 import NavigatedViewer from "bpmn-js/lib/NavigatedViewer";
 import { ImportXMLResult } from "bpmn-js/lib/BaseViewer";
 
-import { Viewport } from "@miragon/bpmn-modeler-shared";
+import {
+    MIN_CANVAS_SIZE_PX,
+    Viewport,
+    isUsableViewbox,
+    observeCanvasSize,
+} from "@miragon/bpmn-modeler-shared";
 
 /**
  * CSS class applied to each element category on the canvas.
@@ -45,14 +50,41 @@ export class DiffViewer {
      */
     private selectedId: string | undefined;
 
+    /** Disposes the canvas-size observer installed by {@link importXML}. */
+    private stopObservingSize: (() => void) | undefined;
+
     constructor(container: string) {
         this.viewer = new NavigatedViewer({ container });
     }
 
     async importXML(xml: string): Promise<ImportXMLResult> {
         const result = await this.viewer.importXML(xml);
-        this.getCanvas().zoom("fit-viewport", "auto");
+
+        // Panes open side by side, so one regularly has no box yet when the
+        // import lands; the fit retries until it does.
+        this.stopObservingSize?.();
+        const canvas = this.getCanvas();
+        this.stopObservingSize = observeCanvasSize(canvas, canvas.getContainer(), {
+            applyInitialViewport: () => this.fitViewport(),
+        });
+        this.fitViewport();
+
         return result;
+    }
+
+    /**
+     * Fits the diagram into the pane.
+     *
+     * @returns `false` if the pane has no usable box yet.
+     */
+    private fitViewport(): boolean {
+        const canvas = this.getCanvas();
+        const { outer } = canvas.viewbox();
+        if (outer.width < MIN_CANVAS_SIZE_PX || outer.height < MIN_CANVAS_SIZE_PX) {
+            return false;
+        }
+        canvas.zoom("fit-viewport", "auto");
+        return true;
     }
 
     /**
@@ -97,6 +129,9 @@ export class DiffViewer {
     }
 
     setViewport(viewport: Viewport): void {
+        if (!isUsableViewbox(viewport)) {
+            return;
+        }
         this.suppressNextChangeEvent = true;
         this.getCanvas().viewbox({ ...viewport });
     }
@@ -114,8 +149,12 @@ export class DiffViewer {
                 return;
             }
             const { x, y, width, height } = event.viewbox;
+            const viewport = { x, y, width, height };
+            if (!isUsableViewbox(viewport)) {
+                return;
+            }
             clearTimeout(debounceTimer);
-            debounceTimer = setTimeout(() => cb({ x, y, width, height }), 80);
+            debounceTimer = setTimeout(() => cb(viewport), 80);
         });
     }
 

--- a/apps/bpmn-webview/src/app/state.spec.ts
+++ b/apps/bpmn-webview/src/app/state.spec.ts
@@ -7,10 +7,10 @@ import { WebviewStateManager } from "./state";
  * `restoreViewport` touches: `host.getState` (the saved-state source that
  * discriminates fresh open from tab-switch rebuild) and the viewport methods.
  */
-function setup(savedState: unknown) {
+function setup(savedState: unknown, applied = true) {
     const getState = vi.fn().mockReturnValue(savedState);
-    const setViewport = vi.fn();
-    const fitViewport = vi.fn();
+    const setViewport = vi.fn().mockReturnValue(applied);
+    const fitViewport = vi.fn().mockReturnValue(applied);
     const host = { getState } as any;
     const modeler = { viewport: { setViewport, fitViewport } } as any;
     return {
@@ -47,5 +47,24 @@ describe("WebviewStateManager.restoreViewport", () => {
 
         expect(fitViewport).toHaveBeenCalledOnce();
         expect(setViewport).not.toHaveBeenCalled();
+    });
+
+    it("applies the viewbox only once across repeated calls", () => {
+        const { manager, fitViewport } = setup(undefined);
+
+        expect(manager.restoreViewport()).toBe(true);
+        expect(manager.restoreViewport()).toBe(true);
+
+        // Re-fitting on every later resize would discard the user's own zoom.
+        expect(fitViewport).toHaveBeenCalledOnce();
+    });
+
+    it("keeps retrying while the canvas is still unsized", () => {
+        const { manager, fitViewport } = setup(undefined, false);
+
+        expect(manager.restoreViewport()).toBe(false);
+        expect(manager.restoreViewport()).toBe(false);
+
+        expect(fitViewport).toHaveBeenCalledTimes(2);
     });
 });

--- a/apps/bpmn-webview/src/app/state.ts
+++ b/apps/bpmn-webview/src/app/state.ts
@@ -28,6 +28,9 @@ function isGroupOpen(group: HTMLElement): boolean {
  * 4. {@link startPersisting}       — subscribes to change events
  */
 export class WebviewStateManager {
+    /** Latches once {@link restoreViewport} has applied a viewbox. */
+    private viewportRestored = false;
+
     constructor(
         private readonly host: HostApi<WebviewState, Command | Query>,
         private readonly modeler: BpmnModeler,
@@ -41,14 +44,24 @@ export class WebviewStateManager {
      * absence of a saved viewport discriminates a genuine fresh open, where we
      * fit the diagram — bpmn-js leaves the canvas at the origin on importXML,
      * which renders a diagram moved far from the origin off-screen (#1149).
+     *
+     * Safe to call repeatedly: nothing happens until the host has laid the
+     * canvas out, and then it applies exactly once — re-fitting on every later
+     * resize would discard the zoom the user chose.
+     *
+     * @returns `true` once a viewbox has been applied, `false` while the
+     *   caller should keep retrying.
      */
-    restoreViewport(): void {
-        const saved = this.getSavedState();
-        if (saved?.viewport) {
-            this.modeler.viewport.setViewport(saved.viewport);
-        } else {
-            this.modeler.viewport.fitViewport();
+    restoreViewport(): boolean {
+        if (this.viewportRestored) {
+            return true;
         }
+
+        const saved = this.getSavedState();
+        this.viewportRestored = saved?.viewport
+            ? this.modeler.viewport.setViewport(saved.viewport)
+            : this.modeler.viewport.fitViewport();
+        return this.viewportRestored;
     }
 
     /**

--- a/apps/bpmn-webview/src/app/viewport.spec.ts
+++ b/apps/bpmn-webview/src/app/viewport.spec.ts
@@ -11,14 +11,29 @@ function setup(inner: Rect, outer: { width: number; height: number }) {
     const viewbox = vi.fn((box?: unknown) => (box ? undefined : { inner, outer }));
     const zoom = vi.fn();
     const canvas = { viewbox, zoom };
+    const listeners: Record<string, (event: any) => void> = {};
+    const eventBus = {
+        on: (event: string, handler: (event: any) => void) => {
+            listeners[event] = handler;
+        },
+    };
     const manager = new ViewportManager((name: string) => {
         if (name === "canvas") return canvas as any;
+        if (name === "eventBus") return eventBus as any;
         throw new Error(`unexpected service: ${name}`);
     });
-    return { manager, viewbox, zoom };
+    /** Fires a `canvas.viewbox.changed` event at the manager's subscriber. */
+    const emitViewboxChanged = (box: Partial<Rect>) =>
+        listeners["canvas.viewbox.changed"]({ viewbox: box });
+    return { manager, viewbox, zoom, emitViewboxChanged };
 }
 
 type Rect = { x: number; y: number; width: number; height: number };
+
+/** Calls that *set* a viewbox, i.e. that passed a box to the accessor. */
+function setterCalls(viewbox: ReturnType<typeof vi.fn>): unknown[] {
+    return viewbox.mock.calls.filter((call) => call.length > 0 && call[0] !== undefined);
+}
 
 /** Screen position of a diagram point under the viewbox the setter received. */
 function project(point: number, boxOrigin: number, scale: number): number {
@@ -36,11 +51,26 @@ describe("ViewportManager.fitViewport", () => {
             { width: 1000, height: 800 },
         );
 
-        manager.fitViewport();
+        expect(manager.fitViewport()).toBe(true);
 
         expect(zoom).toHaveBeenCalledWith("fit-viewport");
         // No manual viewbox is set in the degenerate case.
-        expect(viewbox).toHaveBeenCalledTimes(1);
+        expect(setterCalls(viewbox)).toHaveLength(0);
+    });
+
+    // Fitting against an unlaid-out container is what produced the NaN
+    // transform that renders nothing.
+    it.each([
+        ["not laid out at all", { width: 0, height: 0 }],
+        ["laid out at the IntelliJ pre-warm size", { width: 1, height: 1 }],
+        ["too short to fit into", { width: 1200, height: 8 }],
+    ])("applies nothing when the canvas is %s", (_case, outer) => {
+        const { manager, zoom, viewbox } = setup({ x: 150, y: 80, width: 600, height: 300 }, outer);
+
+        expect(manager.fitViewport()).toBe(false);
+
+        expect(zoom).not.toHaveBeenCalled();
+        expect(setterCalls(viewbox)).toHaveLength(0);
     });
 
     it("clears the palette and never zooms in past 1.0", () => {
@@ -62,6 +92,26 @@ describe("ViewportManager.fitViewport", () => {
         expect(topPx).toBeGreaterThanOrEqual(40);
     });
 
+    // An unstyled palette is a full-width block; reserving it collapsed the
+    // fit to an invisible diagram on a perfectly sized canvas.
+    it("ignores an unstyled, full-width palette", () => {
+        const palette = document.createElement("div");
+        palette.className = "djs-palette";
+        document.body.appendChild(palette);
+        vi.spyOn(palette, "getBoundingClientRect").mockReturnValue({ width: 1000 } as DOMRect);
+
+        const inner = { x: 0, y: 0, width: 1176, height: 537 };
+        const { manager, viewbox } = setup(inner, { width: 1000, height: 800 });
+
+        manager.fitViewport();
+
+        const box = viewbox.mock.calls.at(-1)?.[0] as Rect;
+        const scale = 1000 / box.width;
+        // At least half the canvas stays available, so the diagram is visible.
+        expect(inner.width * scale).toBeGreaterThan(400);
+        palette.remove();
+    });
+
     it("zooms out a diagram larger than the inset area to fit", () => {
         const inner = { x: 0, y: 0, width: 4000, height: 3000 };
         const { manager, viewbox } = setup(inner, { width: 1000, height: 800 });
@@ -74,5 +124,77 @@ describe("ViewportManager.fitViewport", () => {
         // The whole diagram width fits within the inset-reduced viewport.
         const rightPx = project(inner.x + inner.width, box.x, scale);
         expect(rightPx).toBeLessThanOrEqual(1000);
+    });
+});
+
+describe("ViewportManager.setViewport", () => {
+    const inner = { x: 150, y: 80, width: 600, height: 300 };
+
+    it("applies a usable saved viewbox verbatim", () => {
+        const { manager, viewbox } = setup(inner, { width: 1000, height: 800 });
+        const saved = { x: 10, y: 20, width: 500, height: 400 };
+
+        expect(manager.setViewport(saved)).toBe(true);
+
+        expect(setterCalls(viewbox)).toEqual([[saved]]);
+    });
+
+    // `JSON.stringify` writes NaN out as null, so this is the shape a viewbox
+    // saved during a failed restore comes back in.
+    it.each([
+        [
+            "null members from a poisoned persisted state",
+            { x: null, y: null, width: null, height: null },
+        ],
+        ["NaN members", { x: NaN, y: NaN, width: NaN, height: NaN }],
+        ["zero area", { x: 0, y: 0, width: 0, height: 0 }],
+    ])("falls back to a fit for a saved viewbox with %s", (_case, saved) => {
+        const { manager, viewbox } = setup(inner, { width: 1000, height: 800 });
+
+        expect(manager.setViewport(saved as any)).toBe(true);
+
+        // The fit ran instead: the applied box is computed, not the saved one.
+        const applied = setterCalls(viewbox).at(-1) as [Rect];
+        expect(applied[0]).not.toEqual(saved);
+        expect(applied[0].width).toBeGreaterThan(0);
+    });
+
+    it("applies nothing while the canvas is unsized", () => {
+        const { manager, viewbox } = setup(inner, { width: 0, height: 0 });
+
+        expect(manager.setViewport({ x: 10, y: 20, width: 500, height: 400 })).toBe(false);
+
+        expect(setterCalls(viewbox)).toHaveLength(0);
+    });
+});
+
+describe("ViewportManager.onViewportChanged", () => {
+    const inner = { x: 150, y: 80, width: 600, height: 300 };
+
+    it("reports a usable viewbox after the debounce", () => {
+        vi.useFakeTimers();
+        const { manager, emitViewboxChanged } = setup(inner, { width: 1000, height: 800 });
+        const cb = vi.fn();
+        manager.onViewportChanged(cb);
+
+        emitViewboxChanged({ x: 1, y: 2, width: 300, height: 200 });
+        vi.advanceTimersByTime(100);
+
+        expect(cb).toHaveBeenCalledWith({ x: 1, y: 2, width: 300, height: 200 });
+        vi.useRealTimers();
+    });
+
+    // Persisting a NaN viewbox is what makes the blank canvas survive a reopen.
+    it("never reports a degenerate viewbox", () => {
+        vi.useFakeTimers();
+        const { manager, emitViewboxChanged } = setup(inner, { width: 0, height: 0 });
+        const cb = vi.fn();
+        manager.onViewportChanged(cb);
+
+        emitViewboxChanged({ x: 0, y: 0, width: NaN, height: NaN });
+        vi.advanceTimersByTime(100);
+
+        expect(cb).not.toHaveBeenCalled();
+        vi.useRealTimers();
     });
 });

--- a/apps/bpmn-webview/src/app/viewport.ts
+++ b/apps/bpmn-webview/src/app/viewport.ts
@@ -1,3 +1,5 @@
+import { MIN_CANVAS_SIZE_PX, isUsableViewbox } from "@miragon/bpmn-modeler-shared";
+
 import { ViewportData } from "./webviewState";
 
 /**
@@ -26,12 +28,32 @@ export class ViewportManager {
     }
 
     /**
+     * Whether the host has laid the canvas out at a size worth fitting into.
+     *
+     * Every viewbox operation divides by these dimensions, so an unlaid-out
+     * container yields a NaN transform, which SVG renders as nothing.
+     */
+    isCanvasSized(): boolean {
+        const { outer } = this.getService<any>("canvas").viewbox();
+        return outer.width >= MIN_CANVAS_SIZE_PX && outer.height >= MIN_CANVAS_SIZE_PX;
+    }
+
+    /**
      * Restores the canvas to a previously saved viewbox.
      *
+     * Falls back to {@link fitViewport} for a box that cannot be applied
+     * safely, which also recovers tabs whose persisted viewbox was written
+     * while the canvas had no size.
+     *
      * @param viewport The viewbox to apply.
+     * @returns `false` if nothing was applied, so the caller can retry.
      */
-    setViewport(viewport: ViewportData): void {
+    setViewport(viewport: ViewportData): boolean {
+        if (!isUsableViewbox(viewport) || !this.isCanvasSized()) {
+            return this.fitViewport();
+        }
         this.getService<any>("canvas").viewbox(viewport);
+        return true;
     }
 
     /**
@@ -48,24 +70,43 @@ export class ViewportManager {
      * excluded from `outer` and needs no inset.
      *
      * Scale is capped at 1.0 to match fit-to-page semantics — never zoom in.
+     *
+     * @returns `false` if nothing was applied, so the caller can retry.
      */
-    fitViewport(): void {
+    fitViewport(): boolean {
         const canvas = this.getService<any>("canvas");
         const { inner, outer } = canvas.viewbox();
 
-        // No elements (or canvas not laid out yet) — nothing to fit; let
-        // bpmn-js handle the degenerate case.
-        if (!inner.width || !inner.height || !outer.width || !outer.height) {
-            canvas.zoom("fit-viewport");
-            return;
+        // Leaving bpmn-js's identity transform alone keeps the diagram
+        // visible, just not centred; fitting against an unlaid-out container
+        // would divide by it and blank the canvas instead.
+        if (!this.isCanvasSized()) {
+            return false;
         }
 
+        // No elements — nothing to fit; let bpmn-js handle the degenerate case.
+        if (!inner.width || !inner.height) {
+            canvas.zoom("fit-viewport");
+            return true;
+        }
+
+        // Insets are margins, not hard constraints. A palette whose stylesheet
+        // has not been applied yet measures as a full-width block, which would
+        // swallow the viewport and shrink the diagram to nothing; capping each
+        // inset keeps half the canvas available whatever the chrome reports.
+        const maxInsetX = outer.width / 4;
+        const maxInsetY = outer.height / 4;
         const paletteWidth =
             document.querySelector(".djs-palette")?.getBoundingClientRect().width ?? 50;
-        const inset = { top: 40, right: 40, bottom: 40, left: paletteWidth + 20 };
+        const inset = {
+            top: Math.min(40, maxInsetY),
+            right: Math.min(40, maxInsetX),
+            bottom: Math.min(40, maxInsetY),
+            left: Math.min(paletteWidth + 20, maxInsetX),
+        };
 
-        const availableWidth = Math.max(1, outer.width - inset.left - inset.right);
-        const availableHeight = Math.max(1, outer.height - inset.top - inset.bottom);
+        const availableWidth = outer.width - inset.left - inset.right;
+        const availableHeight = outer.height - inset.top - inset.bottom;
 
         const scale = Math.min(1, availableWidth / inner.width, availableHeight / inner.height);
 
@@ -82,6 +123,7 @@ export class ViewportManager {
             width: outer.width / scale,
             height: outer.height / scale,
         });
+        return true;
     }
 
     /**
@@ -89,6 +131,9 @@ export class ViewportManager {
      *
      * The debounce prevents a flood of state writes while the user is actively
      * panning or zooming; only the final position after the gesture is persisted.
+     *
+     * Degenerate viewboxes are dropped: persisting one makes the failure stick,
+     * since every later rebuild of that tab would restore an unusable box.
      *
      * @param cb Callback invoked with the new {@link ViewportData} after each change.
      */
@@ -98,7 +143,10 @@ export class ViewportManager {
             clearTimeout(timer);
             timer = setTimeout(() => {
                 const { x, y, width, height } = event.viewbox;
-                cb({ x, y, width, height });
+                const viewport = { x, y, width, height };
+                if (isUsableViewbox(viewport)) {
+                    cb(viewport);
+                }
             }, 100);
         });
     }

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -48,6 +48,7 @@ import {
     formatErrors,
     initResizer,
     initTheme,
+    observeCanvasSize,
 } from "@miragon/bpmn-modeler-shared";
 import { VsCodeClipboardModule, LabelClipboardModule } from "@miragon/bpmn-modeler-clipboard";
 import { TranslateModule, i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
@@ -58,7 +59,7 @@ import {
     installKeyboardFocus,
     UnsupportedEngineError,
 } from "./app";
-import type { HostApi } from "@miragon/bpmn-modeler-shared";
+import type { HostApi, ResizableCanvas } from "@miragon/bpmn-modeler-shared";
 import type { WebviewState } from "./app/webviewState";
 import { DiffMode } from "./app/diff/DiffMode";
 import type { LintConfigService } from "./app/bpmnlint";
@@ -345,8 +346,14 @@ async function run(): Promise<void> {
 
     stateManager = new WebviewStateManager(host, bpmnModeler);
 
-    // Phase 1: restore viewport (canvas exists after openXml)
+    // Phase 1: restore viewport (canvas exists after openXml). Retried from the
+    // observer because hosts mount the webview before laying it out, and the
+    // observer then keeps the cached viewbox in sync for the rest of the session.
     stateManager.restoreViewport();
+    const canvas = bpmnModeler.getService<ResizableCanvas & { getContainer(): Element }>("canvas");
+    observeCanvasSize(canvas, canvas.getContainer(), {
+        applyInitialViewport: () => stateManager.restoreViewport(),
+    });
 
     // Surface templates bpmn-js rejects (invalid schema, bad `appliesTo`, …).
     // Subscribed *before* GetElementTemplatesCommand so the errors fired while

--- a/apps/bpmn-webview/vitest.config.ts
+++ b/apps/bpmn-webview/vitest.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
 
 export default defineConfig({
     test: {
         name: "bpmn-webview",
         environment: "jsdom",
         include: ["src/**/*.{spec,test}.ts"],
+        alias: {
+            "@miragon/bpmn-modeler-shared": resolve(__dirname, "../../libs/shared/src/index.ts"),
+        },
         coverage: {
             provider: "v8",
             reportsDirectory: "../../coverage/apps/bpmn-webview",

--- a/apps/dmn-webview/src/app/modeler.ts
+++ b/apps/dmn-webview/src/app/modeler.ts
@@ -7,7 +7,11 @@ import {
 import DmnSimulationModule from "@emaarco/dmn-js-simulation";
 import camundaModdleDescriptors from "camunda-dmn-moddle/resources/camunda.json";
 
-import { NoModelerError } from "@miragon/bpmn-modeler-shared";
+import {
+    NoModelerError,
+    type ResizableCanvas,
+    observeCanvasSize,
+} from "@miragon/bpmn-modeler-shared";
 
 let modeler: DmnModeler | undefined;
 
@@ -120,6 +124,28 @@ export async function exportDiagram(): Promise<string> {
     }
 
     throw Error("Failed to save changes made to the diagram!");
+}
+
+/**
+ * Keeps the active view's cached canvas size in sync with its container.
+ *
+ * dmn-js only re-measures when a view is attached, so a host that lays the
+ * webview out after the open leaves the DRD canvas on a stale box, throwing
+ * off hit-testing and drag coordinates.
+ *
+ * @param container The element whose size drives the active view.
+ * @returns A disposer that stops observing.
+ * @throws NoModelerError if the modeler is not initialized
+ */
+export function syncCanvasSize(container: Element): () => void {
+    getModeler();
+    return observeCanvasSize({ resized: () => getActiveCanvas()?.resized() }, container);
+}
+
+/** `undefined` for the decision-table and literal-expression views. */
+function getActiveCanvas(): ResizableCanvas | undefined {
+    const viewer = getModeler().getActiveViewer();
+    return viewer?.get("canvas", false) ?? undefined;
 }
 
 export function onCommandStackChanged(cb: () => void): void {

--- a/apps/dmn-webview/src/bootstrap.ts
+++ b/apps/dmn-webview/src/bootstrap.ts
@@ -34,6 +34,7 @@ import {
     exportDiagram,
     loadDiagram,
     onCommandStackChanged,
+    syncCanvasSize,
     WebviewStateManager,
 } from "./app";
 import type { HostApi } from "@miragon/bpmn-modeler-shared";
@@ -168,6 +169,10 @@ async function initializeModeler(dmnFile: string | undefined) {
     try {
         createModeler();
         onCommandStackChanged(() => void debouncedSendChanges());
+        const canvasElement = document.querySelector("#js-canvas");
+        if (canvasElement) {
+            syncCanvasSize(canvasElement);
+        }
         await openXML(dmnFile);
     } catch (error) {
         if (error instanceof NoModelerError) {

--- a/apps/intellij-plugin/README.md
+++ b/apps/intellij-plugin/README.md
@@ -170,12 +170,10 @@ modeler core or the bridge.
 > key above — it is the platform's master switch.
 
 > **Leave `ide.browser.jcef.osr.enabled` alone.** While out-of-process JCEF is
-> active, setting it to `false` does not give you windowed rendering — it makes
-> **every** `JBCefBrowser` construction throw, so the modeler, diff viewer, and
-> deployment tool window all fail to start (the editor then shows a "could not
-> start" label instead of the diagram). Once out-of-process JCEF is off, `false`
-> does yield windowed rendering, but it measured no better than in-process OSR at
-> the plugin's 60 fps — so there is no reason to touch it either way.
+> active, `false` makes **every** `JBCefBrowser` construction throw, so the
+> modeler, diff viewer, and deployment tool window all fail to start. With
+> out-of-process JCEF off it does yield windowed rendering, but that measured no
+> better than in-process OSR at the plugin's 60 fps.
 
 ## Scope
 

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -6,6 +6,7 @@ export * from "./lib/messages";
 export * from "./lib/documentFlush";
 export * from "./lib/modeler";
 export * from "./lib/theme";
+export * from "./lib/canvasResize";
 export * from "./lib/propertiesPanelResizer";
 export * from "./lib/processVariables";
 export * from "./lib/variableManifest";

--- a/libs/shared/src/lib/canvasResize.spec.ts
+++ b/libs/shared/src/lib/canvasResize.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { isUsableViewbox, observeCanvasSize } from "./canvasResize";
+
+/**
+ * Wires `observeCanvasSize` to a fake canvas and an observer the test fires by
+ * hand. The factory is injected because jsdom ships no `ResizeObserver`.
+ */
+function setup(applyInitialViewport?: () => boolean) {
+    const resized = vi.fn();
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    let fireResize = () => undefined as void;
+
+    const container = {} as Element;
+    const dispose = observeCanvasSize({ resized }, container, {
+        createObserver: (onResize) => {
+            fireResize = onResize;
+            return { observe, disconnect };
+        },
+        applyInitialViewport,
+    });
+
+    return { resized, observe, disconnect, dispose, container, fireResize: () => fireResize() };
+}
+
+describe("observeCanvasSize", () => {
+    it("observes the container it was given", () => {
+        const { observe, container } = setup();
+
+        expect(observe).toHaveBeenCalledWith(container);
+    });
+
+    it("invalidates the cached viewbox on every resize", () => {
+        const { resized, fireResize } = setup();
+
+        fireResize();
+        fireResize();
+
+        expect(resized).toHaveBeenCalledTimes(2);
+    });
+
+    // `resized()` only drops the cache, so a fit running first would still
+    // measure the stale box.
+    it("invalidates the viewbox before applying the initial viewport", () => {
+        const calls: string[] = [];
+        const applyInitialViewport = vi.fn(() => {
+            calls.push("apply");
+            return true;
+        });
+        const { resized, fireResize } = setup(applyInitialViewport);
+        resized.mockImplementation(() => void calls.push("resized"));
+
+        fireResize();
+
+        expect(calls).toEqual(["resized", "apply"]);
+    });
+
+    // The canvas rejects the box while the host has not laid it out, so the
+    // apply has to keep retrying.
+    it("retries the initial viewport until it is applied, then stops", () => {
+        const applyInitialViewport = vi.fn().mockReturnValueOnce(false).mockReturnValue(true);
+        const { fireResize } = setup(applyInitialViewport);
+
+        fireResize();
+        fireResize();
+        fireResize();
+
+        expect(applyInitialViewport).toHaveBeenCalledTimes(2);
+    });
+
+    it("stops observing when disposed", () => {
+        const { disconnect, dispose } = setup();
+
+        dispose();
+
+        expect(disconnect).toHaveBeenCalledOnce();
+    });
+
+    it("degrades to a no-op without a ResizeObserver", () => {
+        const resized = vi.fn();
+        const applyInitialViewport = vi.fn();
+
+        // No `createObserver` and no global — the jsdom/exotic-host case.
+        const dispose = observeCanvasSize({ resized }, {} as Element, { applyInitialViewport });
+        dispose();
+
+        expect(globalThis.ResizeObserver).toBeUndefined();
+        expect(resized).not.toHaveBeenCalled();
+        expect(applyInitialViewport).not.toHaveBeenCalled();
+    });
+});
+
+describe("isUsableViewbox", () => {
+    it.each([
+        ["a plain box", { x: 0, y: 0, width: 800, height: 600 }, true],
+        ["negative origins", { x: -100, y: -50, width: 800, height: 600 }, true],
+        ["undefined", undefined, false],
+        // The shape a persisted NaN viewbox comes back in after JSON.
+        ["null members", { x: null, y: null, width: null, height: null }, false],
+        ["NaN members", { x: NaN, y: NaN, width: NaN, height: NaN }, false],
+        ["an infinite scale", { x: 0, y: 0, width: Infinity, height: Infinity }, false],
+        ["zero area", { x: 0, y: 0, width: 0, height: 0 }, false],
+        ["a negative extent", { x: 0, y: 0, width: -800, height: 600 }, false],
+    ])("returns %s -> %s", (_case, viewbox, expected) => {
+        expect(isUsableViewbox(viewbox as any)).toBe(expected);
+    });
+});

--- a/libs/shared/src/lib/canvasResize.ts
+++ b/libs/shared/src/lib/canvasResize.ts
@@ -1,0 +1,92 @@
+/**
+ * Smallest canvas box (px, both axes) worth fitting a diagram into. A host
+ * that renders off-screen reports roughly one pixel rather than none, and a
+ * fit against that succeeds arithmetically but scales the diagram to nothing.
+ */
+export const MIN_CANVAS_SIZE_PX = 40;
+
+/**
+ * Whether a viewbox can be applied without collapsing the diagram.
+ *
+ * Catches `NaN` from a box measured against an unlaid-out container, and the
+ * `null` it turns into once persisted state has round-tripped through JSON.
+ */
+export function isUsableViewbox(
+    viewbox: { x: number; y: number; width: number; height: number } | undefined,
+): boolean {
+    if (!viewbox) {
+        return false;
+    }
+    const { x, y, width, height } = viewbox;
+    return (
+        Number.isFinite(x) &&
+        Number.isFinite(y) &&
+        Number.isFinite(width) &&
+        width > 0 &&
+        Number.isFinite(height) &&
+        height > 0
+    );
+}
+
+/** The slice of diagram-js's `Canvas` this module needs. */
+export interface ResizableCanvas {
+    resized(): void;
+}
+
+/** Minimal `ResizeObserver` shape, so a fake can be injected in tests. */
+export interface SizeObserver {
+    observe(target: Element): void;
+    disconnect(): void;
+}
+
+export interface CanvasResizeOptions {
+    /** Observer factory; injectable because jsdom ships no `ResizeObserver`. */
+    createObserver?: (onResize: () => void) => SizeObserver;
+
+    /**
+     * Applies the initial viewport. Retried after every resize until it
+     * returns `true`, so the canvas alone decides when its box is trustworthy.
+     */
+    applyInitialViewport?: () => boolean;
+}
+
+/**
+ * Keeps diagram-js's cached viewbox in sync with the container's real size.
+ *
+ * bpmn-js calls `canvas.resized()` only from `attachTo()`, which this codebase
+ * never uses — modelers are constructed with a `container` option — and
+ * nothing else observes the container. The viewbox would otherwise stay cached
+ * at whatever size the container had at import time, which on hosts that mount
+ * the webview before laying it out is zero.
+ *
+ * @returns A disposer that stops observing.
+ */
+export function observeCanvasSize(
+    canvas: ResizableCanvas,
+    container: Element,
+    options: CanvasResizeOptions = {},
+): () => void {
+    const createObserver = options.createObserver ?? defaultObserverFactory();
+    if (!createObserver) {
+        return () => undefined;
+    }
+
+    let applied = options.applyInitialViewport === undefined;
+    const observer = createObserver(() => {
+        // `resized()` only drops the cache, so it has to run first or the
+        // viewport below still measures the stale box.
+        canvas.resized();
+        if (!applied) {
+            applied = options.applyInitialViewport!();
+        }
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+}
+
+/** `undefined` where `ResizeObserver` is missing, so the caller no-ops. */
+function defaultObserverFactory(): ((onResize: () => void) => SizeObserver) | undefined {
+    const Observer = globalThis.ResizeObserver;
+    return Observer ? (onResize) => new Observer(onResize) : undefined;
+}


### PR DESCRIPTION
**Issue**

Aims to fix #1331 and #1198 (rendering only. the "~20s to open" in #1198 has a different cause).

**Description**

bpmn-js is constructed with the `container` option, so `canvas.resized()` — only called from `attachTo()` — never runs, and nothing observes the container. The container's size therefore mattered at exactly one instant, the fit right after `importXML`, and was never re-measured. Hosts routinely mount the webview before laying it out (IntelliJ pre-warms off-screen, Theia builds the iframe before the layout pass), and fitting against that box makes diagram-js divide by zero and write a NaN transform, which SVG renders as nothing. The NaN viewbox was then persisted as `null`, so the blank state survived reopening the tab.

The red marks in #1198 confirm this: they measure exactly `3x20`/`20x3` px, the `camunda-transaction-boundaries` overlay constants. Those are HTML overlays, and `Overlays._updateRoot` does `viewbox.scale || 1` — NaN is falsy, so they stayed visible at scale 1 while the SVG diagram disappeared.

Changes:

- New `observeCanvasSize` in `libs/shared`: calls `canvas.resized()` on resize and retries the initial viewport until the canvas accepts it.
- `ViewportManager` no longer fits or restores against an unlaid-out canvas, and never persists a degenerate viewbox. `restoreViewport()` is one-shot, so a later resize never discards the user's zoom.
- Same observer for the diff panes (plus guards so one pane cannot collapse its partner) and the DMN webview, which only had a stale canvas size since dmn-js never fits.
- Also fixes a second defect with the same symptom: an unstyled `.djs-palette` measures full-width, so the inset swallowed the viewport and rendered the diagram at 1x0 px on a correctly sized canvas. Insets are now capped at a quarter of the canvas.

**Verification**

Reproduced in Chromium with a 0x0 iframe laid out later: no transform written at 0x0, fits correctly once sized; the normal demo load went from 1x0 to 557x254 px; zoom survives a later resize.

**I could not reproduce either issue anymore, but this is not a guarantee that they are fixed** — both are intermittent, and #1198 was never reliably reproducible. Please keep them open until this has run a while in the IntelliJ and standalone hosts.

`ide.browser.jcef.osr.enabled=false` should no longer be needed: windowed rendering just gave the browser real window bounds, hiding the zero-size fit.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
