### PR TITLE
fix(diff): opt the BPMN editor into VS Code diff resolution

### DIFF
--- a/apps/vscode-plugin/README.md
+++ b/apps/vscode-plugin/README.md
@@ -76,8 +76,8 @@ the decision is that".
   or 8. Supports no auth, Basic Auth, and OAuth2 Client Credentials; payload
   files are discovered by convention from `<configFolder>/payloads/`.
 - **Compare two diagrams** — select two `.bpmn` files in the Explorer (or
-  right-click one, **BPMN Modeler: Select for Compare**, then **Compare with
-  Selected** on another) to open a side-by-side read-only diff with element-level
+  right-click one, **Select for Compare (BPMN)**, then **Compare with
+  Selected (BPMN)** on another) to open a side-by-side read-only diff with element-level
   colour coding (added / removed / changed / moved) via
   [`bpmn-js-differ`](https://github.com/bpmn-io/bpmn-js-differ), synchronized
   pan/zoom, and a prev/next change navigator.
@@ -102,8 +102,8 @@ Search for "BPMN Modeler" in the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`
 | BPMN Modeler: Toggle Standard Text Editor | `Ctrl+Shift+E` | Open the XML text editor next to the BPMN modeler                |
 | BPMN Modeler: Display Logging Information |                | Open a console showing modeler log output                        |
 
-The compare commands — **Select for Compare**, **Compare with Selected**, and
-**Compare Selected** — are available from the Explorer right-click menu on
+The compare commands — **Select for Compare (BPMN)**, **Compare with Selected (BPMN)**, and
+**Compare Selected (BPMN)** — are available from the Explorer right-click menu on
 `.bpmn` files rather than the Command Palette.
 
 ### Settings

--- a/apps/vscode-plugin/package.json
+++ b/apps/vscode-plugin/package.json
@@ -284,17 +284,17 @@
             },
             {
                 "command": "bpmn-modeler.selectForCompare",
-                "title": "Select for Compare",
+                "title": "Select for Compare (BPMN)",
                 "category": "Miragon BPMN Modeler"
             },
             {
                 "command": "bpmn-modeler.compareWithSelected",
-                "title": "Compare with Selected",
+                "title": "Compare with Selected (BPMN)",
                 "category": "Miragon BPMN Modeler"
             },
             {
                 "command": "bpmn-modeler.compareSelected",
-                "title": "Compare Selected",
+                "title": "Compare Selected (BPMN)",
                 "category": "Miragon BPMN Modeler"
             },
             {

--- a/apps/vscode-plugin/package.json
+++ b/apps/vscode-plugin/package.json
@@ -19,7 +19,7 @@
         "@types/vscode": "1.93.0",
         "@vitest/coverage-v8": "4.1.9",
         "@vscode/test-cli": "0.0.15",
-        "@vscode/test-electron": "3.0.0",
+        "@vscode/test-electron": "3.1.0",
         "archunit": "2.3.0",
         "copy-webpack-plugin": "14.0.0",
         "ts-loader": "9.6.2",
@@ -179,7 +179,10 @@
                         "filenamePattern": "*.bpmn"
                     }
                 ],
-                "priority": "default"
+                "priority": {
+                    "textEditor": "default",
+                    "diffEditor": "default"
+                }
             },
             {
                 "id": "bpmn-modeler.dmn",

--- a/apps/vscode-plugin/src/composition/diffFeature.ts
+++ b/apps/vscode-plugin/src/composition/diffFeature.ts
@@ -14,12 +14,12 @@ import { SharedDeps } from "./sharedDeps";
 export function register(
     context: ExtensionContext,
     deps: SharedDeps,
-): { diffController: BpmnDiffController } {
+): { diffController: BpmnDiffController; diffStore: DiffPaneStore } {
     const diffStore = new DiffPaneStore();
     context.subscriptions.push(diffStore);
     const diffService = new BpmnDiffService(deps.notifier, deps.vsSettings, diffStore);
     const diffController = new BpmnDiffController(diffStore, diffService, deps.notifier);
     diffController.register(context);
 
-    return { diffController };
+    return { diffController, diffStore };
 }

--- a/apps/vscode-plugin/src/diff/controller/BpmnCompareController.ts
+++ b/apps/vscode-plugin/src/diff/controller/BpmnCompareController.ts
@@ -101,7 +101,7 @@ export class BpmnCompareController {
         const leftUri = this.selection.get();
         if (!leftUri) {
             this.notifier.showInfo(
-                'No file selected for compare. Right-click a .bpmn file and choose "Select for Compare" first.',
+                'No file selected for compare. Right-click a .bpmn file and choose "Select for Compare (BPMN)" first.',
             );
             return;
         }

--- a/apps/vscode-plugin/src/main.ts
+++ b/apps/vscode-plugin/src/main.ts
@@ -12,6 +12,13 @@ import * as commandsFeature from "./composition/commandsFeature";
 import * as deploymentFeature from "./composition/deploymentFeature";
 import * as templateMarketplaceFeature from "./composition/templateMarketplaceFeature";
 
+/** Narrow API surface returned by `activate()` for e2e tests only. */
+export interface TestApi {
+    diff: {
+        sessionFor(uri: string): { origin: string; paneCount: number } | undefined;
+    };
+}
+
 /**
  * Activation is now pure composition: build the shared collaborators once, then
  * let each feature wire itself via its own `register()`. Adding a feature means
@@ -24,13 +31,13 @@ import * as templateMarketplaceFeature from "./composition/templateMarketplaceFe
  * diff's controller, script's service, code-link's handles, and the marketplace
  * service; later features reuse handles the earlier ones returned.
  */
-export function activate(context: ExtensionContext): void {
+export function activate(context: ExtensionContext): TestApi {
     setContext(context);
 
     const deps = buildSharedDeps(context);
     // Below buildSharedDeps so the release check can log through the notifier.
     notifyIfNewRelease(context, deps.notifier);
-    const { diffController } = diffFeature.register(context, deps);
+    const { diffController, diffStore } = diffFeature.register(context, deps);
     const { scriptTaskSvc, scriptVariableStore, scriptManifestParticipant } =
         scriptFeature.register(context, deps);
     const codeLink = codeLinkFeature.register(context, deps);
@@ -49,6 +56,18 @@ export function activate(context: ExtensionContext): void {
     compareFeature.register(context, deps, { diffController });
     commandsFeature.register(context, deps, { bpmnService });
     deploymentFeature.register(context, deps);
+
+    return {
+        diff: {
+            sessionFor(uri: string) {
+                const session = diffStore.findByUri(uri);
+                if (!session) {
+                    return undefined;
+                }
+                return { origin: session.origin, paneCount: session.attachedPanes().length };
+            },
+        },
+    };
 }
 
 const RELEASES_BASE = "https://github.com/Miragon/bpmn-modeler/releases/tag";

--- a/apps/vscode-plugin/src/manifest.contract.spec.ts
+++ b/apps/vscode-plugin/src/manifest.contract.spec.ts
@@ -54,7 +54,10 @@ interface Manifest {
         commands: { command: string; title: string }[];
         keybindings: { command: string }[];
         menus: Record<string, { command: string }[]>;
-        customEditors: { viewType: string }[];
+        customEditors: {
+            viewType: string;
+            priority: string | { textEditor: string; diffEditor?: string };
+        }[];
         configuration: { properties: Record<string, unknown> };
     };
 }
@@ -123,6 +126,15 @@ describe("package.json ↔ code contract", () => {
         const declared = manifest.contributes.customEditors.map((e) => e.viewType);
 
         expect(new Set(declared)).toEqual(new Set([BPMN_VIEW_TYPE, DMN_VIEW_TYPE]));
+    });
+
+    it("opts the BPMN editor into diffs explicitly", () => {
+        // Since VS Code 1.129 a custom editor is excluded from `vscode.diff`
+        // unless `priority.diffEditor` opts in; the string form silently drops
+        // the BPMN diff view back to the text diff.
+        const bpmn = manifest.contributes.customEditors.find((e) => e.viewType === BPMN_VIEW_TYPE);
+
+        expect(bpmn?.priority).toEqual({ textEditor: "default", diffEditor: "default" });
     });
 
     it("keeps config keys in sync between manifest and VsCodeSettings", () => {

--- a/apps/vscode-plugin/src/manifest.contract.spec.ts
+++ b/apps/vscode-plugin/src/manifest.contract.spec.ts
@@ -51,7 +51,7 @@ const manifest = JSON.parse(
 
 interface Manifest {
     contributes: {
-        commands: { command: string }[];
+        commands: { command: string; title: string }[];
         keybindings: { command: string }[];
         menus: Record<string, { command: string }[]>;
         customEditors: { viewType: string }[];
@@ -152,6 +152,52 @@ describe("package.json ↔ code contract", () => {
         );
 
         expect(offenders).toEqual([]);
+    });
+
+    // Context menus render only `title`, not `category` — a title identical to a
+    // VS Code built-in in the same menu group is visually indistinguishable.
+    it("never shadows a built-in VS Code title in a shared context menu", () => {
+        const VSCODE_BUILTIN_MENU_TITLES = new Set(
+            [
+                "Select for Compare",
+                "Compare with Selected",
+                "Compare Selected",
+                "Open to the Side",
+                "Open With...",
+                "Open Timeline",
+                "Copy Path",
+                "Copy Relative Path",
+                "Rename...",
+                "Delete",
+                "Cut",
+                "Copy",
+                "Paste",
+                "Find in Folder...",
+                "Reveal in Finder",
+                "Reveal in File Explorer",
+                "Open in Integrated Terminal",
+            ].map((t) => t.toLowerCase().trim()),
+        );
+
+        const SHARED_MENUS = ["explorer/context", "editor/title", "editor/title/context"];
+
+        const commandsInSharedMenus = new Set(
+            SHARED_MENUS.flatMap(
+                (menu) => manifest.contributes.menus[menu]?.map((e) => e.command) ?? [],
+            ),
+        );
+
+        const titleByCommand = new Map(
+            manifest.contributes.commands.map((c) => [c.command, c.title]),
+        );
+
+        const collisions = [...commandsInSharedMenus]
+            .map((cmd) => ({ cmd, title: titleByCommand.get(cmd) }))
+            .filter(
+                ({ title }) => title && VSCODE_BUILTIN_MENU_TITLES.has(title.toLowerCase().trim()),
+            );
+
+        expect(collisions).toEqual([]);
     });
 
     it("actually sets every custom when-clause context key it gates UI on", () => {

--- a/apps/vscode-plugin/test/e2e/.vscode-test.mjs
+++ b/apps/vscode-plugin/test/e2e/.vscode-test.mjs
@@ -23,10 +23,18 @@ const extensionDevelopmentPath = resolve(repoRoot, "dist/apps/vscode-plugin");
 // inheriting any user/project settings that could perturb activation.
 const workspace = mkdtempSync(resolve(tmpdir(), "bpmn-modeler-e2e-"));
 
-// `@vscode/test-cli` has no teardown hook, so the temp workspace would otherwise
-// accumulate one orphaned dir per local run. Remove it when the test process
+// Electron opens a unix socket under the user-data dir; macOS limits socket
+// paths to 103 chars, so the default `.vscode-test/user-data` under a deep
+// checkout fails with `listen EINVAL`. A short temp dir sidesteps that.
+const userDataDir = mkdtempSync(resolve(tmpdir(), "bpmn-modeler-ud-"));
+
+// `@vscode/test-cli` has no teardown hook, so the temp dirs would otherwise
+// accumulate one orphaned dir per local run. Remove them when the test process
 // exits (any cause); `force` swallows the already-gone case.
-process.on("exit", () => rmSync(workspace, { recursive: true, force: true }));
+process.on("exit", () => {
+    rmSync(workspace, { recursive: true, force: true });
+    rmSync(userDataDir, { recursive: true, force: true });
+});
 
 export default defineConfig({
     label: "vscode-plugin-smoke",
@@ -36,7 +44,7 @@ export default defineConfig({
     extensionDevelopmentPath,
     // `--disable-extensions` isolates from any other installed extensions; the
     // extension under test still loads via `extensionDevelopmentPath`.
-    launchArgs: [workspace, "--disable-extensions"],
+    launchArgs: [workspace, "--disable-extensions", "--user-data-dir", userDataDir],
     mocha: {
         ui: "tdd",
         // Electron's first launch downloads + unpacks; the activation path also

--- a/apps/vscode-plugin/test/e2e/compare.e2e.test.ts
+++ b/apps/vscode-plugin/test/e2e/compare.e2e.test.ts
@@ -30,21 +30,46 @@ function getExtension(): vscode.Extension<TestApi> {
     return ext;
 }
 
-/** Polls `vscode.window.tabGroups` until a tab with the expected label appears. */
-async function waitForTab(label: string, timeoutMs = 10_000): Promise<void> {
+/** Polls until `predicate` holds; fails with `describe()` on timeout. */
+async function waitFor(
+    predicate: () => boolean,
+    describe: () => string,
+    timeoutMs = 10_000,
+): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-        const found = vscode.window.tabGroups.all
-            .flatMap((g) => g.tabs)
-            .some((t) => t.label === label);
-        if (found) {
+        if (predicate()) {
             return;
         }
         await new Promise((r) => setTimeout(r, 250));
     }
-    const open = vscode.window.tabGroups.all.flatMap((g) => g.tabs).map((t) => t.label);
-    assert.fail(
-        `tab "${label}" did not appear within ${timeoutMs}ms — open tabs: ${open.join(", ")}`,
+    assert.fail(`${describe()} (waited ${timeoutMs}ms)`);
+}
+
+/** Polls `vscode.window.tabGroups` until a tab with the expected label appears. */
+function waitForTab(label: string): Promise<void> {
+    const tabs = () => vscode.window.tabGroups.all.flatMap((g) => g.tabs);
+    return waitFor(
+        () => tabs().some((t) => t.label === label),
+        () =>
+            `tab "${label}" did not appear — open tabs: ${tabs()
+                .map((t) => t.label)
+                .join(", ")}`,
+    );
+}
+
+/**
+ * The only observable that proves VS Code routed `vscode.diff` into *our*
+ * custom editor: panes attach to the session solely from our resolve path.
+ * A text diff (the fallback since VS Code 1.129 unless the manifest opts in
+ * via `priority.diffEditor`) leaves the session registered but pane-less.
+ */
+function waitForBothPanes(api: TestApi, uri: string): Promise<void> {
+    return waitFor(
+        () => api.diff.sessionFor(uri)?.paneCount === 2,
+        () =>
+            `diff panes never attached — session: ${JSON.stringify(api.diff.sessionFor(uri))}; ` +
+            `the diff likely opened in the text editor instead of the BPMN viewer`,
     );
 }
 
@@ -66,24 +91,18 @@ suite("BPMN compare commands", () => {
         await vscode.commands.executeCommand("workbench.action.closeAllEditors");
     });
 
-    test("two-step flow opens a diff tab", async () => {
+    test("two-step flow opens the BPMN diff with both panes attached", async () => {
         await vscode.commands.executeCommand("bpmn-modeler.selectForCompare", uriA);
         await vscode.commands.executeCommand("bpmn-modeler.compareWithSelected", uriB);
         await waitForTab(DIFF_TAB_LABEL);
+        await waitForBothPanes(api, uriA.toString());
+
+        assert.strictEqual(api.diff.sessionFor(uriA.toString())?.origin, "compare-files");
     });
 
-    test("single-step flow opens a diff tab", async () => {
+    test("single-step flow opens the BPMN diff with both panes attached", async () => {
         await vscode.commands.executeCommand("bpmn-modeler.compareSelected", uriA, [uriA, uriB]);
         await waitForTab(DIFF_TAB_LABEL);
-    });
-
-    test("two-step flow creates a compare-files session", async () => {
-        await vscode.commands.executeCommand("bpmn-modeler.selectForCompare", uriA);
-        await vscode.commands.executeCommand("bpmn-modeler.compareWithSelected", uriB);
-        await waitForTab(DIFF_TAB_LABEL);
-
-        const session = api.diff.sessionFor(uriA.toString());
-        assert.ok(session, "no session found for the left-hand URI");
-        assert.strictEqual(session.origin, "compare-files");
+        await waitForBothPanes(api, uriA.toString());
     });
 });

--- a/apps/vscode-plugin/test/e2e/compare.e2e.test.ts
+++ b/apps/vscode-plugin/test/e2e/compare.e2e.test.ts
@@ -1,0 +1,89 @@
+import * as assert from "node:assert";
+import { resolve } from "node:path";
+
+import * as vscode from "vscode";
+
+/**
+ * Exercises the Explorer-context-menu compare commands end-to-end in a real
+ * VS Code host. Catches the "titles shadow a built-in" regression that is
+ * invisible to unit tests (which mock `vscode` entirely) and to the smoke
+ * test (which never runs compare commands).
+ */
+
+const EXTENSION_ID = "miragon-gmbh.vs-code-bpmn-modeler";
+
+const FIXTURES = resolve(__dirname, "..", "fixtures");
+const FIXTURE_A = resolve(FIXTURES, "example.bpmn");
+const FIXTURE_B = resolve(FIXTURES, "example-b.bpmn");
+
+const DIFF_TAB_LABEL = "example.bpmn ↔ example-b.bpmn";
+
+interface TestApi {
+    diff: {
+        sessionFor(uri: string): { origin: string; paneCount: number } | undefined;
+    };
+}
+
+function getExtension(): vscode.Extension<TestApi> {
+    const ext = vscode.extensions.getExtension<TestApi>(EXTENSION_ID);
+    assert.ok(ext, `extension ${EXTENSION_ID} not found in host`);
+    return ext;
+}
+
+/** Polls `vscode.window.tabGroups` until a tab with the expected label appears. */
+async function waitForTab(label: string, timeoutMs = 10_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const found = vscode.window.tabGroups.all
+            .flatMap((g) => g.tabs)
+            .some((t) => t.label === label);
+        if (found) {
+            return;
+        }
+        await new Promise((r) => setTimeout(r, 250));
+    }
+    const open = vscode.window.tabGroups.all.flatMap((g) => g.tabs).map((t) => t.label);
+    assert.fail(
+        `tab "${label}" did not appear within ${timeoutMs}ms — open tabs: ${open.join(", ")}`,
+    );
+}
+
+suite("BPMN compare commands", () => {
+    let api: TestApi;
+    const uriA = vscode.Uri.file(FIXTURE_A);
+    const uriB = vscode.Uri.file(FIXTURE_B);
+
+    suiteSetup(async () => {
+        const ext = getExtension();
+        api = await ext.activate();
+    });
+
+    suiteTeardown(async () => {
+        await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    });
+
+    teardown(async () => {
+        await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    });
+
+    test("two-step flow opens a diff tab", async () => {
+        await vscode.commands.executeCommand("bpmn-modeler.selectForCompare", uriA);
+        await vscode.commands.executeCommand("bpmn-modeler.compareWithSelected", uriB);
+        await waitForTab(DIFF_TAB_LABEL);
+    });
+
+    test("single-step flow opens a diff tab", async () => {
+        await vscode.commands.executeCommand("bpmn-modeler.compareSelected", uriA, [uriA, uriB]);
+        await waitForTab(DIFF_TAB_LABEL);
+    });
+
+    test("two-step flow creates a compare-files session", async () => {
+        await vscode.commands.executeCommand("bpmn-modeler.selectForCompare", uriA);
+        await vscode.commands.executeCommand("bpmn-modeler.compareWithSelected", uriB);
+        await waitForTab(DIFF_TAB_LABEL);
+
+        const session = api.diff.sessionFor(uriA.toString());
+        assert.ok(session, "no session found for the left-hand URI");
+        assert.strictEqual(session.origin, "compare-files");
+    });
+});

--- a/apps/vscode-plugin/test/e2e/fixtures/example-b.bpmn
+++ b/apps/vscode-plugin/test/e2e/fixtures/example-b.bpmn
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_02m23tv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.23.0">
+  <bpmn:process id="example-process" name="Example Process" isExecutable="true">
+    <bpmn:startEvent id="Start_Form" name="Start" camunda:formKey="start-form-usertask">
+      <bpmn:outgoing>Flow_1qhfavc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_1k3cs5s" name="Send Mail" camunda:class="com.mycompany.MailTaskImpl">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="sender" />
+          <camunda:inputParameter name="receivers" />
+          <camunda:inputParameter name="messageBody">
+            <camunda:script scriptFormat="freemarker">Hello ${firstName}!</camunda:script>
+          </camunda:inputParameter>
+          <camunda:outputParameter name="mailSendResult">${ resultStatus }</camunda:outputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1qhfavc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0h9cvar</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1qhfavc" sourceRef="Start_Form" targetRef="Activity_1k3cs5s" />
+    <bpmn:userTask id="Activity_review" name="Review Result">
+      <bpmn:incoming>Flow_0h9cvar</bpmn:incoming>
+      <bpmn:outgoing>Flow_review_end</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0h9cvar" sourceRef="Activity_1k3cs5s" targetRef="Activity_review" />
+    <bpmn:endEvent id="Event_1ritf8p">
+      <bpmn:incoming>Flow_review_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_review_end" sourceRef="Activity_review" targetRef="Event_1ritf8p" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_test-prozess">
+    <bpmndi:BPMNPlane id="BPMNPlane_test-prozess" bpmnElement="example-process">
+      <bpmndi:BPMNShape id="Event_1acjyv3_di" bpmnElement="Start_Form">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="145" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1k3cs5s_di" bpmnElement="Activity_1k3cs5s">
+        <dc:Bounds x="240" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_review_di" bpmnElement="Activity_review">
+        <dc:Bounds x="400" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ritf8p_di" bpmnElement="Event_1ritf8p">
+        <dc:Bounds x="562" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1qhfavc_di" bpmnElement="Flow_1qhfavc">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0h9cvar_di" bpmnElement="Flow_0h9cvar">
+        <di:waypoint x="340" y="120" />
+        <di:waypoint x="400" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_review_end_di" bpmnElement="Flow_review_end">
+        <di:waypoint x="500" y="120" />
+        <di:waypoint x="562" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/docs/vscode/features/bpmn-diff.md
+++ b/docs/vscode/features/bpmn-diff.md
@@ -22,15 +22,15 @@ The left pane shows the **before** version (e.g. `HEAD` or the merge-base) and t
 When the two files are visible side by side in the Explorer:
 
 1. Hold <kbd>Cmd</kbd> / <kbd>Ctrl</kbd> and click the two `.bpmn` files so both are selected.
-2. Right-click either one → **BPMN Modeler: Compare Selected**.
+2. Right-click either one → **Compare Selected (BPMN)**.
 3. A diff tab opens with two BPMN canvases — the first-selected file on the left (`before`), the second on the right (`after`).
 
 ### Pick them one at a time
 
 Useful when the two files live in different Explorer folders, or when you want to pair a file you selected earlier against another one you find later.
 
-1. Right-click the first `.bpmn` file → **BPMN Modeler: Select for Compare**. A status-bar note confirms the pick.
-2. Right-click the second `.bpmn` file → **BPMN Modeler: Compare with Selected**.
+1. Right-click the first `.bpmn` file → **Select for Compare (BPMN)**. A status-bar note confirms the pick.
+2. Right-click the second `.bpmn` file → **Compare with Selected (BPMN)**.
 3. The diff tab opens as above.
 
 Selection is in-memory only; reloading the window or running the compare clears it. The menu mirrors VS Code's built-in compare UX: **Select for Compare** and **Compare with Selected** disappear while two files are multi-selected — **Compare Selected** takes their place. Selecting three or more `.bpmn` files hides every compare entry (there is no meaningful three-way compare).

--- a/docs/vscode/features/bpmn-diff.md
+++ b/docs/vscode/features/bpmn-diff.md
@@ -7,6 +7,8 @@ The diff view opens from two entry points, which share the same UI:
 - **Source Control / Git** — any place VS Code opens a text diff for a `.bpmn` file.
 - **Explorer context menu** — pick two `.bpmn` files, either with a multi-selection or one right-click at a time.
 
+> **Note:** Since VS Code 1.129 custom editors are no longer used for diffs unless they opt in. The extension declares `"priority": { "textEditor": "default", "diffEditor": "default" }` for `.bpmn` so both Git diffs and `vscode.diff` render in the BPMN viewer. If you ever see a plain XML diff instead, check `workbench.diffEditorAssociations` in your settings — a `*.bpmn` entry there overrides the extension's default.
+
 ## Usage — Source Control
 
 1. Open the **Source Control** panel in VS Code.

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -28,7 +28,10 @@ module.exports = [
             // bpmnlint plugin) — CommonJS content users copy, not repo source.
             "resources/**",
             // Compiled Extension-Host e2e tests — generated CommonJS, not source.
-            "apps/vscode-plugin/test/e2e/out/**",
+            // Unanchored on purpose: the nested apps/vscode-plugin config reuses
+            // this list with its own base path, where a repo-rooted path never
+            // matches.
+            "**/test/e2e/out/**",
             // The @vscode/test-electron download — the entire VS Code app. Lives
             // here after a local `test:e2e` run; linting it explodes the heap and
             // emits 500k+ spurious errors. Flat config ignores `.gitignore`, so

--- a/yarn.lock
+++ b/yarn.lock
@@ -7499,16 +7499,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vscode/test-electron@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@vscode/test-electron@npm:3.0.0"
+"@vscode/test-electron@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@vscode/test-electron@npm:3.1.0"
   dependencies:
     http-proxy-agent: "npm:^7.0.2"
     https-proxy-agent: "npm:^7.0.5"
     jszip: "npm:^3.10.1"
     ora: "npm:^8.1.0"
     semver: "npm:^7.6.2"
-  checksum: 10c0/8672a6a1496e41cd7ae1675f3d1894f20895fc72eba66d4a9547c7bc5887c8e726f6972a8852df2598ed3a50f3bd9d6d762e99dd1a1c5ae2cb485f21e69c9f81
+  checksum: 10c0/94dec0f45cc35ad50bdff982b377c3160de340af92e4fb5e1fe161e6ecc9bbd3718ecf33f8776da1cfb4b80930d7e9141031ee8ae264465c86c71c99923fa9e4
   languageName: node
   linkType: hard
 
@@ -22633,7 +22633,7 @@ __metadata:
     "@types/vscode": "npm:1.93.0"
     "@vitest/coverage-v8": "npm:4.1.9"
     "@vscode/test-cli": "npm:0.0.15"
-    "@vscode/test-electron": "npm:3.0.0"
+    "@vscode/test-electron": "npm:3.1.0"
     archunit: "npm:2.3.0"
     copy-webpack-plugin: "npm:14.0.0"
     ts-loader: "npm:9.6.2"


### PR DESCRIPTION
## Issue

"Select for Compare" / "Compare with Selected" opened VS Code's plain XML text diff instead of the BPMN diff view.

## Description

Root cause is a VS Code change, not our code: since 1.129 custom editors default to `explicit` priority for diffs and are skipped by `vscode.diff`/SCM diffs unless the manifest opts in; this declares `"priority": { "textEditor": "default", "diffEditor": "default" }` for `.bpmn` (object form stable since 1.133, older hosts fall through to `default`). It also renames the three Explorer compare titles to `… (BPMN)` so they no longer collide with the identically named built-ins in the same menu group. A manifest contract test guards both, and the new e2e compare suite asserts both diff panes attach to the session — verified locally against VS Code 1.134: fails on the old manifest (`paneCount: 0`), passes with the fix. Harness fixes so the e2e suite runs on macOS: `@vscode/test-electron` 3.1.0 (renamed app binary), a short `--user-data-dir` (103-char socket limit), and an eslint ignore that actually matches the compiled e2e output.

## Checklist

- [x] Tests added/updated
- [x] Docs updated