### PR TITLE
feat(editor): let users turn BPMN linting off

### DIFF
--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
@@ -1,4 +1,4 @@
-import { LintResults } from "@miragon/bpmn-modeler-shared";
+import { LintResults, SetLintingEnabledCommand } from "@miragon/bpmn-modeler-shared";
 
 /**
  * The subset of `bpmn-js-bpmnlint`'s `linting` module this service drives. The
@@ -13,6 +13,17 @@ interface Linting {
     toggle(active: boolean): void;
 }
 
+/** The webview→host channel registered as the `vsCodeBridge` DI value in bootstrap. */
+interface VsCodeBridge {
+    postMessage(message: unknown): void;
+}
+
+type Translate = (template: string) => string;
+
+// A slashed circle, painted in `currentColor` so it inherits the chip's text
+// colour like the vendor lint icon does.
+const OFF_ICON = `<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="6"/><line x1="4" y1="4" x2="12" y2="12"/></svg>`;
+
 /**
  * bpmn-js DI service (registered by {@link LintModule}) that renders
  * host-computed bpmnlint results in the canvas. The extension host now runs the
@@ -24,13 +35,31 @@ interface Linting {
  * browser-side `Linter`. The module's own `update()` — fired on import, element
  * changes, and toggles — then diffs and draws the overlays exactly as before, so
  * no overlay/rendering code changes.
+ *
+ * It also owns the in-canvas **disable affordance**: an "off" button beside the
+ * lint summary pill (so the hint advertises that it can be switched off), and a
+ * muted "Linting off" chip shown in its place once disabled — the entry points a
+ * non-technical user needs, since they may never open VS Code settings. Both
+ * write the choice back through the host, which re-lints and pushes the new
+ * state down ({@link render} / {@link renderDisabled}); the webview never flips
+ * its own overlays optimistically.
  */
 export class LintConfigService {
-    static $inject = ["linting"];
+    static $inject = ["linting", "vsCodeBridge", "translate"];
 
     private results: LintResults = {};
 
-    constructor(private readonly linting: Linting) {
+    private toolbar?: HTMLElement;
+
+    private offButton?: HTMLButtonElement;
+
+    private disabledChip?: HTMLElement;
+
+    constructor(
+        private readonly linting: Linting,
+        private readonly bridge: VsCodeBridge,
+        private readonly translate: Translate,
+    ) {
         // Replace the browser-side lint run with the host's precomputed results.
         // `update()` calls `this.lint()`; returning the stored results makes every
         // relint (import.done / elements.changed) repaint them until the host,
@@ -44,6 +73,7 @@ export class LintConfigService {
      * experience identical to before linting moved to the host.
      */
     render(results: LintResults | null): void {
+        this.hideDisabledChip();
         if (!results) {
             this.results = {};
             if (this.linting.isActive()) {
@@ -51,6 +81,7 @@ export class LintConfigService {
                 this.linting.toggle(false);
             }
             document.body.classList.remove("bpmnlint-active");
+            this.hideOffButton();
             return;
         }
 
@@ -61,6 +92,125 @@ export class LintConfigService {
         } else {
             // Activating fires `linting.toggle`, which triggers the first `update()`.
             this.linting.toggle(true);
+        }
+        this.showOffButton();
+    }
+
+    /**
+     * Renders the **user-disabled** state (distinct from the inactive `null`
+     * above): clears the overlays like an inactive linter, but shows a muted
+     * chip so the user can turn linting back on from inside the canvas — the
+     * summary pill they would otherwise click is gone.
+     */
+    renderDisabled(): void {
+        this.results = {};
+        if (this.linting.isActive()) {
+            this.linting.toggle(false);
+        }
+        document.body.classList.remove("bpmnlint-active");
+        this.hideOffButton();
+        this.showDisabledChip();
+    }
+
+    /**
+     * The bpmn-js canvas container, located via the vendor summary pill (created
+     * on module init, so it is present from the first render even while hidden).
+     */
+    private pill(): HTMLElement | null {
+        return document.querySelector<HTMLElement>(".bjsl-button");
+    }
+
+    /**
+     * Wraps the vendor pill in a flex row so an "off" button can sit beside it.
+     * Idempotent: the vendor only rewrites the pill's `innerHTML`/classes on
+     * relint, never re-parents it, so the wrapper and our button survive.
+     */
+    private ensureToolbar(): HTMLElement | null {
+        const pill = this.pill();
+        if (!pill || !pill.parentElement) {
+            return null;
+        }
+        if (!this.toolbar) {
+            this.toolbar = document.createElement("div");
+            this.toolbar.className = "lint-toolbar";
+        }
+        if (pill.parentElement !== this.toolbar) {
+            pill.parentElement.appendChild(this.toolbar);
+            this.toolbar.appendChild(pill);
+        }
+        return this.toolbar;
+    }
+
+    private showOffButton(): void {
+        const toolbar = this.ensureToolbar();
+        if (!toolbar) {
+            return;
+        }
+        if (!this.offButton) {
+            const button = document.createElement("button");
+            button.type = "button";
+            button.className = "lint-off-button";
+            button.innerHTML = OFF_ICON;
+            const label = this.translate("Turn off linting");
+            button.title = label;
+            button.setAttribute("aria-label", label);
+            button.addEventListener("click", () => {
+                this.bridge.postMessage(new SetLintingEnabledCommand(false));
+            });
+            this.offButton = button;
+        }
+        if (this.offButton.parentElement !== toolbar) {
+            toolbar.appendChild(this.offButton);
+        }
+        this.offButton.hidden = false;
+    }
+
+    private hideOffButton(): void {
+        if (this.offButton) {
+            this.offButton.hidden = true;
+        }
+    }
+
+    private showDisabledChip(): void {
+        const pill = this.pill();
+        const container =
+            pill?.parentElement === this.toolbar
+                ? this.toolbar?.parentElement
+                : pill?.parentElement;
+        if (!container) {
+            return;
+        }
+        if (!this.disabledChip) {
+            const chip = document.createElement("div");
+            chip.className = "lint-disabled-chip";
+
+            const text = document.createElement("span");
+            text.className = "lint-disabled-text";
+            text.textContent = this.translate("Linting off");
+
+            const enable = document.createElement("button");
+            enable.type = "button";
+            enable.className = "lint-enable-button";
+            enable.textContent = this.translate("Enable");
+            enable.addEventListener("click", () => {
+                this.bridge.postMessage(new SetLintingEnabledCommand(true));
+            });
+
+            chip.appendChild(text);
+            chip.appendChild(enable);
+            this.disabledChip = chip;
+        }
+        if (this.disabledChip.parentElement !== container) {
+            container.appendChild(this.disabledChip);
+        }
+        this.disabledChip.hidden = false;
+        document.body.classList.add("bpmnlint-disabled");
+    }
+
+    private hideDisabledChip(): void {
+        document.body.classList.remove("bpmnlint-disabled");
+        if (this.disabledChip) {
+            this.disabledChip.hidden = true;
         }
     }
 }

--- a/apps/bpmn-webview/src/app/bpmnlint/bpmnlint.css
+++ b/apps/bpmn-webview/src/app/bpmnlint/bpmnlint.css
@@ -203,35 +203,3 @@ body.bpmnlint-disabled .lint-enable-button {
 body.bpmnlint-disabled .lint-enable-button:hover {
     text-decoration: underline;
 }
-
-/**
- * One-time nudge pointing first-time users at the off-switch. Shown once (a
- * webview-state flag guards it), auto-dismissed, and anchored just above the
- * lint toolbar with a small downward caret.
- */
-.lint-nudge {
-    position: absolute;
-    bottom: 52px;
-    left: 50%;
-    transform: translateX(-50%);
-    max-width: 230px;
-    padding: 8px 10px;
-    background-color: #1f1f1f;
-    color: #fff;
-    border-radius: 6px;
-    font-size: 12px;
-    line-height: 1.4;
-    text-align: center;
-    z-index: 200;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
-}
-
-.lint-nudge::after {
-    content: "";
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border: 5px solid transparent;
-    border-top-color: #1f1f1f;
-}

--- a/apps/bpmn-webview/src/app/bpmnlint/bpmnlint.css
+++ b/apps/bpmn-webview/src/app/bpmnlint/bpmnlint.css
@@ -98,3 +98,140 @@ body.bpmnlint-active .bjsl-id-hint {
     font-weight: 500;
     border-radius: 4px;
 }
+
+/**
+ * Disable affordance. The summary pill only toggles overlay visibility, so the
+ * "turn linting off" entry point is a small button wrapped into a flex row
+ * beside it; once disabled, a muted chip takes its place so the user can turn it
+ * back on without leaving the canvas. The canvas is white in every theme, so the
+ * palette matches the light chip above and needs no dark-mode variant.
+ *
+ * The toolbar hosts the vendor pill, whose own absolute centering is neutralised
+ * so it flows inside the row; the row itself carries the bottom-centre anchor.
+ */
+.lint-toolbar {
+    display: none;
+}
+
+body.bpmnlint-active .lint-toolbar {
+    position: absolute;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    z-index: 100;
+}
+
+body.bpmnlint-active .lint-toolbar .bjsl-button {
+    position: static;
+    bottom: auto;
+    left: auto;
+    transform: none;
+}
+
+body.bpmnlint-active .lint-off-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    background-color: #f7f7f7;
+    color: #666;
+    cursor: pointer;
+    transition:
+        background-color 0.12s ease,
+        border-color 0.12s ease,
+        color 0.12s ease;
+}
+
+body.bpmnlint-active .lint-off-button:hover {
+    background-color: #f7d9d7;
+    border-color: #f1c2c0;
+    color: #c0392b;
+}
+
+body.bpmnlint-active .lint-off-button:focus-visible {
+    outline: 2px solid rgba(0, 120, 212, 0.7);
+    outline-offset: 1px;
+}
+
+.lint-off-button[hidden] {
+    display: none;
+}
+
+.lint-disabled-chip {
+    display: none;
+}
+
+body.bpmnlint-disabled .lint-disabled-chip {
+    position: absolute;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px 4px 12px;
+    border: 1px solid #e4e4e4;
+    border-radius: 6px;
+    background-color: #f4f4f4;
+    color: #777;
+    font-size: 12px;
+    line-height: 1.4;
+    z-index: 100;
+}
+
+.lint-disabled-chip[hidden] {
+    display: none;
+}
+
+body.bpmnlint-disabled .lint-enable-button {
+    border: none;
+    background: transparent;
+    padding: 2px 4px;
+    color: #0b6cbf;
+    font-weight: 600;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+body.bpmnlint-disabled .lint-enable-button:hover {
+    text-decoration: underline;
+}
+
+/**
+ * One-time nudge pointing first-time users at the off-switch. Shown once (a
+ * webview-state flag guards it), auto-dismissed, and anchored just above the
+ * lint toolbar with a small downward caret.
+ */
+.lint-nudge {
+    position: absolute;
+    bottom: 52px;
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: 230px;
+    padding: 8px 10px;
+    background-color: #1f1f1f;
+    color: #fff;
+    border-radius: 6px;
+    font-size: 12px;
+    line-height: 1.4;
+    text-align: center;
+    z-index: 200;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+
+.lint-nudge::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: #1f1f1f;
+}

--- a/apps/bpmn-webview/src/app/host.ts
+++ b/apps/bpmn-webview/src/app/host.ts
@@ -233,14 +233,10 @@ class MockHost extends MockHostApi<StateType, MessageType> {
                 break;
             }
             case message.type === "GetBpmnlintConfigCommand": {
-                // Standalone browser preview: no extension host runs the linter,
-                // so report "no results" and linting stays inactive.
                 dispatchEvent(new BpmnlintResultsQuery(null));
                 break;
             }
             case message.type === "SetLintingEnabledCommand": {
-                // No settings backend in the browser preview; linting is inactive
-                // here anyway, so there is nothing to toggle.
                 console.debug("[DEBUG] SetLintingEnabledCommand", message);
                 break;
             }

--- a/apps/bpmn-webview/src/app/host.ts
+++ b/apps/bpmn-webview/src/app/host.ts
@@ -238,6 +238,12 @@ class MockHost extends MockHostApi<StateType, MessageType> {
                 dispatchEvent(new BpmnlintResultsQuery(null));
                 break;
             }
+            case message.type === "SetLintingEnabledCommand": {
+                // No settings backend in the browser preview; linting is inactive
+                // here anyway, so there is nothing to toggle.
+                console.debug("[DEBUG] SetLintingEnabledCommand", message);
+                break;
+            }
             default: {
                 throw new Error(`Unknown message type: ${(message as MessageType).type}`);
             }

--- a/apps/bpmn-webview/src/app/webviewState.ts
+++ b/apps/bpmn-webview/src/app/webviewState.ts
@@ -28,6 +28,4 @@ export interface WebviewState {
     selectedElementIds?: string[];
     panelScroll?: number;
     expandedGroupIndexes?: number[];
-    /** Set once the "you can turn linting off here" nudge has been shown. */
-    lintOffHintSeen?: boolean;
 }

--- a/apps/bpmn-webview/src/app/webviewState.ts
+++ b/apps/bpmn-webview/src/app/webviewState.ts
@@ -28,4 +28,6 @@ export interface WebviewState {
     selectedElementIds?: string[];
     panelScroll?: number;
     expandedGroupIndexes?: number[];
+    /** Set once the "you can turn linting off here" nudge has been shown. */
+    lintOffHintSeen?: boolean;
 }

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -111,48 +111,6 @@ document.addEventListener("visibilitychange", () => {
  */
 const bpmnModeler = new BpmnModeler();
 
-/** Whether the one-time "you can turn linting off" nudge has already been shown. */
-function hasSeenLintOffHint(): boolean {
-    try {
-        return host.getState()?.lintOffHintSeen === true;
-    } catch {
-        return false;
-    }
-}
-
-function markLintOffHintSeen(): void {
-    try {
-        host.updateState({ lintOffHintSeen: true });
-    } catch {
-        // No prior state yet — nothing to preserve, so seed it with just the flag.
-        host.setState({ lintOffHintSeen: true });
-    }
-}
-
-/**
- * Shows a subtle, self-dismissing callout above the lint toolbar the first time
- * linting surfaces, telling design-only users they can turn it off there. Guarded
- * by a persisted flag so it appears once, not on every relint or reopen.
- */
-function maybeShowLintOffNudge(): void {
-    if (hasSeenLintOffHint()) {
-        return;
-    }
-    const toolbar = document.querySelector<HTMLElement>(".lint-toolbar");
-    const anchor = toolbar?.parentElement;
-    if (!anchor) {
-        return;
-    }
-    markLintOffHintSeen();
-    const nudge = document.createElement("div");
-    nudge.className = "lint-nudge";
-    nudge.textContent = i18n.translate("Not automating? You can turn linting off here.");
-    anchor.appendChild(nudge);
-    const dismiss = () => nudge.remove();
-    nudge.addEventListener("click", dismiss);
-    window.setTimeout(dismiss, 6000);
-}
-
 /**
  * Re-imports the XML while preserving the user's drill-down plane,
  * viewbox, and selection. The snapshot is taken from the live canvas
@@ -653,9 +611,6 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
             try {
                 const query = message.data as BpmnlintResultsQuery;
                 bpmnModeler.getService<LintConfigService>("bpmnLintConfig").render(query.results);
-                if (query.results) {
-                    maybeShowLintOffNudge();
-                }
             } catch (error: any) {
                 host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -111,6 +111,48 @@ document.addEventListener("visibilitychange", () => {
  */
 const bpmnModeler = new BpmnModeler();
 
+/** Whether the one-time "you can turn linting off" nudge has already been shown. */
+function hasSeenLintOffHint(): boolean {
+    try {
+        return host.getState()?.lintOffHintSeen === true;
+    } catch {
+        return false;
+    }
+}
+
+function markLintOffHintSeen(): void {
+    try {
+        host.updateState({ lintOffHintSeen: true });
+    } catch {
+        // No prior state yet — nothing to preserve, so seed it with just the flag.
+        host.setState({ lintOffHintSeen: true });
+    }
+}
+
+/**
+ * Shows a subtle, self-dismissing callout above the lint toolbar the first time
+ * linting surfaces, telling design-only users they can turn it off there. Guarded
+ * by a persisted flag so it appears once, not on every relint or reopen.
+ */
+function maybeShowLintOffNudge(): void {
+    if (hasSeenLintOffHint()) {
+        return;
+    }
+    const toolbar = document.querySelector<HTMLElement>(".lint-toolbar");
+    const anchor = toolbar?.parentElement;
+    if (!anchor) {
+        return;
+    }
+    markLintOffHintSeen();
+    const nudge = document.createElement("div");
+    nudge.className = "lint-nudge";
+    nudge.textContent = i18n.translate("Not automating? You can turn linting off here.");
+    anchor.appendChild(nudge);
+    const dismiss = () => nudge.remove();
+    nudge.addEventListener("click", dismiss);
+    window.setTimeout(dismiss, 6000);
+}
+
 /**
  * Re-imports the XML while preserving the user's drill-down plane,
  * viewbox, and selection. The snapshot is taken from the live canvas
@@ -611,6 +653,17 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
             try {
                 const query = message.data as BpmnlintResultsQuery;
                 bpmnModeler.getService<LintConfigService>("bpmnLintConfig").render(query.results);
+                if (query.results) {
+                    maybeShowLintOffNudge();
+                }
+            } catch (error: any) {
+                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+            }
+            break;
+        }
+        case queryOrCommand.type === "BpmnLintDisabledQuery": {
+            try {
+                bpmnModeler.getService<LintConfigService>("bpmnLintConfig").renderDisabled();
             } catch (error: any) {
                 host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }

--- a/apps/modeler-bridge/src/adapters.ts
+++ b/apps/modeler-bridge/src/adapters.ts
@@ -453,6 +453,10 @@ export class RpcStatusBar implements StatusBarPort {
         /* not supported yet for intellij */
     }
 
+    showBpmnlintDisabled(): void {
+        /* not supported yet for intellij */
+    }
+
     showBpmnlintNoConfig(): void {
         /* not supported yet for intellij */
     }

--- a/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
+++ b/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
@@ -35,6 +35,7 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
         deps.statusBar,
         deps.notifier,
         new DefaultBpmnlintConfigService(),
+        deps.settings,
     );
 
     // The webview posts this once on load (fire-and-forget, not part of the

--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -521,6 +521,14 @@ export class BridgeSettings implements SettingsPort {
         return this.snapshot.language;
     }
     /**
+     * IntelliJ has no linting-off toggle yet (out of scope), so linting stays on
+     * in the bridge — the VS Code / standalone `linting.enabled` setting drives
+     * the opt-out on those hosts.
+     */
+    getLintingEnabled(): boolean {
+        return true;
+    }
+    /**
      * Whether to ship the Camunda SPIN globals (`S`/`JSON`) and the
      * `SpinJsonNode` member table to the host. The gate lives here in the bridge
      * (single source) so the thin Kotlin completion contributor needs no toggle

--- a/apps/vscode-plugin/README.md
+++ b/apps/vscode-plugin/README.md
@@ -81,6 +81,12 @@ the decision is that".
   colour coding (added / removed / changed / moved) via
   [`bpmn-js-differ`](https://github.com/bpmn-io/bpmn-js-differ), synchronized
   pan/zoom, and a prev/next change navigator.
+- **Linting** — diagrams are checked with [bpmnlint](https://github.com/bpmn-io/bpmnlint)
+  (a bundled default, or a `.bpmnlintrc` found in your workspace); findings show as
+  hints on the canvas, in the **Problems** panel, and in the status bar. Only
+  drawing processes, not automating them? Turn linting off — for all your files —
+  from the switch on the lint hint, the **BPMN Modeler: Toggle Linting** command,
+  the status-bar badge, or the `miragon.bpmnModeler.linting.enabled` setting.
 - **Export** — copy the current diagram to the clipboard as SVG, or save an SVG
   next to the source file, via the SVG commands below.
 - **Multi-language UI** — palette, context pad, and properties panel available
@@ -99,6 +105,7 @@ Search for "BPMN Modeler" in the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`
 | BPMN Modeler: Change Engine Version       |                | Switch between engine versions (within a platform)               |
 | BPMN Modeler: Migrate All BPMN Diagrams   |                | Switch the engine versions of all BPMN diagrams in the workspace |
 | BPMN Modeler: Change Modeler Language     |                | Change the UI language of the modeler                            |
+| BPMN Modeler: Toggle Linting              |                | Turn BPMN linting on or off (applies to all files)               |
 | BPMN Modeler: Toggle Standard Text Editor | `Ctrl+Shift+E` | Open the XML text editor next to the BPMN modeler                |
 | BPMN Modeler: Display Logging Information |                | Open a console showing modeler log output                        |
 
@@ -113,6 +120,7 @@ Search for "BPMN Modeler" in Settings (`Ctrl+,` / `Cmd+,`).
 | Setting                                         | Default                     | Description                                                             |
 |-------------------------------------------------|-----------------------------|-------------------------------------------------------------------------|
 | `miragon.bpmnModeler.configFolder`              | `.camunda`                  | Folder name used for element template and payload file discovery        |
+| `miragon.bpmnModeler.linting.enabled`           | `true`                      | Run BPMN linting; turn off to hide all lint hints (design-only users)   |
 | `miragon.bpmnModeler.language`                  | `en`                        | UI language for the modeler (e.g. `de`, `fr`, `zh-Hans`)                |
 | `miragon.bpmnModeler.colorTheme`                | `automatic`                 | Color theme for the BPMN canvas (`automatic` or `light`)                |
 | `miragon.bpmnModeler.favouriteBpmnElements`     | `["bpmn:ServiceTask", ...]` | BPMN element types pinned at the top of the append menu palette (max 6) |

--- a/apps/vscode-plugin/package.json
+++ b/apps/vscode-plugin/package.json
@@ -271,6 +271,11 @@
                 "category": "Miragon BPMN Modeler"
             },
             {
+                "command": "bpmn-modeler.toggleLinting",
+                "title": "Toggle Linting",
+                "category": "Miragon BPMN Modeler"
+            },
+            {
                 "command": "bpmn-modeler.addMarketplace",
                 "title": "Add Marketplace",
                 "category": "Miragon BPMN Modeler"
@@ -442,6 +447,12 @@
                     "type": "boolean",
                     "default": true,
                     "markdownDescription": "Offer Camunda SPIN globals (`S(…)`, `JSON(…)`) and SpinJsonNode member completion in inline Camunda 7 scripts. Disable if your project does not have camunda-spin on the classpath."
+                },
+                "miragon.bpmnModeler.linting.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "scope": "application",
+                    "markdownDescription": "Run BPMN linting (in-canvas hints, Problems entries, and the status-bar badge). Turn this off if you only design processes and do not want automation/execution rules. You can also toggle it from the lint hint in the modeler or via the **BPMN: Toggle Linting** command."
                 },
                 "miragon.bpmnModeler.configFolder": {
                     "type": "string",

--- a/apps/vscode-plugin/src/composition/editorFeature.ts
+++ b/apps/vscode-plugin/src/composition/editorFeature.ts
@@ -43,6 +43,7 @@ import {
     resyncScriptTasksHandler,
     getPropertiesPanelStateHandler,
     setPropertiesPanelStateHandler,
+    setLintingEnabledHandler,
     getClipboardHandler,
     setClipboardHandler,
     getTextClipboardHandler,
@@ -138,6 +139,7 @@ export function register(
         deps.statusBar,
         deps.notifier,
         new DefaultBpmnlintConfigService(),
+        deps.vsSettings,
     );
     const clipboardMediator = new BpmnClipboardMediator(
         deps.editorStore,
@@ -191,6 +193,7 @@ export function register(
         .on("GetBpmnlintConfigCommand", getBpmnlintConfigHandler(lintConfigSvc))
         .on("GetBpmnModelerSettingCommand", getBpmnModelerSettingHandler(settingsBroadcaster))
         .on("GetBpmnModelerSettingCommand", resyncScriptTasksHandler(scriptTaskSvc))
+        .on("SetLintingEnabledCommand", setLintingEnabledHandler())
         .on("GetPropertiesPanelStateCommand", getPropertiesPanelStateHandler(panelSvc))
         .on("SetPropertiesPanelStateCommand", setPropertiesPanelStateHandler(panelSvc))
         .on("GetClipboardCommand", getClipboardHandler(clipboardMediator))

--- a/apps/vscode-plugin/src/manifest.contract.spec.ts
+++ b/apps/vscode-plugin/src/manifest.contract.spec.ts
@@ -24,6 +24,7 @@ import {
     RELOAD_MODELER_CMD,
     SAVE_SVG_CMD,
     TOGGLE_CMD,
+    TOGGLE_LINTING_CMD,
 } from "./modeler/bpmn/controller/CommandController";
 import {
     COMPARE_SELECTED_CMD,
@@ -72,6 +73,7 @@ const CODE_COMMAND_IDS = [
     CHANGE_ENGINE_VERSION_CMD,
     MIGRATE_ALL_CMD,
     CHANGE_LANGUAGE_CMD,
+    TOGGLE_LINTING_CMD,
     NEW_BPMN_MODEL_CMD,
     NEW_DMN_MODEL_CMD,
     RELOAD_MODELER_CMD,

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/CommandController.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/CommandController.ts
@@ -42,6 +42,8 @@ export const CHANGE_ENGINE_VERSION_CMD = "bpmn-modeler.changeEngineVersion";
 export const MIGRATE_ALL_CMD = "bpmn-modeler.migrateAllDiagrams";
 // VS Code command ID for changing the modeler language.
 export const CHANGE_LANGUAGE_CMD = "bpmn-modeler.changeLanguage";
+// VS Code command ID for turning BPMN linting on/off (the design-only opt-out).
+export const TOGGLE_LINTING_CMD = "bpmn-modeler.toggleLinting";
 // VS Code command ID for scaffolding a new BPMN model.
 export const NEW_BPMN_MODEL_CMD = "bpmn-modeler.newBpmnModel";
 // VS Code command ID for scaffolding a new DMN model.
@@ -96,6 +98,7 @@ export class CommandController {
             commands.registerCommand(CHANGE_ENGINE_VERSION_CMD, this.changeEngineVersion, this),
             commands.registerCommand(MIGRATE_ALL_CMD, this.migrateAllDiagrams, this),
             commands.registerCommand(CHANGE_LANGUAGE_CMD, this.changeLanguage, this),
+            commands.registerCommand(TOGGLE_LINTING_CMD, this.toggleLinting, this),
             commands.registerCommand(NEW_BPMN_MODEL_CMD, this.newBpmnModel, this),
             commands.registerCommand(NEW_DMN_MODEL_CMD, this.newDmnModel, this),
             commands.registerCommand(RELOAD_MODELER_CMD, this.reloadModeler, this),
@@ -181,6 +184,22 @@ export class CommandController {
             // Breadcrumb: a language switch changes UI strings across the modeler,
             // so record it to explain later "why is the panel in German?" reports.
             this.notifier.logInfo(`Modeler language changed to ${picked.description}`);
+        });
+    }
+
+    /**
+     * Flips `miragon.bpmnModeler.linting.enabled` (default on) at Global (User)
+     * scope — the design-only opt-out. Reachable from the command palette and
+     * the "BPMNlint: off" status-bar badge; the webview pill writes the same
+     * setting directly. The config change re-lints every open editor, so no
+     * webview message is sent from here.
+     */
+    toggleLinting(): Promise<void> {
+        return this.logAndRethrow(async () => {
+            const config = workspace.getConfiguration("miragon.bpmnModeler");
+            const enabled = config.get<boolean>("linting.enabled") ?? true;
+            await config.update("linting.enabled", !enabled, ConfigurationTarget.Global);
+            this.notifier.logInfo(`BPMN linting ${!enabled ? "enabled" : "disabled"}`);
         });
     }
 

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.spec.ts
@@ -66,7 +66,7 @@ function createServices(watcher: WatcherResult) {
 }
 
 describe("BpmnlintParticipant", () => {
-    it("re-discovers the config only when the configFolder setting changes", async () => {
+    it("re-lints when the configFolder or linting.enabled setting changes, but not on others", async () => {
         const { lintSvc, locator, statusBar, notifier } = createServices({
             disposables: [],
             errors: [],
@@ -80,6 +80,9 @@ describe("BpmnlintParticipant", () => {
 
         captured.settingChange?.(settingChange("miragon.bpmnModeler.configFolder"), EDITOR_ID);
         expect(lintSvc.setBpmnlintConfig).toHaveBeenCalledWith(EDITOR_ID, false);
+
+        captured.settingChange?.(settingChange("miragon.bpmnModeler.linting.enabled"), EDITOR_ID);
+        expect(lintSvc.setBpmnlintConfig).toHaveBeenCalledTimes(2);
     });
 
     it("joins watcher disposables to the session bag", async () => {

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.ts
@@ -40,7 +40,12 @@ export class BpmnlintParticipant implements EditorSessionParticipant {
 
     async onResolve(session: EditorSessionContext): Promise<void> {
         session.onSettingChange((event, editorId) => {
-            if (event.affectsConfiguration("miragon.bpmnModeler.configFolder")) {
+            if (
+                event.affectsConfiguration("miragon.bpmnModeler.configFolder") ||
+                // Toggling linting on/off must re-run the pass: off pushes the
+                // disabled state and clears diagnostics, on re-lints from scratch.
+                event.affectsConfiguration("miragon.bpmnModeler.linting.enabled")
+            ) {
                 this.lintSvc.setBpmnlintConfig(editorId, session.panel.active);
             }
         });

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.ts
@@ -42,8 +42,6 @@ export class BpmnlintParticipant implements EditorSessionParticipant {
         session.onSettingChange((event, editorId) => {
             if (
                 event.affectsConfiguration("miragon.bpmnModeler.configFolder") ||
-                // Toggling linting on/off must re-run the pass: off pushes the
-                // disabled state and clears diagnostics, on re-lints from scratch.
                 event.affectsConfiguration("miragon.bpmnModeler.linting.enabled")
             ) {
                 this.lintSvc.setBpmnlintConfig(editorId, session.panel.active);

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
@@ -5,6 +5,7 @@ import {
     NavigateToImplementationCommand,
     NavigateToReferencedModelCommand,
     SetClipboardCommand,
+    SetLintingEnabledCommand,
     SetPropertiesPanelStateCommand,
     SetTextClipboardCommand,
     SyncActivitiesCommand,
@@ -12,6 +13,8 @@ import {
     UpdateScriptSourceCommand,
     UpdateScriptVariablesCommand,
 } from "@miragon/bpmn-modeler-shared";
+
+import { ConfigurationTarget, workspace } from "vscode";
 
 import { posix } from "path";
 
@@ -116,6 +119,27 @@ export function getPropertiesPanelStateHandler(
 ): MessageHandler {
     return (_message: Command, editorId: string) => {
         panelSvc.sendPropertiesPanelState(editorId);
+    };
+}
+
+/**
+ * `SetLintingEnabledCommand` → persist the user's linting on/off choice.
+ *
+ * Written at Global (User) scope so a design-only user silences linting across
+ * every project in one switch — matching the intent of a personal preference,
+ * like {@link CommandController.changeLanguage}. The config write re-triggers a
+ * lint (via {@link BpmnlintParticipant}'s change listener), which pushes the new
+ * state back to the webview; the webview never flips its own overlays.
+ */
+export function setLintingEnabledHandler(): MessageHandler {
+    return async (message: Command) => {
+        await workspace
+            .getConfiguration("miragon.bpmnModeler")
+            .update(
+                "linting.enabled",
+                (message as SetLintingEnabledCommand).enabled,
+                ConfigurationTarget.Global,
+            );
     };
 }
 

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeSettings.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeSettings.ts
@@ -29,6 +29,18 @@ export class VsCodeSettings implements SettingsPort {
     }
 
     /**
+     * Whether bpmnlint runs. Defaults to `true`, so automation users keep the
+     * zero-config lint experience; design-only users flip it off (globally, from
+     * the webview pill or the settings UI) to silence rules they do not use.
+     */
+    getLintingEnabled(): boolean {
+        return (
+            workspace.getConfiguration("miragon.bpmnModeler").get<boolean>("linting.enabled") ??
+            true
+        );
+    }
+
+    /**
      * Reads the config folder name from VS Code configuration.
      *
      * Defaults to `.camunda` if the setting is not configured.

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeStatusBar.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeStatusBar.ts
@@ -4,6 +4,7 @@ import { Engine, ENGINE_LABEL } from "@miragon/bpmn-modeler-shared";
 
 import { StatusBarPort } from "@miragon/bpmn-modeler-core";
 const CHANGE_ENGINE_VERSION_CMD = "bpmn-modeler.changeEngineVersion";
+const TOGGLE_LINTING_CMD = "bpmn-modeler.toggleLinting";
 
 export class VsCodeStatusBar implements StatusBarPort {
     private templateStatusItem: StatusBarItem | undefined;
@@ -51,6 +52,7 @@ export class VsCodeStatusBar implements StatusBarPort {
         item.text = "$(check) BPMNlint";
         item.tooltip = configPath;
         item.backgroundColor = undefined;
+        item.command = undefined;
         item.show();
     }
 
@@ -61,6 +63,7 @@ export class VsCodeStatusBar implements StatusBarPort {
         // fully-green tick — the exact ambiguity this state exists to remove.
         item.backgroundColor = new ThemeColor("statusBarItem.warningBackground");
         item.tooltip = `${configPath}\n\nUnresolved (install the plugin providing these): ${unresolved.join(", ")}`;
+        item.command = undefined;
         item.show();
     }
 
@@ -72,6 +75,18 @@ export class VsCodeStatusBar implements StatusBarPort {
         const engine = platform ? ENGINE_LABEL[platform] : "no execution platform";
         item.tooltip = `Linting against the bundled default (${engine}).\nAdd a .bpmnlintrc to your workspace to override it.`;
         item.backgroundColor = undefined;
+        item.command = undefined;
+        item.show();
+    }
+
+    showBpmnlintDisabled(): void {
+        const item = this.getOrCreateBpmnlintStatusItem();
+        // Circle-slash (not the info `i`) reads as "deliberately off", and the
+        // command turns it back on with one click for users who never open settings.
+        item.text = "$(circle-slash) BPMNlint: off";
+        item.tooltip = "BPMN linting is turned off — click to turn it back on.";
+        item.backgroundColor = undefined;
+        item.command = TOGGLE_LINTING_CMD;
         item.show();
     }
 
@@ -80,6 +95,7 @@ export class VsCodeStatusBar implements StatusBarPort {
         item.text = "$(info) BPMNlint: no .bpmnlintrc";
         item.tooltip = undefined;
         item.backgroundColor = undefined;
+        item.command = undefined;
         item.show();
     }
 

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // still resolve under vitest.
 vi.mock("vscode", () => ({}));
 
-import { BpmnlintResultsQuery } from "@miragon/bpmn-modeler-shared";
+import { BpmnLintDisabledQuery, BpmnlintResultsQuery } from "@miragon/bpmn-modeler-shared";
 
 import { BpmnLintConfigService } from "./BpmnLintConfigService";
 import { DefaultBpmnlintConfigService } from "./DefaultBpmnlintConfigService";
@@ -37,6 +37,7 @@ function createService() {
         showBpmnlintActive: vi.fn(),
         showBpmnlintUnresolved: vi.fn(),
         showBpmnlintDefault: vi.fn(),
+        showBpmnlintDisabled: vi.fn(),
         showBpmnlintNoConfig: vi.fn(),
         hideBpmnlintStatus: vi.fn(),
     };
@@ -45,6 +46,9 @@ function createService() {
         logInfo: vi.fn(),
         logDebug: vi.fn(),
         logWarning: vi.fn(),
+    };
+    const settings = {
+        getLintingEnabled: vi.fn().mockReturnValue(true),
     };
 
     const service = new BpmnLintConfigService(
@@ -57,6 +61,7 @@ function createService() {
         notifier as never,
         // The real builder: the c7/c8 cases assert the exact layered config it emits.
         new DefaultBpmnlintConfigService(),
+        settings as never,
     );
 
     return {
@@ -68,6 +73,7 @@ function createService() {
         diagnostics,
         statusBar,
         notifier,
+        settings,
     };
 }
 
@@ -97,6 +103,34 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintResultsQuery;
         expect(msg.type).toBe("BpmnlintResultsQuery");
         expect(msg.results).toEqual(RESULTS);
+    });
+
+    it("skips linting and pushes the disabled state when linting is turned off", async () => {
+        const { service, editorStore, locator, lintRunner, diagnostics, statusBar, settings } =
+            createService();
+        settings.getLintingEnabled.mockReturnValue(false);
+
+        const result = await service.setBpmnlintConfig(EDITOR);
+
+        expect(result).toBe(true);
+        // The gate short-circuits before any config discovery or lint run.
+        expect(locator.findNearestConfig).not.toHaveBeenCalled();
+        expect(lintRunner.lint).not.toHaveBeenCalled();
+        expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
+        expect(statusBar.showBpmnlintDisabled).toHaveBeenCalledOnce();
+        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnLintDisabledQuery;
+        expect(msg.type).toBe("BpmnLintDisabledQuery");
+    });
+
+    it("leaves the status bar untouched when disabled and reflectInStatusBar is false", async () => {
+        const { service, editorStore, statusBar, settings } = createService();
+        settings.getLintingEnabled.mockReturnValue(false);
+
+        await service.setBpmnlintConfig(EDITOR, false);
+
+        expect(statusBar.showBpmnlintDisabled).not.toHaveBeenCalled();
+        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnLintDisabledQuery;
+        expect(msg.type).toBe("BpmnLintDisabledQuery");
     });
 
     it("shows the unresolved status and warns when rules could not be resolved", async () => {

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
@@ -1,6 +1,11 @@
 import { posix } from "path";
 
-import { BpmnlintResultsQuery, Engine, LintResults } from "@miragon/bpmn-modeler-shared";
+import {
+    BpmnLintDisabledQuery,
+    BpmnlintResultsQuery,
+    Engine,
+    LintResults,
+} from "@miragon/bpmn-modeler-shared";
 
 import { BpmnDocument } from "../../../shared/domain/BpmnDocument";
 import { ExecutionPlatformNotDetectedError } from "../../../shared/domain/errors";
@@ -9,6 +14,7 @@ import {
     DocumentPort,
     LintRunnerPort,
     NotifierPort,
+    SettingsPort,
     StatusBarPort,
 } from "../../../shared/domain/hostPorts";
 import { EditorSessionStore } from "../../../shared/infrastructure/EditorSessionStore";
@@ -42,6 +48,7 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
         private readonly statusBar: StatusBarPort,
         private readonly notifier: NotifierPort,
         private readonly defaultConfig: DefaultBpmnlintConfigService,
+        private readonly settings: SettingsPort,
     ) {}
 
     /**
@@ -68,6 +75,18 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
      * state rather than crashing the editor or silently swapping in the default.
      */
     private async lintAndPush(editorId: string, reflectInStatusBar: boolean): Promise<boolean> {
+        // User opted out of linting entirely: skip the run and clear every
+        // surface (overlays, Problems entries), so design-only users are not
+        // shown automation rules. Distinct from the no-config state — nothing
+        // failed — so the webview can offer a re-enable affordance.
+        if (!this.settings.getLintingEnabled()) {
+            if (reflectInStatusBar) {
+                this.statusBar.showBpmnlintDisabled();
+            }
+            this.diagnostics.clear(editorId);
+            return this.pushDisabled(editorId);
+        }
+
         let results: LintResults | null;
         try {
             const dir = posix.dirname(this.vsDocument.getFilePath(editorId));
@@ -194,6 +213,23 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
         } catch (error) {
             this.notifier.logWarning(
                 `[bpmnlint] results push skipped: ${(error as Error).message}`,
+            );
+            return false;
+        }
+    }
+
+    /**
+     * Tells the webview linting is user-disabled so it shows the re-enable chip
+     * rather than hiding the pill (which {@link BpmnlintResultsQuery} `null`
+     * does). Same recoverable-drop handling as {@link pushResults}: a hidden
+     * panel makes the post reject, and the webview re-requests on reload.
+     */
+    private async pushDisabled(editorId: string): Promise<boolean> {
+        try {
+            return await this.editorStore.postMessage(editorId, new BpmnLintDisabledQuery());
+        } catch (error) {
+            this.notifier.logWarning(
+                `[bpmnlint] disabled push skipped: ${(error as Error).message}`,
             );
             return false;
         }

--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -129,6 +129,12 @@ export interface SettingsPort {
     getShowTransactionBoundaries(): boolean;
     getConfigFolder(): string;
     getC8ApiVersion(): string;
+    /**
+     * Whether bpmnlint runs at all. `false` suppresses every lint surface
+     * (overlays, Problems entries, status bar) so design-only users are not
+     * shown automation rules they do not care about. Defaults to `true`.
+     */
+    getLintingEnabled(): boolean;
     getColorTheme(): "automatic" | "light";
     getFavouriteBpmnElements(): string[];
     getLanguage(): string;
@@ -212,6 +218,13 @@ export interface StatusBarPort {
      * applied, or `undefined` for the structural-only base on a platform-less file.
      */
     showBpmnlintDefault(platform: Engine | undefined): void;
+    /**
+     * State for linting switched off by the user
+     * (`miragon.bpmnModeler.linting.enabled` = `false`). Distinct from
+     * {@link showBpmnlintNoConfig} — nothing is wrong; the user opted out — and
+     * offers a click target to switch it back on.
+     */
+    showBpmnlintDisabled(): void;
     showBpmnlintNoConfig(): void;
     hideBpmnlintStatus(): void;
 }

--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -204,26 +204,8 @@ export interface StatusBarPort {
     hideEngineVersion(): void;
     disposeEngineVersionStatus(): void;
     showBpmnlintActive(configPath: string): void;
-    /**
-     * Distinct state for a config the host applied but could not fully resolve:
-     * one or more referenced rules/configs (typically `bpmnlint-plugin-*` not
-     * installed in the workspace) were skipped. Surfaced so the "✓ BPMNlint" tick
-     * never masks silently-dropped rules — `unresolved` lists them for the tooltip.
-     */
     showBpmnlintUnresolved(configPath: string, unresolved: string[]): void;
-    /**
-     * State for the zero-config **bundled default** — visually distinct from a
-     * project's own `.bpmnlintrc` ({@link showBpmnlintActive}) so the two are never
-     * confused. `platform` is the detected engine whose deployability layer is
-     * applied, or `undefined` for the structural-only base on a platform-less file.
-     */
     showBpmnlintDefault(platform: Engine | undefined): void;
-    /**
-     * State for linting switched off by the user
-     * (`miragon.bpmnModeler.linting.enabled` = `false`). Distinct from
-     * {@link showBpmnlintNoConfig} — nothing is wrong; the user opted out — and
-     * offers a click target to switch it back on.
-     */
     showBpmnlintDisabled(): void;
     showBpmnlintNoConfig(): void;
     hideBpmnlintStatus(): void;

--- a/libs/shared/src/lib/modeler.ts
+++ b/libs/shared/src/lib/modeler.ts
@@ -156,6 +156,23 @@ export class BpmnlintResultsQuery extends Query {
 }
 
 /**
+ * Tells the webview the user has switched linting **off** (the
+ * `miragon.bpmnModeler.linting.enabled` setting is `false`), as opposed to
+ * linting merely being inactive (no `.bpmnlintrc`, or a host failure), which
+ * {@link BpmnlintResultsQuery} with `null` already signals.
+ *
+ * The distinction matters for the webview affordance: an *inactive* linter
+ * hides its chip entirely, but a *disabled* one shows a muted "Linting off"
+ * chip so the user can turn it back on from inside the canvas — the pill they
+ * would otherwise use is gone. Carries no payload; the state is the message.
+ */
+export class BpmnLintDisabledQuery extends Query {
+    constructor() {
+        super("BpmnLintDisabledQuery");
+    }
+}
+
+/**
  * Centres the canvas on an element by id. VS Code strips the range for custom
  * editors and fires no diagnostic-click event, so a Problems-panel bpmnlint
  * finding reaches its element through a command link that posts this instead.
@@ -463,6 +480,24 @@ export class SetPropertiesPanelStateCommand extends Command {
     constructor(visible: boolean) {
         super("SetPropertiesPanelStateCommand");
         this.visible = visible;
+    }
+}
+
+/**
+ * Sent by the BPMN webview when the user toggles linting from inside the canvas
+ * — the "Turn off linting" affordance on the lint pill, or the "Enable" action
+ * on the disabled chip. The host persists the choice to the
+ * `miragon.bpmnModeler.linting.enabled` User setting (the single source of
+ * truth), which re-lints and pushes the new state back down, so the webview
+ * never flips its own overlays optimistically. Hosts without the setting (e.g.
+ * the IntelliJ bridge) simply ignore it and linting is unaffected.
+ */
+export class SetLintingEnabledCommand extends Command {
+    public readonly enabled: boolean;
+
+    constructor(enabled: boolean) {
+        super("SetLintingEnabledCommand");
+        this.enabled = enabled;
     }
 }
 


### PR DESCRIPTION
## Problem

The modeler serves two audiences: **automation** users rely on linting, while **design-only** users (drawing processes, no execution) do not. Since the zero-config lint default (#1327), giving a diagram an execution platform lights up the full `camunda-compat` rule layer — a wall of overlays / Problems entries / status-bar badge that is irrelevant to design-only users and drives churn. There was **no user-facing way to turn linting off**.

Closes #1357.

## Solution

A blunt, global **on/off** — `miragon.bpmnModeler.linting.enabled` (default `true`, User scope) — as the single source of truth:

- **Host gate** in `BpmnLintConfigService`: when off, no lint run, Problems cleared, and a distinct `BpmnLintDisabledQuery` is pushed (not the inactive `null`, so the webview can offer a re-enable path).
- **In-webview affordance** (so non-technical users never open settings): an "off" switch beside the lint pill, a one-time nudge pointing at it, and a muted "Linting off · Enable" chip once disabled — all writing the setting back via `SetLintingEnabledCommand`.
- **Parity entry points**: status-bar badge (`BPMNlint: off`), the **BPMN: Toggle Linting** command, and the Settings UI.

Works identically in **VS Code and the Theia/Electron standalone** (same `.vsix`, settings API, webview). **IntelliJ** is out of scope but keeps compiling (bridge adapters return `true` / no-op).

Chosen over the alternatives (keep-structural / three-state; per-workspace / per-file scope) for the simplest, most understandable opt-out; it can be extended later.

## Verification

- `corepack yarn build` — clean
- `corepack yarn test` — 1602 passed (added a gate test in `BpmnLintConfigService.spec`, extended `BpmnlintParticipant.spec`, updated `manifest.contract`)
- `corepack yarn lint` — 0 errors · `corepack yarn format:check` — clean

Not covered by unit tests: the in-canvas DOM/CSS affordance (off-button, disabled chip, nudge) — verify manually under F5 and `yarn workspace @miragon/bpmn-modeler-standalone dev`.

## Docs

`apps/vscode-plugin/README.md` (the Marketplace listing) gains a compact linting bullet plus the new command and setting rows.