### PR TITLE
feat(vscode-plugin): focus a BPMN lint finding's element on the canvas

### DIFF
--- a/apps/bpmn-webview/src/app/diff/DiffViewer.ts
+++ b/apps/bpmn-webview/src/app/diff/DiffViewer.ts
@@ -8,6 +8,8 @@ import {
     observeCanvasSize,
 } from "@miragon/bpmn-modeler-shared";
 
+import { centreOf } from "../elementGeometry";
+
 /**
  * CSS class applied to each element category on the canvas.
  */
@@ -254,39 +256,4 @@ export class DiffViewer {
     private getCanvas(): any {
         return this.viewer.get<any>("canvas");
     }
-}
-
-/**
- * Returns the geometric centre of a bpmn-js element, or `undefined` when the
- * element has neither shape bounds nor waypoints to derive a position from.
- */
-function centreOf(element: {
-    x?: number;
-    y?: number;
-    width?: number;
-    height?: number;
-    waypoints?: ReadonlyArray<{ x: number; y: number }>;
-}): { x: number; y: number } | undefined {
-    if (typeof element.x === "number" && typeof element.y === "number") {
-        return {
-            x: element.x + (element.width ?? 0) / 2,
-            y: element.y + (element.height ?? 0) / 2,
-        };
-    }
-    const wps = element.waypoints;
-    if (wps && wps.length > 0) {
-        let minX = wps[0].x;
-        let maxX = wps[0].x;
-        let minY = wps[0].y;
-        let maxY = wps[0].y;
-        for (let i = 1; i < wps.length; i++) {
-            const p = wps[i];
-            if (p.x < minX) minX = p.x;
-            if (p.x > maxX) maxX = p.x;
-            if (p.y < minY) minY = p.y;
-            if (p.y > maxY) maxY = p.y;
-        }
-        return { x: (minX + maxX) / 2, y: (minY + maxY) / 2 };
-    }
-    return undefined;
 }

--- a/apps/bpmn-webview/src/app/elementGeometry.ts
+++ b/apps/bpmn-webview/src/app/elementGeometry.ts
@@ -1,0 +1,37 @@
+export interface PositionedElement {
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+    waypoints?: ReadonlyArray<{ x: number; y: number }>;
+}
+
+/**
+ * Geometric centre of a bpmn-js element, or `undefined` when it has neither
+ * shape bounds nor waypoints. Connections carry only `waypoints`; without the
+ * bbox-midpoint branch they would centre at (0, 0).
+ */
+export function centreOf(element: PositionedElement): { x: number; y: number } | undefined {
+    if (typeof element.x === "number" && typeof element.y === "number") {
+        return {
+            x: element.x + (element.width ?? 0) / 2,
+            y: element.y + (element.height ?? 0) / 2,
+        };
+    }
+    const wps = element.waypoints;
+    if (wps && wps.length > 0) {
+        let minX = wps[0].x;
+        let maxX = wps[0].x;
+        let minY = wps[0].y;
+        let maxY = wps[0].y;
+        for (let i = 1; i < wps.length; i++) {
+            const p = wps[i];
+            if (p.x < minX) minX = p.x;
+            if (p.x > maxX) maxX = p.x;
+            if (p.y < minY) minY = p.y;
+            if (p.y > maxY) maxY = p.y;
+        }
+        return { x: (minX + maxX) / 2, y: (minY + maxY) / 2 };
+    }
+    return undefined;
+}

--- a/apps/bpmn-webview/src/app/viewport.spec.ts
+++ b/apps/bpmn-webview/src/app/viewport.spec.ts
@@ -198,3 +198,93 @@ describe("ViewportManager.onViewportChanged", () => {
         vi.useRealTimers();
     });
 });
+
+// The viewbox getter reports the current box; the setter is a spy so the
+// centred box can be asserted.
+function setupFocus(
+    current: { x: number; y: number; width: number; height: number },
+    outer: { width: number; height: number },
+    elements: Record<string, unknown>,
+) {
+    const viewbox = vi.fn((box?: unknown) => (box ? undefined : { ...current, outer }));
+    const canvas = { viewbox };
+    const registry = { get: (id: string) => elements[id] };
+    const manager = new ViewportManager((name: string) => {
+        if (name === "canvas") return canvas as any;
+        if (name === "elementRegistry") return registry as any;
+        throw new Error(`unexpected service: ${name}`);
+    });
+    return { manager, viewbox };
+}
+
+describe("ViewportManager.centerOnElement", () => {
+    it("centres a shape on the current zoom when already zoomed in enough", () => {
+        const { manager, viewbox } = setupFocus(
+            { x: 0, y: 0, width: 1000, height: 800 }, // scale 1.0 ≥ floor
+            { width: 1000, height: 800 },
+            { Task_1: { x: 100, y: 100, width: 100, height: 100 } },
+        );
+
+        expect(manager.centerOnElement("Task_1")).toBe(true);
+
+        // Centre (150,150), box unchanged in size, positioned so the centre sits
+        // in the middle of the viewport.
+        expect(viewbox.mock.calls.at(-1)?.[0]).toEqual({
+            x: 150 - 500,
+            y: 150 - 400,
+            width: 1000,
+            height: 800,
+        });
+    });
+
+    it("pulls in to the minimum zoom when far zoomed out", () => {
+        const { manager, viewbox } = setupFocus(
+            { x: 0, y: 0, width: 2000, height: 1600 }, // scale 0.5 < floor 0.75
+            { width: 1000, height: 800 },
+            { Task_1: { x: 100, y: 100, width: 100, height: 100 } },
+        );
+
+        manager.centerOnElement("Task_1");
+
+        const box = viewbox.mock.calls.at(-1)?.[0] as Rect;
+        // Widened to the floor: outer / 0.75.
+        expect(box.width).toBeCloseTo(1000 / 0.75);
+        expect(box.height).toBeCloseTo(800 / 0.75);
+        // Still centred on the element centre (150,150).
+        expect(box.x + box.width / 2).toBeCloseTo(150);
+        expect(box.y + box.height / 2).toBeCloseTo(150);
+    });
+
+    it("centres a connection on its waypoint-bbox midpoint", () => {
+        const { manager, viewbox } = setupFocus(
+            { x: 0, y: 0, width: 1000, height: 800 },
+            { width: 1000, height: 800 },
+            {
+                Flow_1: {
+                    waypoints: [
+                        { x: 100, y: 100 },
+                        { x: 300, y: 300 },
+                    ],
+                },
+            },
+        );
+
+        manager.centerOnElement("Flow_1");
+
+        const box = viewbox.mock.calls.at(-1)?.[0] as Rect;
+        expect(box.x + box.width / 2).toBeCloseTo(200);
+        expect(box.y + box.height / 2).toBeCloseTo(200);
+    });
+
+    it("leaves the viewport untouched for an unknown element", () => {
+        const { manager, viewbox } = setupFocus(
+            { x: 0, y: 0, width: 1000, height: 800 },
+            { width: 1000, height: 800 },
+            {},
+        );
+
+        expect(manager.centerOnElement("missing")).toBe(false);
+        // Only the getter (if at all); never the setter.
+        expect(viewbox.mock.calls.every((call) => call[0] === undefined)).toBe(true);
+    });
+});

--- a/apps/bpmn-webview/src/app/viewport.ts
+++ b/apps/bpmn-webview/src/app/viewport.ts
@@ -1,6 +1,7 @@
 import { MIN_CANVAS_SIZE_PX, isUsableViewbox } from "@miragon/bpmn-modeler-shared";
 
 import { ViewportData } from "./webviewState";
+import { centreOf } from "./elementGeometry";
 
 /**
  * Function type for accessing a service from the bpmn-js DI container.
@@ -9,6 +10,10 @@ import { ViewportData } from "./webviewState";
  * @param name The DI service name.
  */
 type ServiceAccessor = <T>(name: string) => T;
+
+// Zoom floor when focusing an element, so a far-zoomed-out view still shows it
+// legibly. Never zooms out past the user's current level.
+const MIN_FOCUS_ZOOM = 0.75;
 
 /**
  * Reads, writes, and subscribes to canvas viewbox changes.
@@ -122,6 +127,40 @@ export class ViewportManager {
             y: inner.y - marginY / scale,
             width: outer.width / scale,
             height: outer.height / scale,
+        });
+        return true;
+    }
+
+    /**
+     * Centres the viewport on `id`, enforcing {@link MIN_FOCUS_ZOOM}. Returns
+     * `false` when the element is not on the canvas (e.g. a stale lint finding),
+     * leaving the viewport untouched. Unlike the diff pane's variant it lets the
+     * `viewbox.changed` event through, so the focused position is persisted.
+     */
+    centerOnElement(id: string): boolean {
+        const canvas = this.getService<any>("canvas");
+        const element = this.getService<any>("elementRegistry").get(id);
+        if (!element) {
+            return false;
+        }
+        const centre = centreOf(element);
+        if (!centre) {
+            return false;
+        }
+
+        const viewbox = canvas.viewbox();
+        // scale = outer/viewbox width; below the floor, widen the box (smaller
+        // viewbox = higher zoom).
+        const scale = viewbox.width > 0 ? viewbox.outer.width / viewbox.width : MIN_FOCUS_ZOOM;
+        const width = scale < MIN_FOCUS_ZOOM ? viewbox.outer.width / MIN_FOCUS_ZOOM : viewbox.width;
+        const height =
+            scale < MIN_FOCUS_ZOOM ? viewbox.outer.height / MIN_FOCUS_ZOOM : viewbox.height;
+
+        canvas.viewbox({
+            x: centre.x - width / 2,
+            y: centre.y - height / 2,
+            width,
+            height,
         });
         return true;
     }

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -14,6 +14,7 @@ import {
     ElementTemplatesQuery,
     Engine,
     FlushDocumentQuery,
+    FocusElementQuery,
     GetBpmnFileCommand,
     GetBpmnlintConfigCommand,
     GetBpmnModelerSettingCommand,
@@ -145,6 +146,10 @@ const respondToFlush = createFlushResponder(
 const bpmnFileResolver = createResolver<BpmnFileQuery>();
 
 let modelerIsInitialized = false;
+
+// A FocusElementQuery can arrive before the import finishes (host opens the
+// editor and focuses in one tick); apply it once the modeler is ready.
+let pendingFocusId: string | undefined;
 
 // Separate resolvers for element clipboard and text (label) clipboard.
 let elementClipboardResolver = createResolver<ClipboardQuery>();
@@ -284,6 +289,11 @@ async function run(): Promise<void> {
     ];
     await initializeModeler(bpmnFileQuery?.content, bpmnFileQuery?.engine, extraModules);
     modelerIsInitialized = true;
+
+    if (pendingFocusId !== undefined) {
+        bpmnModeler.viewport.centerOnElement(pendingFocusId);
+        pendingFocusId = undefined;
+    }
 
     /**
      * Bridge "Edit Script" / "Open in Editor" triggers (script-task context
@@ -689,6 +699,19 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
             try {
                 const query = message.data as ImplementationStatusQuery;
                 bpmnModeler.applyImplementationStatus(query.resolved);
+            } catch (error: any) {
+                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+            }
+            break;
+        }
+        case queryOrCommand.type === "FocusElementQuery": {
+            try {
+                const { elementId } = message.data as FocusElementQuery;
+                if (modelerIsInitialized) {
+                    bpmnModeler.viewport.centerOnElement(elementId);
+                } else {
+                    pendingFocusId = elementId;
+                }
             } catch (error: any) {
                 host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }

--- a/apps/vscode-plugin/package.json
+++ b/apps/vscode-plugin/package.json
@@ -314,6 +314,11 @@
                 "title": "Reload Modeler",
                 "category": "Miragon BPMN Modeler",
                 "icon": "$(refresh)"
+            },
+            {
+                "command": "bpmn-modeler.focusLintElement",
+                "title": "Focus Lint Element",
+                "category": "Miragon BPMN Modeler"
             }
         ],
         "keybindings": [
@@ -375,6 +380,10 @@
                 },
                 {
                     "command": "bpmn-modeler.compareSelected",
+                    "when": "false"
+                },
+                {
+                    "command": "bpmn-modeler.focusLintElement",
                     "when": "false"
                 }
             ],

--- a/apps/vscode-plugin/src/composition/editorFeature.ts
+++ b/apps/vscode-plugin/src/composition/editorFeature.ts
@@ -20,6 +20,10 @@ import { ModelNavigationService } from "@miragon/bpmn-modeler-core";
 import { ReferencedModelLocator } from "@miragon/bpmn-modeler-core";
 import { ModelerEditorController } from "../modeler/editor-session/ModelerEditorController";
 import { DocumentSaveFlushController } from "../modeler/editor-session/DocumentSaveFlushController";
+import {
+    FocusLintElementController,
+    FOCUS_LINT_ELEMENT_CMD,
+} from "../modeler/bpmn/controller/FocusLintElementController";
 import { NodeBpmnLinter } from "@miragon/bpmn-modeler-core";
 import { VsCodeDiagnostics } from "../shared/infrastructure/VsCodeDiagnostics";
 import { BpmnRenderParticipant } from "../modeler/bpmn/controller/editor-participants/BpmnRenderParticipant";
@@ -130,7 +134,7 @@ export function register(
         deps.vsDocument,
         lintConfigLocator,
         new NodeBpmnLinter(),
-        new VsCodeDiagnostics(),
+        new VsCodeDiagnostics(FOCUS_LINT_ELEMENT_CMD),
         deps.statusBar,
         deps.notifier,
         new DefaultBpmnlintConfigService(),
@@ -286,6 +290,10 @@ export function register(
         ],
         initialPanelVisible: () => dmnPanelSvc.getPersistedPanelVisibility(),
     }).register(context);
+
+    // Turns each element-specific bpmnlint diagnostic into a click-to-centre
+    // action; the diagnostics carry a command link to this controller.
+    new FocusLintElementController(deps.editorStore, deps.notifier).register(context);
 
     // Flush debounced webview changes into the buffer before every save so a
     // persist never writes XML that trails the live model by the debounce window.

--- a/apps/vscode-plugin/src/manifest.contract.spec.ts
+++ b/apps/vscode-plugin/src/manifest.contract.spec.ts
@@ -37,6 +37,7 @@ import {
     UPDATE_MARKETPLACES_CMD,
 } from "./templateMarketplace/controller/TemplateMarketplaceController";
 import { OPEN_ALL_SCRIPT_TASKS_CMD } from "./scriptTask/controller/ScriptTaskCommandController";
+import { FOCUS_LINT_ELEMENT_CMD } from "./modeler/bpmn/controller/FocusLintElementController";
 import { BPMN_VIEW_TYPE, DMN_VIEW_TYPE } from "@miragon/bpmn-modeler-core";
 
 const SRC_DIR = __dirname;
@@ -78,6 +79,7 @@ const CODE_COMMAND_IDS = [
     ADD_MARKETPLACE_CMD,
     UPDATE_MARKETPLACES_CMD,
     REMOVE_MARKETPLACE_CMD,
+    FOCUS_LINT_ELEMENT_CMD,
 ];
 
 const CONFIG_NAMESPACE = "miragon.bpmnModeler";

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/FocusLintElementController.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/FocusLintElementController.spec.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const executeCommandMock = vi.fn();
+
+vi.mock("vscode", () => ({
+    commands: {
+        registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+        executeCommand: (...args: unknown[]) => executeCommandMock(...args),
+    },
+    Uri: { parse: (value: string) => ({ value, toString: () => value }) },
+}));
+
+import { BPMN_VIEW_TYPE } from "@miragon/bpmn-modeler-core";
+import { FocusElementQuery } from "@miragon/bpmn-modeler-shared";
+
+import { FocusLintElementController } from "./FocusLintElementController";
+
+function setup() {
+    const postMessage = vi.fn().mockResolvedValue(true);
+    const logError = vi.fn();
+    const controller = new FocusLintElementController({ postMessage } as any, { logError } as any);
+    return { controller, postMessage, logError };
+}
+
+beforeEach(() => {
+    executeCommandMock.mockReset();
+    executeCommandMock.mockResolvedValue(undefined);
+});
+
+describe("FocusLintElementController", () => {
+    it("activates the editor then posts a focus query for the element", async () => {
+        const { controller, postMessage } = setup();
+
+        await (controller as any).focus("file:///a.bpmn", "Task_1");
+
+        expect(executeCommandMock).toHaveBeenCalledWith(
+            "vscode.openWith",
+            expect.objectContaining({ value: "file:///a.bpmn" }),
+            BPMN_VIEW_TYPE,
+        );
+        expect(postMessage).toHaveBeenCalledWith("file:///a.bpmn", expect.any(FocusElementQuery));
+        expect(postMessage.mock.calls[0][1].elementId).toBe("Task_1");
+    });
+
+    it("logs instead of throwing when activation fails", async () => {
+        const { controller, postMessage, logError } = setup();
+        executeCommandMock.mockRejectedValue(new Error("no editor"));
+
+        await (controller as any).focus("file:///a.bpmn", "Task_1");
+
+        expect(postMessage).not.toHaveBeenCalled();
+        expect(logError).toHaveBeenCalledOnce();
+    });
+});

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/FocusLintElementController.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/FocusLintElementController.ts
@@ -1,0 +1,41 @@
+import { commands, ExtensionContext, Uri } from "vscode";
+
+import { BPMN_VIEW_TYPE, EditorSessionStore } from "@miragon/bpmn-modeler-core";
+import { FocusElementQuery } from "@miragon/bpmn-modeler-shared";
+
+import { VsCodeNotifier } from "../../../shared/infrastructure/VsCodeNotifier";
+
+// VS Code command ID behind a bpmnlint diagnostic's clickable code link.
+export const FOCUS_LINT_ELEMENT_CMD = "bpmn-modeler.focusLintElement";
+
+/**
+ * Centres the BPMN canvas on the element behind a bpmnlint Problems-panel
+ * finding. VS Code strips the range for custom editors and fires no diagnostic-
+ * click event, so each element-specific diagnostic carries a `command:` link to
+ * {@link FOCUS_LINT_ELEMENT_CMD} instead; this activates the editor and asks the
+ * webview to centre the element. Hidden from the palette (only invoked via link).
+ */
+export class FocusLintElementController {
+    constructor(
+        private readonly editorStore: EditorSessionStore,
+        private readonly notifier: VsCodeNotifier,
+    ) {}
+
+    register(context: ExtensionContext): void {
+        context.subscriptions.push(
+            commands.registerCommand(FOCUS_LINT_ELEMENT_CMD, this.focus, this),
+        );
+    }
+
+    // `editorId` is the document URI string — the store key editors register
+    // under, which the diagnostics were published against.
+    private async focus(editorId: string, elementId: string): Promise<void> {
+        try {
+            // Idempotent: reveals the open editor, or opens it if none yet.
+            await commands.executeCommand("vscode.openWith", Uri.parse(editorId), BPMN_VIEW_TYPE);
+            await this.editorStore.postMessage(editorId, new FocusElementQuery(elementId));
+        } catch (error) {
+            this.notifier.logError(error instanceof Error ? error : new Error(String(error)));
+        }
+    }
+}

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeDiagnostics.spec.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeDiagnostics.spec.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const setMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock("vscode", () => {
+    class Position {
+        constructor(
+            readonly line: number,
+            readonly character: number,
+        ) {}
+    }
+    class Range {
+        constructor(
+            readonly start: Position,
+            readonly end: Position,
+        ) {}
+    }
+    class Diagnostic {
+        code: unknown;
+        source: string | undefined;
+        constructor(
+            readonly range: Range,
+            readonly message: string,
+            readonly severity: number,
+        ) {}
+    }
+    return {
+        Diagnostic,
+        Range,
+        Position,
+        Uri: { parse: (value: string) => ({ value, toString: () => value }) },
+        DiagnosticSeverity: { Error: 0, Warning: 1, Information: 2 },
+        languages: {
+            createDiagnosticCollection: () => ({ set: setMock, delete: deleteMock }),
+        },
+    };
+});
+
+import { LintResults } from "@miragon/bpmn-modeler-shared";
+
+import { VsCodeDiagnostics } from "./VsCodeDiagnostics";
+
+const XML = `<?xml version="1.0"?><bpmn:task id="Task_1" /><bpmn:process id="Process_1" />`;
+const DOC = "file:///diagram.bpmn";
+const FOCUS_CMD = "bpmn-modeler.focusLintElement";
+
+/** The single diagnostic set on the collection by the last `publish` call. */
+function publishedDiagnostic(results: LintResults, focusCommandId?: string) {
+    new VsCodeDiagnostics(focusCommandId).publish(DOC, XML, results);
+    return setMock.mock.calls.at(-1)?.[1][0];
+}
+
+beforeEach(() => {
+    setMock.mockClear();
+    deleteMock.mockClear();
+});
+
+describe("VsCodeDiagnostics element-specific navigation", () => {
+    it("links an element finding to the focus command with editor + element id", () => {
+        const diagnostic = publishedDiagnostic(
+            {
+                "label-required": [
+                    {
+                        id: "Task_1",
+                        message: "Label required",
+                        category: "error",
+                        rule: "label-required",
+                    },
+                ],
+            },
+            FOCUS_CMD,
+        );
+
+        expect(diagnostic.code.value).toBe("label-required");
+        const target = diagnostic.code.target.toString() as string;
+        const [scheme, query] = target.split("?");
+        expect(scheme).toBe(`command:${FOCUS_CMD}`);
+        expect(JSON.parse(decodeURIComponent(query))).toEqual([DOC, "Task_1"]);
+    });
+
+    it("leaves a diagram-wide finding (no element id) as a plain rule code", () => {
+        const diagnostic = publishedDiagnostic(
+            {
+                "no-implementation-process": [
+                    { message: "…", category: "warn", rule: "no-implementation-process" },
+                ],
+            },
+            FOCUS_CMD,
+        );
+
+        expect(diagnostic.code).toBe("no-implementation-process");
+    });
+
+    it("omits the link when no focus command is wired", () => {
+        const diagnostic = publishedDiagnostic(
+            {
+                "label-required": [
+                    {
+                        id: "Task_1",
+                        message: "Label required",
+                        category: "error",
+                        rule: "label-required",
+                    },
+                ],
+            },
+            undefined,
+        );
+
+        expect(diagnostic.code).toBe("label-required");
+    });
+});

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeDiagnostics.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeDiagnostics.ts
@@ -20,10 +20,18 @@ import { DiagnosticsPort } from "@miragon/bpmn-modeler-core";
  * best-effort scan for the element's `id="…"` in the XML, falling back to the
  * document start. That is enough for the Problems entry to open the file; the
  * precise on-canvas location is still shown by the in-diagram overlay.
+ *
+ * Element-specific findings additionally get a clickable `code` link to a host
+ * command that centres the element — the only handle a Problems entry has,
+ * since VS Code discards the range for custom editors. The command id is
+ * injected so this shared adapter stays decoupled from the feature that owns it.
  */
 export class VsCodeDiagnostics implements DiagnosticsPort {
     private readonly collection: DiagnosticCollection =
         languages.createDiagnosticCollection("bpmnlint");
+
+    // focusCommandId is called with (editorId, elementId); omitted → no link.
+    constructor(private readonly focusCommandId?: string) {}
 
     publish(documentUri: string, xml: string, results: LintResults): void {
         const uri = Uri.parse(documentUri);
@@ -38,7 +46,15 @@ export class VsCodeDiagnostics implements DiagnosticsPort {
                     this.severity(report.category),
                 );
                 diagnostic.source = "bpmnlint";
-                if (report.rule) {
+                const target =
+                    report.id && this.focusCommandId
+                        ? this.focusCommandTarget(documentUri, report.id)
+                        : undefined;
+                if (target) {
+                    // Fallback label keeps the code link clickable when a finding
+                    // carries no rule.
+                    diagnostic.code = { value: report.rule ?? "bpmnlint", target };
+                } else if (report.rule) {
                     diagnostic.code = report.rule;
                 }
                 diagnostics.push(diagnostic);
@@ -50,6 +66,13 @@ export class VsCodeDiagnostics implements DiagnosticsPort {
 
     clear(documentUri: string): void {
         this.collection.delete(Uri.parse(documentUri));
+    }
+
+    // Args are a JSON array in the query string (VS Code command-URI
+    // convention), URI-encoded so reserved characters in ids survive.
+    private focusCommandTarget(editorId: string, elementId: string): Uri {
+        const args = encodeURIComponent(JSON.stringify([editorId, elementId]));
+        return Uri.parse(`command:${this.focusCommandId}?${args}`);
     }
 
     private severity(category: string): DiagnosticSeverity {

--- a/libs/shared/src/lib/modeler.ts
+++ b/libs/shared/src/lib/modeler.ts
@@ -155,6 +155,20 @@ export class BpmnlintResultsQuery extends Query {
     }
 }
 
+/**
+ * Centres the canvas on an element by id. VS Code strips the range for custom
+ * editors and fires no diagnostic-click event, so a Problems-panel bpmnlint
+ * finding reaches its element through a command link that posts this instead.
+ */
+export class FocusElementQuery extends Query {
+    public readonly elementId: string;
+
+    constructor(elementId: string) {
+        super("FocusElementQuery");
+        this.elementId = elementId;
+    }
+}
+
 export interface BpmnModelerSetting {
     readonly alignToOrigin: boolean;
     readonly showTransactionBoundaries: boolean;


### PR DESCRIPTION
## Why

BPMN lint findings show up as native diagnostics in the **Problems** panel, but on large diagrams they tell you *what* is wrong, not *where*. Clicking a finding now centres the affected element on the canvas, closing the loop from finding to element.

Closes #1336.

## What

- Each element-specific bpmnlint diagnostic gets a clickable `code` link carrying `(editorId, elementId)`.
- Clicking it runs a new host command `bpmn-modeler.focusLintElement`, which activates the editor (`vscode.openWith`, idempotent) and posts a `FocusElementQuery`.
- The webview centres the element, enforcing a minimum zoom so a far-zoomed-out view still shows it clearly, and buffers the request if the diagram is still importing (editor opened by the click).
- Diagram-wide findings (no element id) keep the previous behaviour — plain rule code, no link.

## Known limitation (by design)

**Only the code-link (rule badge) triggers centring, not a full-row click.** VS Code strips the diagnostic range before handing a document to a custom editor and fires no diagnostic-click event ([microsoft/vscode#211351](https://github.com/microsoft/vscode/issues/211351), closed as *out-of-scope*), so a row click can never tell us which element was meant. The command link is the only handle a Problems entry has to reach its element.

## Notes

- VS Code only: `DiagnosticsPort` is a no-op on other hosts, so nothing changes for IntelliJ/standalone. `FocusElementQuery` is harmless there (never sent).
- Shared `centreOf` extracted from `DiffViewer` into `elementGeometry.ts` (reused, not duplicated).

## Testing

- `corepack yarn test` — 549 passing (new unit tests for viewport centring, diagnostic linking, and the command controller; architecture/no-cycles green).
- `corepack yarn lint` (0 errors) and `corepack yarn format:check` clean.
- vscode-plugin (ts-loader) and webview builds compile.
- Manual F5: clicking a finding's code badge activates the editor and centres the element, including when the editor must first be opened; the lint overlay stays visible.