### PR TITLE
fix(bpmn-webview): keep zoom stable across VS Code tab switches

### DIFF
--- a/apps/bpmn-webview/src/app/state.spec.ts
+++ b/apps/bpmn-webview/src/app/state.spec.ts
@@ -8,15 +8,19 @@ import { WebviewStateManager } from "./state";
  */
 function setup(savedState: unknown, applied = true) {
     const getState = vi.fn().mockReturnValue(savedState);
+    const updateState = vi.fn();
+    const setState = vi.fn();
     const setViewport = vi.fn().mockReturnValue(applied);
     const fitViewport = vi.fn().mockReturnValue(applied);
-    const getViewport = vi.fn().mockReturnValue({ x: 0, y: 0, width: 1000, height: 800 });
+    const getViewport = vi
+        .fn()
+        .mockReturnValue({ x: 5, y: 10, width: 400, height: 300, scale: 1.2 });
     const setRootElementById = vi.fn().mockReturnValue(true);
     const getRootElementId = vi.fn().mockReturnValue(undefined);
     const onRootChanged = vi.fn();
     const getSelectedElementIds = vi.fn().mockReturnValue([]);
     const selectElementsByIds = vi.fn();
-    const host = { getState } as any;
+    const host = { getState, updateState, setState } as any;
     const modeler = {
         viewport: { setViewport, fitViewport, getViewport },
         rootElement: { setRootElementById, getRootElementId, onRootChanged },
@@ -31,6 +35,7 @@ function setup(savedState: unknown, applied = true) {
         getViewport,
         getSelectedElementIds,
         selectElementsByIds,
+        updateState,
     };
 }
 
@@ -176,5 +181,27 @@ describe("WebviewStateManager.captureViewState / applyViewState", () => {
         manager.applyViewState(snapshot);
         // setRootElementById(undefined) returns false — no plane switch
         expect(setRootElementById).toHaveBeenCalledWith(undefined);
+    });
+});
+
+describe("WebviewStateManager.flushViewport", () => {
+    it("persists the current viewbox synchronously", () => {
+        const { manager, getViewport, updateState } = setup(undefined);
+
+        manager.flushViewport();
+
+        expect(getViewport).toHaveBeenCalledOnce();
+        expect(updateState).toHaveBeenCalledWith({
+            viewport: { x: 5, y: 10, width: 400, height: 300, scale: 1.2 },
+        });
+    });
+
+    it("skips persistence when the viewbox is degenerate", () => {
+        const { manager, getViewport, updateState } = setup(undefined);
+        getViewport.mockReturnValue({ x: NaN, y: NaN, width: NaN, height: NaN });
+
+        manager.flushViewport();
+
+        expect(updateState).not.toHaveBeenCalled();
     });
 });

--- a/apps/bpmn-webview/src/app/state.ts
+++ b/apps/bpmn-webview/src/app/state.ts
@@ -1,4 +1,4 @@
-import { Command, Query, HostApi } from "@miragon/bpmn-modeler-shared";
+import { Command, Query, HostApi, isUsableViewbox } from "@miragon/bpmn-modeler-shared";
 import { CanvasViewState, WebviewState } from "./webviewState";
 import { BpmnModeler } from "./modeler";
 
@@ -136,6 +136,19 @@ export class WebviewStateManager {
                 });
             }
         });
+    }
+
+    /**
+     * Writes the current viewport to persisted state immediately, bypassing the
+     * 100 ms debounce in {@link ViewportManager.onViewportChanged}. Called on
+     * `visibilitychange → hidden` so a tab switch right after a gesture does
+     * not lose the last position.
+     */
+    flushViewport(): void {
+        const viewport = this.modeler.viewport.getViewport();
+        if (isUsableViewbox(viewport)) {
+            this.persistPartialState({ viewport });
+        }
     }
 
     startPersisting(): void {

--- a/apps/bpmn-webview/src/app/viewport.spec.ts
+++ b/apps/bpmn-webview/src/app/viewport.spec.ts
@@ -28,7 +28,7 @@ function setup(inner: Rect, outer: { width: number; height: number }) {
     return { manager, viewbox, zoom, emitViewboxChanged };
 }
 
-type Rect = { x: number; y: number; width: number; height: number };
+type Rect = { x: number; y: number; width: number; height: number; scale?: number };
 
 /** Calls that *set* a viewbox, i.e. that passed a box to the accessor. */
 function setterCalls(viewbox: ReturnType<typeof vi.fn>): unknown[] {
@@ -159,6 +159,28 @@ describe("ViewportManager.setViewport", () => {
         expect(applied[0].width).toBeGreaterThan(0);
     });
 
+    it("restores the same zoom when outer differs from save-time size", () => {
+        const saveOuter = { width: 1200, height: 900 };
+        const restoreOuter = { width: 800, height: 600 };
+        const savedScale = 1.5;
+        const saved = {
+            x: 10,
+            y: 20,
+            width: saveOuter.width / savedScale,
+            height: saveOuter.height / savedScale,
+            scale: savedScale,
+        };
+        const { manager, viewbox } = setup(inner, restoreOuter);
+
+        expect(manager.setViewport(saved)).toBe(true);
+
+        const applied = setterCalls(viewbox).at(-1) as [Rect];
+        const appliedScale = restoreOuter.width / applied[0].width;
+        expect(appliedScale).toBeCloseTo(savedScale);
+        expect(applied[0].x).toBe(saved.x);
+        expect(applied[0].y).toBe(saved.y);
+    });
+
     it("applies nothing while the canvas is unsized", () => {
         const { manager, viewbox } = setup(inner, { width: 0, height: 0 });
 
@@ -171,16 +193,16 @@ describe("ViewportManager.setViewport", () => {
 describe("ViewportManager.onViewportChanged", () => {
     const inner = { x: 150, y: 80, width: 600, height: 300 };
 
-    it("reports a usable viewbox after the debounce", () => {
+    it("reports a usable viewbox with scale after the debounce", () => {
         vi.useFakeTimers();
         const { manager, emitViewboxChanged } = setup(inner, { width: 1000, height: 800 });
         const cb = vi.fn();
         manager.onViewportChanged(cb);
 
-        emitViewboxChanged({ x: 1, y: 2, width: 300, height: 200 });
+        emitViewboxChanged({ x: 1, y: 2, width: 300, height: 200, scale: 2.5 });
         vi.advanceTimersByTime(100);
 
-        expect(cb).toHaveBeenCalledWith({ x: 1, y: 2, width: 300, height: 200 });
+        expect(cb).toHaveBeenCalledWith({ x: 1, y: 2, width: 300, height: 200, scale: 2.5 });
         vi.useRealTimers();
     });
 

--- a/apps/bpmn-webview/src/app/viewport.ts
+++ b/apps/bpmn-webview/src/app/viewport.ts
@@ -28,8 +28,8 @@ export class ViewportManager {
      * Returns the current canvas viewbox (position and zoom level).
      */
     getViewport(): ViewportData {
-        const { x, y, width, height } = this.getService<any>("canvas").viewbox();
-        return { x, y, width, height };
+        const { x, y, width, height, scale } = this.getService<any>("canvas").viewbox();
+        return { x, y, width, height, scale };
     }
 
     /**
@@ -57,7 +57,21 @@ export class ViewportManager {
         if (!isUsableViewbox(viewport) || !this.isCanvasSized()) {
             return this.fitViewport();
         }
-        this.getService<any>("canvas").viewbox(viewport);
+        const canvas = this.getService<any>("canvas");
+        // The container size at restore time is not the size at save time
+        // (VS Code re-show / panel layout race), so zoom must be pinned
+        // explicitly rather than derived from width/height.
+        if (viewport.scale !== undefined && Number.isFinite(viewport.scale) && viewport.scale > 0) {
+            const { outer } = canvas.viewbox();
+            canvas.viewbox({
+                x: viewport.x,
+                y: viewport.y,
+                width: outer.width / viewport.scale,
+                height: outer.height / viewport.scale,
+            });
+        } else {
+            canvas.viewbox(viewport);
+        }
         return true;
     }
 
@@ -181,8 +195,8 @@ export class ViewportManager {
         this.getService<any>("eventBus").on("canvas.viewbox.changed", (event: any) => {
             clearTimeout(timer);
             timer = setTimeout(() => {
-                const { x, y, width, height } = event.viewbox;
-                const viewport = { x, y, width, height };
+                const { x, y, width, height, scale } = event.viewbox;
+                const viewport: ViewportData = { x, y, width, height, scale };
                 if (isUsableViewbox(viewport)) {
                     cb(viewport);
                 }

--- a/apps/bpmn-webview/src/app/webviewState.ts
+++ b/apps/bpmn-webview/src/app/webviewState.ts
@@ -3,6 +3,8 @@ export interface ViewportData {
     y: number;
     width: number;
     height: number;
+    /** Persisted so the exact zoom survives a container-size change on restore. */
+    scale?: number;
 }
 
 /**

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -101,6 +101,7 @@ function registerGlobalErrorHandlers(): void {
 document.addEventListener("visibilitychange", () => {
     if (document.visibilityState === "hidden") {
         void debouncedSendXmlChanges.flush();
+        stateManager?.flushViewport();
     }
 });
 


### PR DESCRIPTION
**Issue**

Since #1152 the viewport is fitted on a fresh open, discriminated by "no saved viewport in `getState()`". That discrimination holds on a VS Code tab switch (selection is restored, so the saved state is present), yet the diagram sometimes came back slightly zoomed out. IntelliJ, which never tears the page down, is unaffected.

**Description**

The persisted viewport was `{x, y, width, height}` and diagram-js derives the zoom from the container size at apply time (`min(outer.w/width, outer.h/height)`), so restoring while VS Code re-shows the iframe at a transient size — or before the properties panel is laid out — landed on a different zoom that then stuck. The viewport now also persists `scale`, and `setViewport` pins it explicitly so the restore is independent of the container size (legacy states without `scale` still take the old path). Additionally the viewport state is flushed on `visibilitychange → hidden`, so a tab switch right after a gesture no longer loses the last position to the 100 ms persist debounce. Tests cover the size-mismatch restore, the legacy path, `scale` reporting, and the flush.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
