### PR TITLE
fix(bpmn-webview): make optional-FEEL inputs legible in dark mode

### DIFF
--- a/apps/bpmn-webview/src/styles/dark-theme/properties-panel.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/properties-panel.css
@@ -106,13 +106,17 @@
 
 .bio-properties-panel-textarea textarea,
 .bio-properties-panel-textfield input,
-.bio-properties-panel-numberfield input {
+.bio-properties-panel-numberfield input,
+.bio-properties-panel-feel-entry input,
+.bio-properties-panel-feel-entry textarea {
     color: var(--dt-surface-a60) !important;
 }
 
 .bio-properties-panel-textarea > textarea:focus,
 .bio-properties-panel-textfield > input:focus,
-.bio-properties-panel-numberfield > input:focus {
+.bio-properties-panel-numberfield > input:focus,
+.bio-properties-panel-feel-entry input:focus,
+.bio-properties-panel-feel-entry textarea:focus {
     color: var(--dt-surface-a70) !important;
 }
 

--- a/apps/dmn-webview/src/styles/dark-theme/properties-panel.css
+++ b/apps/dmn-webview/src/styles/dark-theme/properties-panel.css
@@ -112,13 +112,17 @@
 
 .bio-properties-panel-textarea textarea,
 .bio-properties-panel-textfield input,
-.bio-properties-panel-numberfield input {
+.bio-properties-panel-numberfield input,
+.bio-properties-panel-feel-entry input,
+.bio-properties-panel-feel-entry textarea {
     color: var(--dt-surface-a60) !important;
 }
 
 .bio-properties-panel-textarea > textarea:focus,
 .bio-properties-panel-textfield > input:focus,
-.bio-properties-panel-numberfield > input:focus {
+.bio-properties-panel-numberfield > input:focus,
+.bio-properties-panel-feel-entry input:focus,
+.bio-properties-panel-feel-entry textarea:focus {
     color: var(--dt-surface-a70) !important;
 }
 


### PR DESCRIPTION
**Issue**

In dark mode, Camunda 8 optional-FEEL fields (e.g. the Timer event *Value* field) render black text on the dark input background while the value is not a `=` expression.

**Description**

Optional-FEEL entries render a plain `<input>`/`<textarea>` inside `.bio-properties-panel-feel-entry` until the value becomes an expression; upstream `@bpmn-io/properties-panel` never sets a text colour on it and `<input>` does not inherit `--text-base-color`, so it fell back to the UA default black. The existing dark-theme colour overrides for textfield/textarea/numberfield are extended to the `feel-entry` wrapper (normal and `:focus` states) in both the BPMN and DMN webviews. The CodeMirror (`=` expression) branch was already covered and is unchanged.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created