### PR TITLE
chore(deps): bump @miragon/bpmnlint-plugin-rules to 0.10.0

### DIFF
--- a/libs/modeler-core/package.json
+++ b/libs/modeler-core/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@miragon/bpmn-modeler-shared": "workspace:*",
-    "@miragon/bpmnlint-plugin-rules": "0.2.0",
+    "@miragon/bpmnlint-plugin-rules": "0.10.0",
     "bpmn-js-differ": "3.2.0",
     "bpmn-moddle": "10.0.0",
     "bpmnlint": "11.13.0",

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
@@ -123,8 +123,7 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
 
         expect(result).toBe(true);
         expect(lintRunner.lint).toHaveBeenCalledWith(XML, EDITOR, {
-            extends: ["bpmnlint:recommended", "plugin:@miragon/rules/recommended"],
-            rules: { "@miragon/rules/flow-through-element": "warn" },
+            extends: ["bpmnlint:recommended", "plugin:@miragon/rules/recommended-for-modeling"],
         });
         expect(diagnostics.publish).toHaveBeenCalledWith(EDITOR, XML, RESULTS);
         expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith(undefined);
@@ -145,7 +144,7 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         expect(anchor).toBe(EDITOR);
         expect((config as { extends: string[] }).extends).toEqual([
             "bpmnlint:recommended",
-            "plugin:@miragon/rules/recommended",
+            "plugin:@miragon/rules/recommended-for-modeling",
             "plugin:camunda-compat/camunda-platform-7-24",
         ]);
         expect((config as { moddleExtensions: Record<string, unknown> }).moddleExtensions).toEqual({

--- a/libs/modeler-core/src/modeler/bpmn/service/DefaultBpmnlintConfigService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/DefaultBpmnlintConfigService.ts
@@ -7,23 +7,20 @@ import { Engine } from "@miragon/bpmn-modeler-shared";
  * validation for free (issue #1327). A workspace `.bpmnlintrc` — even `{}` — is
  * still nearest-config-wins and never reaches here.
  *
- * The layered config (`bpmnlint:recommended` + `plugin:@miragon/rules/recommended` + the
- * matching `plugin:camunda-compat/*` engine layer, with the engine's moddle
- * descriptor embedded) now comes from `@miragon/bpmnlint-plugin-rules`'
- * {@link getDefaultLintConfig}. All of it resolves from the bundled resolver in
- * {@link NodeBpmnLinter} (the workspace has none installed).
- *
- * On top of the package default, the Miragon `flow-through-element` rule — a
- * sequence flow routed through an unrelated shape's body — is switched on; the
- * other Miragon rules stay off (their package default).
+ * The layered config comes from `@miragon/bpmnlint-plugin-rules`'
+ * {@link getDefaultLintConfig}. We always request the `modeling` Miragon layer
+ * (`plugin:@miragon/rules/recommended-for-modeling` — layout hints at `warn`, id
+ * conventions off), decoupled from the engine so a Camunda diagram is not held to
+ * the stricter automation bar in the zero-config path. The engine still adds its
+ * `plugin:camunda-compat/*` deployability layer and typed moddle descriptor when
+ * given. All of it resolves from the bundled resolver in {@link NodeBpmnLinter}
+ * (the workspace has none installed).
  */
 export class DefaultBpmnlintConfigService {
     async build(platform: Engine | undefined): Promise<Record<string, unknown>> {
-        const config = getDefaultLintConfig({ engine: platform }) as Record<string, unknown>;
-        const rules = (config.rules ?? {}) as Record<string, unknown>;
-        return {
-            ...config,
-            rules: { ...rules, "@miragon/rules/flow-through-element": "warn" },
-        };
+        return getDefaultLintConfig({ engine: platform, preset: "modeling" }) as Record<
+            string,
+            unknown
+        >;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3634,7 +3634,7 @@ __metadata:
   resolution: "@miragon/bpmn-modeler-core@workspace:libs/modeler-core"
   dependencies:
     "@miragon/bpmn-modeler-shared": "workspace:*"
-    "@miragon/bpmnlint-plugin-rules": "npm:0.2.0"
+    "@miragon/bpmnlint-plugin-rules": "npm:0.10.0"
     "@types/node": "npm:26.1.2"
     "@vitest/coverage-v8": "npm:4.1.9"
     bpmn-js-differ: "npm:3.2.0"
@@ -3828,9 +3828,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@miragon/bpmnlint-plugin-rules@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@miragon/bpmnlint-plugin-rules@npm:0.2.0"
+"@miragon/bpmnlint-plugin-rules@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@miragon/bpmnlint-plugin-rules@npm:0.10.0"
   dependencies:
     bpmnlint-plugin-camunda-compat: "npm:2.59.2"
     bpmnlint-utils: "npm:1.1.1"
@@ -3838,7 +3838,7 @@ __metadata:
     zeebe-bpmn-moddle: "npm:1.17.0"
   peerDependencies:
     bpmnlint: ">=11"
-  checksum: 10c0/4b2f6ff5c106f9b42df5b318da9df70126acfe992b6647bb0d29b5beb7b858b0953a82856016f7aa2382b1c63b7d09f34fa695a5852684596d098680e847b099
+  checksum: 10c0/ce196d4acb336bf49376602b134fe5fb25a0016b4b3bbb35fc27d72947b45c7f0e49e18341194c121a13028fc647a08b9977365398bd644346b38188425f10bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Updates the modeler's Miragon lint rules to **0.10.0** and always applies the **modeling** preset in the zero-config lint path.

### What 0.10.0 brings
- **New layout rules:** `flow-connection-side`, `flow-crossing`, `flow-orthogonal`, `flow-target-alignment`.
- **Preset split:** `plugin:@miragon/rules/recommended` is gone; there are now `recommended-for-modeling` (layout hints at `warn`, id conventions off) and `recommended-for-automation` (every Miragon rule stricter).
- **Preset decoupled from engine:** `getDefaultLintConfig({ engine, preset })` — the Miragon opinion layer can now be chosen independently of the engine's deployability layer.

### Changes in this repo
- Bump dependency in `libs/modeler-core/package.json` (+ `yarn.lock`).
- `DefaultBpmnlintConfigService` now calls `getDefaultLintConfig({ engine, preset: "modeling" })`. A Camunda (c7/c8) diagram keeps its `camunda-compat` deployability layer + typed moddle, but is linted against the relaxed **modeling** opinion layer instead of the stricter automation bar. The now-redundant explicit `flow-through-element: "warn"` override is dropped.
- Update `BpmnLintConfigService.spec.ts` to expect `recommended-for-modeling` (including for c7/c8).

### Behavioral effect
Documents without a `.bpmnlintrc` get the layout rules at `warn`; ID-convention rules (`element-id-naming`, `no-generated-ids`) stay **off** even for Camunda files. Deployability checks for c7/c8 are unchanged.

### Verification
- `yarn workspace @miragon/bpmn-modeler-core build` ✅
- Full test suite: **1600 passed / 138 files** ✅
- `yarn format:check` ✅