### PR TITLE
feat(bpmn-webview): persist drill-down plane across tab switches and re-imports

### DIFF
--- a/apps/bpmn-webview/src/app/index.ts
+++ b/apps/bpmn-webview/src/app/index.ts
@@ -1,6 +1,7 @@
 export * from "./modeler";
 export * from "./viewport";
 export * from "./selection";
+export * from "./rootElement";
 export * from "./state";
 export * from "./propertiesPanelClipboard";
 export * from "./keyboardFocus";

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -35,6 +35,7 @@ import {
 } from "./scriptTaskContextPad";
 import { ViewportManager } from "./viewport";
 import { SelectionManager } from "./selection";
+import { RootElementManager } from "./rootElement";
 import { deriveEngines } from "./engines";
 import LintModule from "./bpmnlint";
 import { setColorThemeMode } from "@miragon/bpmn-modeler-shared";
@@ -80,6 +81,8 @@ export class BpmnModeler {
 
     private _selection: SelectionManager | undefined;
 
+    private _rootElement: RootElementManager | undefined;
+
     // Optional host sink for non-fatal warnings (element-not-found, missing
     // inline script). Kept as an injected callback rather than a host import so
     // the modeler stays constructible in tests and the standalone dev browser.
@@ -107,6 +110,18 @@ export class BpmnModeler {
             throw new NoModelerError();
         }
         return this._selection;
+    }
+
+    /**
+     * Access the root element manager after {@link create}.
+     *
+     * @throws {NoModelerError} If the modeler has not been created yet.
+     */
+    get rootElement(): RootElementManager {
+        if (!this._rootElement) {
+            throw new NoModelerError();
+        }
+        return this._rootElement;
     }
 
     /**
@@ -164,6 +179,7 @@ export class BpmnModeler {
         const accessor = <T>(name: string): T => this.getModeler().get<T>(name);
         this._viewport = new ViewportManager(accessor);
         this._selection = new SelectionManager(accessor);
+        this._rootElement = new RootElementManager(accessor);
 
         /**
          * Apply default favourites immediately after creation.

--- a/apps/bpmn-webview/src/app/rootElement.spec.ts
+++ b/apps/bpmn-webview/src/app/rootElement.spec.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RootElementManager } from "./rootElement";
+
+function setup(currentRootId: string, elements: Record<string, unknown> = {}) {
+    const setRootElement = vi.fn();
+    const canvas = {
+        getRootElement: vi.fn().mockReturnValue({ id: currentRootId }),
+        setRootElement,
+    };
+    const elementRegistry = {
+        get: vi.fn((id: string) => elements[id]),
+    };
+    const listeners: Record<string, (event: any) => void> = {};
+    const eventBus = {
+        on: (event: string, handler: (event: any) => void) => {
+            listeners[event] = handler;
+        },
+    };
+    const manager = new RootElementManager((name: string) => {
+        if (name === "canvas") return canvas as any;
+        if (name === "elementRegistry") return elementRegistry as any;
+        if (name === "eventBus") return eventBus as any;
+        throw new Error(`unexpected service: ${name}`);
+    });
+    const emitRootSet = (elementId: string) =>
+        listeners["root.set"]?.({ element: { id: elementId } });
+    return { manager, canvas, elementRegistry, setRootElement, emitRootSet };
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("RootElementManager.getRootElementId", () => {
+    it("returns the current root ID for a user-created root", () => {
+        const { manager } = setup("SubProcess_1_plane");
+        expect(manager.getRootElementId()).toBe("SubProcess_1_plane");
+    });
+
+    it("returns undefined for the implicit root", () => {
+        const { manager } = setup("__implicitrootbase");
+        expect(manager.getRootElementId()).toBeUndefined();
+    });
+
+    it("returns undefined when canvas has no root element", () => {
+        const canvas = { getRootElement: vi.fn().mockReturnValue(null) };
+        const manager = new RootElementManager((name: string) => {
+            if (name === "canvas") return canvas as any;
+            throw new Error(`unexpected service: ${name}`);
+        });
+        expect(manager.getRootElementId()).toBeUndefined();
+    });
+});
+
+describe("RootElementManager.setRootElementById", () => {
+    it("switches the canvas root to the element with the given ID", () => {
+        const planeElement = { id: "SubProcess_1_plane" };
+        const { manager, setRootElement } = setup("Process_1", {
+            SubProcess_1_plane: planeElement,
+        });
+
+        expect(manager.setRootElementById("SubProcess_1_plane")).toBe(true);
+        expect(setRootElement).toHaveBeenCalledWith(planeElement);
+    });
+
+    it("returns false when the element does not exist", () => {
+        const { manager, setRootElement } = setup("Process_1");
+
+        expect(manager.setRootElementById("removed_plane")).toBe(false);
+        expect(setRootElement).not.toHaveBeenCalled();
+    });
+
+    it("returns false when the element is already the current root", () => {
+        const { manager, setRootElement } = setup("SubProcess_1_plane", {
+            SubProcess_1_plane: { id: "SubProcess_1_plane" },
+        });
+
+        expect(manager.setRootElementById("SubProcess_1_plane")).toBe(false);
+        expect(setRootElement).not.toHaveBeenCalled();
+    });
+
+    it("returns false for undefined id", () => {
+        const { manager, setRootElement } = setup("Process_1");
+
+        expect(manager.setRootElementById(undefined)).toBe(false);
+        expect(setRootElement).not.toHaveBeenCalled();
+    });
+});
+
+describe("RootElementManager.onRootChanged", () => {
+    it("fires the callback with the new root ID", () => {
+        const { manager, emitRootSet } = setup("Process_1");
+        const cb = vi.fn();
+        manager.onRootChanged(cb);
+
+        emitRootSet("SubProcess_1_plane");
+
+        expect(cb).toHaveBeenCalledWith("SubProcess_1_plane");
+    });
+
+    it("fires undefined for the implicit root", () => {
+        const { manager, emitRootSet } = setup("Process_1");
+        const cb = vi.fn();
+        manager.onRootChanged(cb);
+
+        emitRootSet("__implicitrootbase");
+
+        expect(cb).toHaveBeenCalledWith(undefined);
+    });
+});

--- a/apps/bpmn-webview/src/app/rootElement.ts
+++ b/apps/bpmn-webview/src/app/rootElement.ts
@@ -1,0 +1,82 @@
+/**
+ * Function type for accessing a service from the bpmn-js DI container.
+ *
+ * @template T The service type to retrieve.
+ * @param name The DI service name.
+ */
+type ServiceAccessor = <T>(name: string) => T;
+
+/**
+ * bpmn-js assigns synthetic root IDs prefixed with this token when no
+ * user-created root exists yet. These are internal and must not be
+ * persisted — restoring one after the modeler re-imports would fail
+ * because the ID is regenerated on every import.
+ */
+const IMPLICIT_ROOT_PREFIX = "__implicitroot";
+
+/**
+ * Reads, writes, and subscribes to the active canvas root element.
+ *
+ * The root element determines which plane is visible — the top-level
+ * process or a collapsed sub-process drill-down. Decoupled from the
+ * modeler through a {@link ServiceAccessor} so the concern can be tested
+ * and composed independently, following the same pattern as
+ * {@link ViewportManager} and {@link SelectionManager}.
+ */
+export class RootElementManager {
+    constructor(private readonly getService: ServiceAccessor) {}
+
+    /**
+     * Returns the ID of the active canvas root, or `undefined` when the
+     * canvas is on the implicit (top-level process) root — which should
+     * not be persisted because its ID is regenerated on every import.
+     */
+    getRootElementId(): string | undefined {
+        const root = this.getService<any>("canvas").getRootElement();
+        if (!root || root.id.startsWith(IMPLICIT_ROOT_PREFIX)) {
+            return undefined;
+        }
+        return root.id;
+    }
+
+    /**
+     * Switches the canvas to the root element with the given ID.
+     *
+     * @returns `false` when the element does not exist (e.g. the
+     *   sub-process was removed by an undo) or is already the current
+     *   root, so the caller knows no plane switch occurred. Must be
+     *   called *before* applying a viewbox — viewbox coordinates are
+     *   plane-relative, and the DrilldownCentering handler scrolls on
+     *   `root.set`, which a subsequent `setViewport` overrides.
+     */
+    setRootElementById(id: string | undefined): boolean {
+        if (!id) {
+            return false;
+        }
+        const canvas = this.getService<any>("canvas");
+        const current = canvas.getRootElement();
+        if (current?.id === id) {
+            return false;
+        }
+        const element = this.getService<any>("elementRegistry").get(id);
+        if (!element) {
+            return false;
+        }
+        canvas.setRootElement(element);
+        return true;
+    }
+
+    /**
+     * Subscribes to root element changes on the event bus.
+     *
+     * @param cb Callback invoked with the new root element's ID (or
+     *   `undefined` for the implicit root) whenever the active plane
+     *   changes — e.g. drill-down into a collapsed sub-process.
+     */
+    onRootChanged(cb: (rootElementId: string | undefined) => void): void {
+        this.getService<any>("eventBus").on("root.set", (event: any) => {
+            const id = event.element?.id;
+            cb(id && !id.startsWith(IMPLICIT_ROOT_PREFIX) ? id : undefined);
+        });
+    }
+}

--- a/apps/bpmn-webview/src/app/state.spec.ts
+++ b/apps/bpmn-webview/src/app/state.spec.ts
@@ -3,20 +3,34 @@ import { describe, expect, it, vi } from "vitest";
 import { WebviewStateManager } from "./state";
 
 /**
- * Builds a `WebviewStateManager` wired to spies for the only collaborators
- * `restoreViewport` touches: `host.getState` (the saved-state source that
- * discriminates fresh open from tab-switch rebuild) and the viewport methods.
+ * Builds a `WebviewStateManager` wired to spies for the collaborators
+ * that `restoreViewport`, `captureViewState`, and `applyViewState` touch.
  */
 function setup(savedState: unknown, applied = true) {
     const getState = vi.fn().mockReturnValue(savedState);
     const setViewport = vi.fn().mockReturnValue(applied);
     const fitViewport = vi.fn().mockReturnValue(applied);
+    const getViewport = vi.fn().mockReturnValue({ x: 0, y: 0, width: 1000, height: 800 });
+    const setRootElementById = vi.fn().mockReturnValue(true);
+    const getRootElementId = vi.fn().mockReturnValue(undefined);
+    const onRootChanged = vi.fn();
+    const getSelectedElementIds = vi.fn().mockReturnValue([]);
+    const selectElementsByIds = vi.fn();
     const host = { getState } as any;
-    const modeler = { viewport: { setViewport, fitViewport } } as any;
+    const modeler = {
+        viewport: { setViewport, fitViewport, getViewport },
+        rootElement: { setRootElementById, getRootElementId, onRootChanged },
+        selection: { getSelectedElementIds, selectElementsByIds },
+    } as any;
     return {
         manager: new WebviewStateManager(host, modeler),
         setViewport,
         fitViewport,
+        setRootElementById,
+        getRootElementId,
+        getViewport,
+        getSelectedElementIds,
+        selectElementsByIds,
     };
 }
 
@@ -66,5 +80,101 @@ describe("WebviewStateManager.restoreViewport", () => {
         expect(manager.restoreViewport()).toBe(false);
 
         expect(fitViewport).toHaveBeenCalledTimes(2);
+    });
+
+    it("restores root element before viewport on a tab-switch rebuild", () => {
+        const viewport = { x: 10, y: 20, width: 800, height: 600 };
+        const rootElementId = "SubProcess_1_plane";
+        const { manager, setRootElementById, setViewport } = setup({
+            viewport,
+            rootElementId,
+        });
+
+        manager.restoreViewport();
+
+        expect(setRootElementById).toHaveBeenCalledWith(rootElementId);
+        expect(setViewport).toHaveBeenCalledWith(viewport);
+
+        // Root must be set before the viewbox — viewbox coordinates are
+        // plane-relative.
+        const rootOrder = setRootElementById.mock.invocationCallOrder[0]!;
+        const viewportOrder = setViewport.mock.invocationCallOrder[0]!;
+        expect(rootOrder).toBeLessThan(viewportOrder);
+    });
+
+    it("skips root restore when no rootElementId is saved", () => {
+        const viewport = { x: 10, y: 20, width: 800, height: 600 };
+        const { manager, setRootElementById, setViewport } = setup({ viewport });
+
+        manager.restoreViewport();
+
+        expect(setRootElementById).not.toHaveBeenCalled();
+        expect(setViewport).toHaveBeenCalledWith(viewport);
+    });
+
+    it("falls back to viewbox-only when the sub-process was removed", () => {
+        const viewport = { x: 10, y: 20, width: 800, height: 600 };
+        const { manager, setRootElementById, setViewport } = setup({
+            viewport,
+            rootElementId: "removed_plane",
+        });
+        setRootElementById.mockReturnValue(false);
+
+        manager.restoreViewport();
+
+        expect(setRootElementById).toHaveBeenCalledWith("removed_plane");
+        expect(setViewport).toHaveBeenCalledWith(viewport);
+    });
+});
+
+describe("WebviewStateManager.captureViewState / applyViewState", () => {
+    it("round-trips the canvas view state", () => {
+        const {
+            manager,
+            getRootElementId,
+            getViewport,
+            getSelectedElementIds,
+            setRootElementById,
+            setViewport,
+            selectElementsByIds,
+        } = setup(undefined);
+
+        getRootElementId.mockReturnValue("SubProcess_1_plane");
+        getViewport.mockReturnValue({ x: 100, y: 200, width: 500, height: 300 });
+        getSelectedElementIds.mockReturnValue(["Task_1", "Task_2"]);
+
+        const snapshot = manager.captureViewState();
+        manager.applyViewState(snapshot);
+
+        expect(setRootElementById).toHaveBeenCalledWith("SubProcess_1_plane");
+        expect(setViewport).toHaveBeenCalledWith({ x: 100, y: 200, width: 500, height: 300 });
+        expect(selectElementsByIds).toHaveBeenCalledWith(["Task_1", "Task_2"]);
+    });
+
+    it("applies root before viewbox in applyViewState", () => {
+        const { manager, setRootElementById, setViewport, getRootElementId, getViewport } =
+            setup(undefined);
+
+        getRootElementId.mockReturnValue("SubProcess_1_plane");
+        getViewport.mockReturnValue({ x: 0, y: 0, width: 1000, height: 800 });
+
+        const snapshot = manager.captureViewState();
+        manager.applyViewState(snapshot);
+
+        const rootOrder = setRootElementById.mock.invocationCallOrder[0]!;
+        const viewportOrder = setViewport.mock.invocationCallOrder[0]!;
+        expect(rootOrder).toBeLessThan(viewportOrder);
+    });
+
+    it("handles capture with no drill-down (top-level process)", () => {
+        const { manager, getRootElementId, setRootElementById } = setup(undefined);
+        getRootElementId.mockReturnValue(undefined);
+
+        const snapshot = manager.captureViewState();
+        expect(snapshot.rootElementId).toBeUndefined();
+
+        manager.applyViewState(snapshot);
+        // setRootElementById(undefined) returns false — no plane switch
+        expect(setRootElementById).toHaveBeenCalledWith(undefined);
     });
 });

--- a/apps/bpmn-webview/src/app/state.ts
+++ b/apps/bpmn-webview/src/app/state.ts
@@ -1,5 +1,5 @@
 import { Command, Query, HostApi } from "@miragon/bpmn-modeler-shared";
-import { WebviewState } from "./webviewState";
+import { CanvasViewState, WebviewState } from "./webviewState";
 import { BpmnModeler } from "./modeler";
 
 const PANEL_SCROLL_CONTAINER = ".bio-properties-panel-scroll-container";
@@ -26,6 +26,10 @@ function isGroupOpen(group: HTMLElement): boolean {
  * 2. {@link restoreSelection}      — after element templates + settings applied
  * 3. {@link restorePanelUiState}   — after properties panel is rendered
  * 4. {@link startPersisting}       — subscribes to change events
+ *
+ * For mid-session re-imports (undo/redo, XML push, language switch), use
+ * {@link captureViewState} / {@link applyViewState} to snapshot and
+ * restore the drill-down plane, viewbox, and selection.
  */
 export class WebviewStateManager {
     /** Latches once {@link restoreViewport} has applied a viewbox. */
@@ -58,6 +62,17 @@ export class WebviewStateManager {
         }
 
         const saved = this.getSavedState();
+
+        // Restore the drill-down plane before the viewbox — viewbox
+        // coordinates are plane-relative, and applying them against the
+        // wrong root would pan to a nonsensical position. If the
+        // sub-process no longer exists (removed by an undo before the
+        // tab was revisited), setRootElementById returns false and the
+        // canvas stays on the top-level process root.
+        if (saved?.rootElementId) {
+            this.modeler.rootElement.setRootElementById(saved.rootElementId);
+        }
+
         this.viewportRestored = saved?.viewport
             ? this.modeler.viewport.setViewport(saved.viewport)
             : this.modeler.viewport.fitViewport();
@@ -124,6 +139,10 @@ export class WebviewStateManager {
     }
 
     startPersisting(): void {
+        this.modeler.rootElement.onRootChanged((rootElementId) => {
+            this.persistPartialState({ rootElementId });
+        });
+
         this.modeler.viewport.onViewportChanged((viewport) => {
             this.persistPartialState({ viewport });
         });
@@ -134,6 +153,31 @@ export class WebviewStateManager {
 
         this.subscribePanelScroll();
         this.subscribeGroupExpansion();
+    }
+
+    /**
+     * Snapshots the live canvas state — drill-down plane, viewbox, and
+     * selection — so it can be re-applied after a destructive re-import
+     * (undo/redo host push, language switch).
+     */
+    captureViewState(): CanvasViewState {
+        return {
+            rootElementId: this.modeler.rootElement.getRootElementId(),
+            viewport: this.modeler.viewport.getViewport(),
+            selectedElementIds: this.modeler.selection.getSelectedElementIds(),
+        };
+    }
+
+    /**
+     * Re-applies a previously captured view state after a re-import.
+     *
+     * Order matters: root first (viewbox coordinates are plane-relative),
+     * then viewbox, then selection.
+     */
+    applyViewState(snapshot: CanvasViewState): void {
+        this.modeler.rootElement.setRootElementById(snapshot.rootElementId);
+        this.modeler.viewport.setViewport(snapshot.viewport);
+        this.modeler.selection.selectElementsByIds(snapshot.selectedElementIds);
     }
 
     private getSavedState(): WebviewState | undefined {

--- a/apps/bpmn-webview/src/app/webviewState.ts
+++ b/apps/bpmn-webview/src/app/webviewState.ts
@@ -6,9 +6,22 @@ export interface ViewportData {
 }
 
 /**
+ * Snapshot of the canvas view that can be captured from the live
+ * modeler and re-applied after a re-import (undo/redo, XML push,
+ * language switch) to preserve the user's drill-down plane, viewport,
+ * and selection.
+ */
+export interface CanvasViewState {
+    rootElementId?: string;
+    viewport: ViewportData;
+    selectedElementIds: string[];
+}
+
+/**
  * Webview state persisted via the host's `setState` / `getState`.
  */
 export interface WebviewState {
+    rootElementId?: string;
     viewport?: ViewportData;
     selectedElementIds?: string[];
     panelScroll?: number;

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -111,12 +111,26 @@ document.addEventListener("visibilitychange", () => {
 const bpmnModeler = new BpmnModeler();
 
 /**
+ * Re-imports the XML while preserving the user's drill-down plane,
+ * viewbox, and selection. The snapshot is taken from the live canvas
+ * inside the debounced function so a burst of host pushes captures
+ * once, not from a half-imported intermediate.
+ */
+async function reloadXmlPreservingView(bpmn: string): Promise<void> {
+    const snapshot = stateManager?.captureViewState();
+    await openXml(bpmn);
+    if (snapshot) {
+        stateManager.applyViewState(snapshot);
+    }
+}
+
+/**
  * Debounce the update of the XML content to avoid too many updates.
  *
  * @param bpmn Latest BPMN XML string received from the backend.
  * @throws {NoModelerError} If the modeler is not available.
  */
-const debouncedUpdateXML = asyncDebounce(openXml, 100);
+const debouncedUpdateXML = asyncDebounce(reloadXmlPreservingView, 100);
 
 /**
  * Debounces the outbound document sync so a burst of model changes (e.g.
@@ -739,15 +753,15 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
 /**
  * Re-renders the diagram by exporting and re-importing the XML.
  *
- * Preserves the current viewport (position and zoom) so the user does not
- * lose their place.  Used after a language switch to force bpmn-js to
- * re-invoke `translate()` for all UI elements.
+ * Preserves the current drill-down plane, viewport, and selection so the
+ * user does not lose their place.  Used after a language switch to force
+ * bpmn-js to re-invoke `translate()` for all UI elements.
  */
 async function refreshDiagram(): Promise<void> {
     const xml = await bpmnModeler.exportDiagram();
-    const viewport = bpmnModeler.viewport.getViewport();
+    const snapshot = stateManager.captureViewState();
     await bpmnModeler.loadDiagram(xml);
-    bpmnModeler.viewport.setViewport(viewport);
+    stateManager.applyViewState(snapshot);
 }
 
 /**


### PR DESCRIPTION
**Issue**

Stepping into a collapsed sub-process was lost on every tab switch and on Ctrl+Z / Ctrl+Shift+Z — the canvas snapped back to the top-level process.

**Description**

The webview is rebuilt on tab switch and re-imports the XML on any host-side document change (undo/redo of the text document, side-by-side XML edit, language switch), and neither path restored the drill-down plane. Adds a `RootElementManager` (sibling of `ViewportManager`/`SelectionManager`) that reads/sets the canvas root and subscribes to `root.set`, persists `rootElementId` in `WebviewState`, and restores it *before* the viewbox because viewbox coordinates are plane-relative. Mid-session re-imports (`BpmnFileQuery` push, `refreshDiagram`) now snapshot root + viewbox + selection via `captureViewState`/`applyViewState` and re-apply them afterwards; a removed sub-process falls back gracefully to the process root.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created