### PR TITLE
fix(ci): focus renamed i18n-extras/core workspaces in publish jobs

### DIFF
--- a/.github/workflows/publish-intellij.yml
+++ b/.github/workflows/publish-intellij.yml
@@ -88,7 +88,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies (focused)
-        run: yarn workspaces focus bpmn-modeler @miragon/bpmn-modeler-webview @miragon/bpmn-modeler-deployment-webview @miragon/bpmn-modeler-shared @miragon/bpmn-modeler-core @miragon/bpmn-modeler-bridge @miragon/bpmn-modeler-append-menu @miragon/bpmn-modeler-clipboard @miragon/bpmn-modeler-i18n @miragon/bpmn-modeler-element-template-chooser
+        run: yarn workspaces focus bpmn-modeler @miragon/bpmn-modeler-webview @miragon/bpmn-modeler-deployment-webview @miragon/bpmn-modeler-shared @miragon/bpmn-modeler-core @miragon/bpmn-modeler-bridge @miragon/bpmn-modeler-append-menu @miragon/bpmn-modeler-clipboard @miragon/bpmn-modeler-i18n-extras @miragon/bpmn-modeler-element-template-chooser
 
       - name: Build shared libraries
         run: yarn build:libs

--- a/.github/workflows/publish-open-vsx-modeler.yml
+++ b/.github/workflows/publish-open-vsx-modeler.yml
@@ -69,7 +69,7 @@ jobs:
           cache: yarn
 
       - name: Install dependencies (focused)
-        run: yarn workspaces focus bpmn-modeler vs-code-bpmn-modeler @miragon/bpmn-modeler-webview @miragon/dmn-modeler-webview @miragon/bpmn-modeler-deployment-webview @miragon/bpmn-modeler-shared @miragon/bpmn-modeler-append-menu @miragon/bpmn-modeler-clipboard @miragon/bpmn-modeler-i18n @miragon/bpmn-modeler-element-template-chooser
+        run: yarn workspaces focus bpmn-modeler vs-code-bpmn-modeler @miragon/bpmn-modeler-webview @miragon/dmn-modeler-webview @miragon/bpmn-modeler-deployment-webview @miragon/bpmn-modeler-shared @miragon/bpmn-modeler-core @miragon/bpmn-modeler-append-menu @miragon/bpmn-modeler-clipboard @miragon/bpmn-modeler-i18n-extras @miragon/bpmn-modeler-element-template-chooser
 
       - name: Resolve version
         id: version

--- a/.github/workflows/publish-vscode-modeler.yml
+++ b/.github/workflows/publish-vscode-modeler.yml
@@ -70,7 +70,7 @@ jobs:
           cache: yarn
 
       - name: Install dependencies (focused)
-        run: yarn workspaces focus bpmn-modeler vs-code-bpmn-modeler @miragon/bpmn-modeler-webview @miragon/dmn-modeler-webview @miragon/bpmn-modeler-deployment-webview @miragon/bpmn-modeler-shared @miragon/bpmn-modeler-append-menu @miragon/bpmn-modeler-clipboard @miragon/bpmn-modeler-i18n @miragon/bpmn-modeler-element-template-chooser
+        run: yarn workspaces focus bpmn-modeler vs-code-bpmn-modeler @miragon/bpmn-modeler-webview @miragon/dmn-modeler-webview @miragon/bpmn-modeler-deployment-webview @miragon/bpmn-modeler-shared @miragon/bpmn-modeler-core @miragon/bpmn-modeler-append-menu @miragon/bpmn-modeler-clipboard @miragon/bpmn-modeler-i18n-extras @miragon/bpmn-modeler-element-template-chooser
 
       - name: Resolve version
         id: version


### PR DESCRIPTION
## What
The three publish workflows (`publish-vscode-modeler`, `publish-open-vsx-modeler`, `publish-intellij`) still passed `@miragon/bpmn-modeler-i18n` to `yarn workspaces focus`. That package is no longer a local workspace — it is now an external npm package, and the local overlay was renamed to `@miragon/bpmn-modeler-i18n-extras`. `yarn workspaces focus` treats every argument as a local workspace, fails to find it, and hard-errors:

```
Internal Error: Workspace not found (@miragon/bpmn-modeler-i18n)
```

This broke the VS Code Publish job of the `release vscode 1.9.0` release run.

## Fix
- `@miragon/bpmn-modeler-i18n` → `@miragon/bpmn-modeler-i18n-extras` in all three publish jobs.
- Add the missing `@miragon/bpmn-modeler-core` workspace to the vscode + open-vsx focus lists (already present in `build.yml` and the intellij job).

`build.yml` was already updated to the new names; only the publish workflows lagged behind.