### PR TITLE
feat(bpmn-webview): navigate diagrams with tab/shift+tab along flows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,16 @@
-**Issue**
+## Issue
 
+Closes #
 
+## Description
 
-**Description**
+<!-- What changed and why. Link an ADR if this changes architecture or public API. -->
 
+## Author checklist
 
-
-**Checklist**
-
-* Code is easy to understand
-* No obvious errors or bugs
-* CI/CD Pipelines did run successfully
-* Tests were implemented
-* Documentation was created
+- [ ] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
+- [ ] Tests added or updated (or N/A)
+- [ ] Docs (or N/A)
+- [ ] Self-reviewed the diff
+- [ ] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
+- [ ] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)

--- a/apps/bpmn-webview/package.json
+++ b/apps/bpmn-webview/package.json
@@ -20,6 +20,7 @@
         "@miragon/bpmn-modeler-clipboard": "workspace:*",
         "@miragon/bpmn-modeler-code-link": "workspace:*",
         "@miragon/bpmn-modeler-element-template-chooser": "workspace:*",
+        "@miragon/bpmn-modeler-flow-navigation": "workspace:*",
         "@miragon/bpmn-modeler-i18n": "0.2.0",
         "@miragon/bpmn-modeler-i18n-extras": "workspace:*",
         "@miragon/bpmn-modeler-shared": "workspace:*",

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -9,6 +9,7 @@ import { CreateAppendElementTemplatesModule } from "bpmn-js-create-append-anythi
 import { AppendMenuModule } from "@miragon/bpmn-modeler-append-menu";
 import { NavigateToReferencedModelModule } from "@miragon/bpmn-model-navigation";
 import { CodeLinkModule, type CodeLinkMapClient } from "@miragon/bpmn-modeler-code-link";
+import { FlowNavigationModule } from "@miragon/bpmn-modeler-flow-navigation";
 import { CreateAppendC7ElementTemplatesModule } from "@miragon/create-append-c7";
 import {
     BpmnModelerSetting,
@@ -140,6 +141,7 @@ export class BpmnModeler {
             AppendMenuModule,
             NavigateToReferencedModelModule,
             CodeLinkModule,
+            FlowNavigationModule,
         ];
         const extra = extraModules ?? [];
 

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -20,6 +20,8 @@ import {
     ScriptTaskScript,
 } from "@miragon/bpmn-modeler-shared";
 import { ScriptEditorButtonsModule } from "./scriptEditorButtons";
+import { ScriptEditorKeyboardModule } from "./scriptEditorKeyboard";
+import { ScriptEditorOpenerModule } from "./scriptEditorOpener";
 import { OpenScriptEditorsStore, OpenScriptEditorsStoreModule } from "./openScriptEditorsStore";
 import { ScriptLockPropertiesProviderModule } from "./scriptLockPropertiesProvider";
 import { collectInlineScriptTasks, findListenerAt } from "./scriptModel";
@@ -157,7 +159,9 @@ export class BpmnModeler {
                         CreateAppendC7ElementTemplatesModule,
                         TransactionBoundariesModule,
                         ScriptTaskContextPadModule,
+                        ScriptEditorOpenerModule,
                         ScriptEditorButtonsModule,
+                        ScriptEditorKeyboardModule,
                         OpenScriptEditorsStoreModule,
                         ScriptLockPropertiesProviderModule,
                         ScriptSourceWatcherModule,
@@ -507,11 +511,12 @@ export class BpmnModeler {
     /**
      * Registers a callback for the unified `scriptEditor.open` event.
      *
-     * Three sources fire it: the canvas context pad on script tasks
+     * Four sources fire it: the canvas context pad on script tasks
      * ({@link ScriptTaskContextPadModule}), the Script-group header icon
-     * on the properties panel for script tasks, and the per-listener icon
+     * on the properties panel for script tasks, the per-listener icon
      * on each script-typed listener row (both via
-     * {@link ScriptEditorButtonsModule}).
+     * {@link ScriptEditorButtonsModule}), and the `o` keyboard shortcut
+     * ({@link ScriptEditorKeyboardModule}).
      */
     onOpenScriptEditor(callback: (data: OpenScriptEditorEvent) => void): void {
         this.getModeler()

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
@@ -1,18 +1,5 @@
-/**
- * Returns true if `el` is a surface where the user is editing text
- * (`<input>`, `<textarea>`, or any `contenteditable` element).
- *
- * The webview-level keyboard guard uses this predicate to decide whether
- * bpmn-js should be allowed to receive a Ctrl/Cmd+A keystroke: text surfaces
- * own their own selection, so the event must not reach bpmn-js's Keyboard
- * service.
- */
-export function isTextEditingSurface(el: Element | null): boolean {
-    if (el instanceof HTMLInputElement) return true;
-    if (el instanceof HTMLTextAreaElement) return true;
-    if (el instanceof HTMLElement && el.contentEditable === "true") return true;
-    return false;
-}
+import { isTextEditingSurface } from "@miragon/bpmn-modeler-shared";
+export { isTextEditingSurface };
 
 /**
  * Writes the current text selection to the extension-host clipboard.

--- a/apps/bpmn-webview/src/app/scriptEditorButtons.ts
+++ b/apps/bpmn-webview/src/app/scriptEditorButtons.ts
@@ -1,6 +1,5 @@
-import { OPEN_SCRIPT_EDITOR_EVENT, OpenScriptEditorEvent } from "./scriptTaskContextPad";
 import { EDITOR_ICON_SVG } from "./editorIcon";
-import { readScriptTaskFormat } from "./scriptModel";
+import type { ScriptEditorOpener } from "./scriptEditorOpener";
 
 /**
  * bpmn-js DI module that injects "Open script in editor" icon buttons into
@@ -9,22 +8,18 @@ import { readScriptTaskFormat } from "./scriptModel";
  *   - One button on the **Script** group header for `bpmn:ScriptTask`
  *     elements.
  *   - One button per listener row in the **Execution Listeners** /
- *     **Task Listeners** groups. The button is always rendered; if the
- *     listener is not yet an inline `<camunda:script>` (e.g. Java class,
- *     expression, delegate expression, or external-resource script), the
- *     click handler converts it via the command stack before opening the
- *     editor — making the conversion a single undoable user action.
+ *     **Task Listeners** groups. The button is always rendered; the
+ *     {@link ScriptEditorOpener} converts non-inline-script listeners via
+ *     the command stack before opening the editor.
  *
  * Implementation: a {@link MutationObserver} watches the properties-panel
  * container and runs the injection scan on every DOM mutation. The scan is
  * idempotent — already-processed elements are tagged with
  * `data-script-btn-injected="true"` so subsequent passes are no-ops.
  *
- * Click handlers fire {@link OPEN_SCRIPT_EDITOR_EVENT} on the bpmn-js event
- * bus with a {@link OpenScriptEditorEvent} payload. The webview entry point
- * forwards it to the extension host as `OpenScriptEditorCommand`, which
- * opens the inline script in an editor tab with
- * kind-aware completion suggestions for the bound Camunda beans.
+ * Click handlers delegate to {@link ScriptEditorOpener}, which fires the
+ * unified open-editor event the webview entry point forwards to the
+ * extension host as `OpenScriptEditorCommand`.
  *
  * The listener-row buttons read the listener identity (element id, type,
  * index) from the entry's `data-entry-id` attribute at *click time* rather
@@ -56,14 +51,12 @@ const INJECTED_MARKER = "data-script-btn-injected";
 class ScriptEditorButtons {
     private observer: MutationObserver | undefined;
 
-    static $inject = ["eventBus", "selection", "elementRegistry", "modeling", "bpmnFactory"];
+    static $inject = ["eventBus", "selection", "scriptEditorOpener"];
 
     constructor(
         private readonly eventBus: any,
         private readonly selection: any,
-        private readonly elementRegistry: any,
-        private readonly modeling: any,
-        private readonly bpmnFactory: any,
+        private readonly opener: ScriptEditorOpener,
     ) {
         this.startObserving();
         this.eventBus.on("diagram.destroy", () => this.stopObserving());
@@ -174,46 +167,21 @@ class ScriptEditorButtons {
     }
 
     /**
-     * Handler for the script-task **Script** group header button. Reads the
-     * currently selected element's inline script and fires the unified
-     * open-editor event with `kind: "script-task"`.
+     * Handler for the script-task **Script** group header button. Opens the
+     * currently selected element's inline script.
      */
     private handleScriptHeaderClick(): void {
         const selected = this.selection.get();
         if (!selected || selected.length === 0) {
             return;
         }
-
-        const element = selected[0];
-        const bo = element.businessObject;
-        if (!bo) {
-            return;
-        }
-
-        const scriptFormat = readScriptTaskFormat(bo);
-        const content = bo.script || "";
-
-        this.eventBus.fire(OPEN_SCRIPT_EDITOR_EVENT, {
-            elementId: element.id,
-            kind: "script-task",
-            listenerIndex: undefined,
-            eventName: undefined,
-            scriptFormat,
-            content,
-        } as OpenScriptEditorEvent);
+        this.opener.openScriptTask(selected[0]);
     }
 
     /**
-     * Handler for a listener-row icon button.
-     *
-     * Reads the listener identity from the closest `[data-entry-id]`
-     * ancestor and looks up the listener via the element registry — using
-     * the registry rather than `selection.get()` because the properties
-     * panel also displays the implicit root process when nothing is
-     * selected, in which case the selection service returns an empty array.
-     *
-     * If the listener is not yet an inline `<camunda:script>`, converts it
-     * via the command stack so the user can edit it in a virtual document.
+     * Handler for a listener-row icon button. Reads the listener identity
+     * from the closest `[data-entry-id]` ancestor and delegates to the
+     * opener, which resolves the listener via the element registry.
      */
     private handleListenerItemClick(button: HTMLElement): void {
         const entry = button.closest("[data-entry-id]");
@@ -222,94 +190,11 @@ class ScriptEditorButtons {
         if (!match) {
             return;
         }
-        const elementId = match[1];
-        const listenerType = match[2] as "executionListener" | "taskListener";
-        const listenerIndex = parseInt(match[3], 10);
-
-        const element = this.elementRegistry.get(elementId);
-        const listener = this.lookupListener(elementId, listenerType, listenerIndex);
-        if (!element || !listener) {
-            return;
-        }
-
-        this.ensureInlineScript(element, listener);
-
-        const kind = listenerType === "executionListener" ? "execution-listener" : "task-listener";
-
-        this.eventBus.fire(OPEN_SCRIPT_EDITOR_EVENT, {
-            elementId,
-            kind,
-            listenerIndex,
-            eventName: listener.get?.("event") ?? listener.event ?? undefined,
-            scriptFormat:
-                listener.script.get?.("scriptFormat") ?? listener.script.scriptFormat ?? "",
-            content: listener.script.get?.("value") ?? listener.script.value ?? "",
-        } as OpenScriptEditorEvent);
-    }
-
-    /**
-     * Converts a listener's implementation to an inline `<camunda:script>`
-     * if it isn't one already. No-op when the listener already uses an
-     * inline script.
-     *
-     * Two paths:
-     * - The listener has a `<camunda:script>` with a `resource` attribute
-     *   (external-resource implementation): strip `resource` and seed an
-     *   empty `value` on the existing element.
-     * - The listener has no script element (Java class / expression /
-     *   delegate expression): create a fresh `<camunda:script>` and clear
-     *   the other implementation attributes in the same update so the
-     *   entire switch is one undoable command.
-     */
-    private ensureInlineScript(element: any, listener: any): void {
-        const existingScript = listener.script;
-        const existingValue = existingScript?.get?.("value") ?? existingScript?.value;
-        if (typeof existingValue === "string") {
-            return;
-        }
-
-        if (existingScript) {
-            this.modeling.updateModdleProperties(element, listener, {
-                class: undefined,
-                expression: undefined,
-                delegateExpression: undefined,
-            });
-            this.modeling.updateModdleProperties(element, existingScript, {
-                resource: undefined,
-                value: "",
-            });
-            return;
-        }
-
-        const script = this.bpmnFactory.create("camunda:Script", {
-            scriptFormat: "",
-            value: "",
-        });
-        this.modeling.updateModdleProperties(element, listener, {
-            class: undefined,
-            expression: undefined,
-            delegateExpression: undefined,
-            script,
-        });
-    }
-
-    private lookupListener(
-        elementId: string,
-        listenerType: "executionListener" | "taskListener",
-        listenerIndex: number,
-    ): any {
-        const element = this.elementRegistry.get(elementId);
-        if (!element) {
-            return undefined;
-        }
-        const extensionType =
-            listenerType === "executionListener"
-                ? "camunda:ExecutionListener"
-                : "camunda:TaskListener";
-        const listeners = (element.businessObject?.extensionElements?.values || []).filter(
-            (e: any) => e.$type === extensionType,
+        this.opener.openListener(
+            match[1],
+            match[2] as "executionListener" | "taskListener",
+            parseInt(match[3], 10),
         );
-        return listeners[listenerIndex];
     }
 }
 

--- a/apps/bpmn-webview/src/app/scriptEditorKeyboard.spec.ts
+++ b/apps/bpmn-webview/src/app/scriptEditorKeyboard.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ScriptEditorKeyboard } from "./scriptEditorKeyboard";
+
+// ---------------------------------------------------------------------------
+// Test harness — mirrors the flow-navigation keyboard spec style.
+// ---------------------------------------------------------------------------
+
+function build() {
+    let listener!: (ctx: { keyEvent: KeyboardEvent }) => boolean | undefined;
+
+    const keyboard = {
+        addListener: vi.fn((l: typeof listener) => {
+            listener = l;
+        }),
+        isCmd: vi.fn((e: KeyboardEvent) => !!(e.ctrlKey || e.metaKey)),
+        isShift: vi.fn((e: KeyboardEvent) => !!e.shiftKey),
+    };
+
+    const selection = {
+        get: vi.fn((): { id: string }[] => []),
+    };
+
+    const opener = {
+        openFirstScript: vi.fn(() => false),
+    };
+
+    const services: Record<string, unknown> = {};
+    const injector = {
+        get: vi.fn((name: string) => services[name] ?? null),
+    };
+
+    new ScriptEditorKeyboard(
+        keyboard as never,
+        selection as never,
+        opener as never,
+        injector as never,
+    );
+
+    function dispatch(
+        key: string,
+        opts?: { shift?: boolean; ctrl?: boolean; alt?: boolean },
+    ): boolean | undefined {
+        return listener({
+            keyEvent: {
+                key,
+                shiftKey: opts?.shift ?? false,
+                ctrlKey: opts?.ctrl ?? false,
+                metaKey: false,
+                altKey: opts?.alt ?? false,
+            } as unknown as KeyboardEvent,
+        });
+    }
+
+    return { selection, opener, services, dispatch };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ScriptEditorKeyboard", () => {
+    it("o with a script on the selected element → opened, consumed", () => {
+        const { selection, opener, dispatch } = build();
+        const element = { id: "Task_1" };
+        selection.get.mockReturnValue([element]);
+        opener.openFirstScript.mockReturnValue(true);
+
+        expect(dispatch("o")).toBe(true);
+        expect(opener.openFirstScript).toHaveBeenCalledWith(element);
+    });
+
+    it("o without a script on the element → key passes through", () => {
+        const { selection, opener, dispatch } = build();
+        selection.get.mockReturnValue([{ id: "Task_1" }]);
+        opener.openFirstScript.mockReturnValue(false);
+
+        expect(dispatch("o")).toBeUndefined();
+    });
+
+    it("other keys pass through untouched", () => {
+        const { opener, dispatch } = build();
+
+        expect(dispatch("g")).toBeUndefined();
+        expect(opener.openFirstScript).not.toHaveBeenCalled();
+    });
+
+    it("modified o (cmd/ctrl, alt, shift) passes through", () => {
+        const { selection, opener, dispatch } = build();
+        selection.get.mockReturnValue([{ id: "Task_1" }]);
+
+        expect(dispatch("o", { ctrl: true })).toBeUndefined();
+        expect(dispatch("o", { alt: true })).toBeUndefined();
+        expect(dispatch("o", { shift: true })).toBeUndefined();
+        expect(opener.openFirstScript).not.toHaveBeenCalled();
+    });
+
+    it("ignored without exactly one selected element", () => {
+        const { selection, opener, dispatch } = build();
+
+        selection.get.mockReturnValue([]);
+        expect(dispatch("o")).toBeUndefined();
+
+        selection.get.mockReturnValue([{ id: "a" }, { id: "b" }]);
+        expect(dispatch("o")).toBeUndefined();
+
+        expect(opener.openFirstScript).not.toHaveBeenCalled();
+    });
+
+    it("ignored while direct editing is active", () => {
+        const { selection, opener, services, dispatch } = build();
+        selection.get.mockReturnValue([{ id: "Task_1" }]);
+        services["directEditing"] = { isActive: () => true };
+
+        expect(dispatch("o")).toBeUndefined();
+        expect(opener.openFirstScript).not.toHaveBeenCalled();
+    });
+
+    it("ignored while a popup menu is open", () => {
+        const { selection, opener, services, dispatch } = build();
+        selection.get.mockReturnValue([{ id: "Task_1" }]);
+        services["popupMenu"] = { isOpen: () => true };
+
+        expect(dispatch("o")).toBeUndefined();
+        expect(opener.openFirstScript).not.toHaveBeenCalled();
+    });
+});

--- a/apps/bpmn-webview/src/app/scriptEditorKeyboard.ts
+++ b/apps/bpmn-webview/src/app/scriptEditorKeyboard.ts
@@ -1,0 +1,83 @@
+import type { ScriptEditorOpener } from "./scriptEditorOpener";
+
+/**
+ * Wires the "o" keyboard shortcut to open the selected element's script in
+ * the host editor — the same action as the "Open script in editor" buttons —
+ * so script tasks and listener scripts are reachable without the mouse.
+ *
+ * Delegates to {@link ScriptEditorOpener}, which picks the first script in
+ * properties-panel order (inline script, then execution listeners, then task
+ * listeners). Elements without any script leave the key untouched.
+ */
+
+// ---------------------------------------------------------------------------
+// Structural service interfaces — satisfied by diagram-js at runtime,
+// mocked with plain objects in tests.
+// ---------------------------------------------------------------------------
+
+interface Keyboard {
+    addListener(listener: (ctx: { keyEvent: KeyboardEvent }) => boolean | undefined): void;
+    isCmd(event: KeyboardEvent): boolean;
+    isShift(event: KeyboardEvent): boolean;
+}
+
+interface Selection {
+    get(): { id: string }[];
+}
+
+interface Injector {
+    get(name: string, strict: false): unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class ScriptEditorKeyboard {
+    static $inject = ["keyboard", "selection", "scriptEditorOpener", "injector"];
+
+    constructor(
+        keyboard: Keyboard,
+        selection: Selection,
+        opener: ScriptEditorOpener,
+        injector: Injector,
+    ) {
+        keyboard.addListener((ctx) =>
+            this.handleKeyDown(ctx.keyEvent, keyboard, selection, opener, injector),
+        );
+    }
+
+    private handleKeyDown(
+        event: KeyboardEvent,
+        keyboard: Keyboard,
+        selection: Selection,
+        opener: ScriptEditorOpener,
+        injector: Injector,
+    ): boolean | undefined {
+        if (event.key !== "o") return undefined;
+        if (keyboard.isCmd(event) || event.altKey || keyboard.isShift(event)) return undefined;
+
+        const directEditing = injector.get("directEditing", false) as {
+            isActive(): boolean;
+        } | null;
+        if (directEditing?.isActive()) return undefined;
+
+        const popupMenu = injector.get("popupMenu", false) as { isOpen(): boolean } | null;
+        if (popupMenu?.isOpen()) return undefined;
+
+        const selected = selection.get();
+        if (selected.length !== 1) return undefined;
+
+        return opener.openFirstScript(selected[0]) ? true : undefined;
+    }
+}
+
+/**
+ * bpmn-js / didi module exporting the script-editor keyboard shortcut.
+ * Register via `additionalModules` (together with
+ * {@link ScriptEditorOpenerModule}) when creating the C7 modeler.
+ */
+export const ScriptEditorKeyboardModule = {
+    __init__: ["scriptEditorKeyboard"],
+    scriptEditorKeyboard: ["type", ScriptEditorKeyboard],
+};

--- a/apps/bpmn-webview/src/app/scriptEditorOpener.spec.ts
+++ b/apps/bpmn-webview/src/app/scriptEditorOpener.spec.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ScriptEditorOpener } from "./scriptEditorOpener";
+import { OPEN_SCRIPT_EDITOR_EVENT } from "./scriptTaskContextPad";
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+function build(elements: Record<string, unknown> = {}) {
+    const eventBus = { fire: vi.fn() };
+    const elementRegistry = { get: vi.fn((id: string) => elements[id]) };
+    // Applies the properties like the real command stack does — the opener
+    // reads `listener.script` right after converting.
+    const modeling = {
+        updateModdleProperties: vi.fn(
+            (_element: unknown, target: Record<string, unknown>, props: Record<string, unknown>) =>
+                Object.assign(target, props),
+        ),
+    };
+    const bpmnFactory = {
+        create: vi.fn((type: string, props: Record<string, unknown>) => ({
+            $type: type,
+            ...props,
+        })),
+    };
+
+    const opener = new ScriptEditorOpener(eventBus, elementRegistry, modeling, bpmnFactory);
+
+    return { opener, eventBus, modeling, bpmnFactory };
+}
+
+function scriptTaskElement(overrides: Record<string, unknown> = {}) {
+    return {
+        id: "Task_1",
+        businessObject: {
+            $type: "bpmn:ScriptTask",
+            scriptFormat: "groovy",
+            script: "println 'hi'",
+            ...overrides,
+        },
+    };
+}
+
+function listenerElement(listeners: unknown[], id = "Task_1") {
+    return {
+        id,
+        businessObject: {
+            $type: "bpmn:ServiceTask",
+            extensionElements: { values: listeners },
+        },
+    };
+}
+
+function inlineListener(type: string, overrides: Record<string, unknown> = {}) {
+    return {
+        $type: type,
+        event: "start",
+        script: { scriptFormat: "javascript", value: "code()" },
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ScriptEditorOpener", () => {
+    describe("openScriptTask", () => {
+        it("fires the open event for a script task", () => {
+            const { opener, eventBus } = build();
+
+            const opened = opener.openScriptTask(scriptTaskElement());
+
+            expect(opened).toBe(true);
+            expect(eventBus.fire).toHaveBeenCalledWith(OPEN_SCRIPT_EDITOR_EVENT, {
+                elementId: "Task_1",
+                kind: "script-task",
+                listenerIndex: undefined,
+                eventName: undefined,
+                scriptFormat: "groovy",
+                content: "println 'hi'",
+            });
+        });
+
+        it("opens an empty document when the script is unset", () => {
+            const { opener, eventBus } = build();
+
+            opener.openScriptTask(scriptTaskElement({ script: undefined, scriptFormat: "" }));
+
+            expect(eventBus.fire).toHaveBeenCalledWith(
+                OPEN_SCRIPT_EDITOR_EVENT,
+                expect.objectContaining({ content: "", scriptFormat: "" }),
+            );
+        });
+
+        it("returns false for non-script-task elements", () => {
+            const { opener, eventBus } = build();
+
+            const opened = opener.openScriptTask({
+                id: "Task_1",
+                businessObject: { $type: "bpmn:ServiceTask" },
+            });
+
+            expect(opened).toBe(false);
+            expect(eventBus.fire).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("openListener", () => {
+        it("fires the open event for an inline-script execution listener", () => {
+            const element = listenerElement([inlineListener("camunda:ExecutionListener")]);
+            const { opener, eventBus, modeling } = build({ Task_1: element });
+
+            const opened = opener.openListener("Task_1", "executionListener", 0);
+
+            expect(opened).toBe(true);
+            expect(modeling.updateModdleProperties).not.toHaveBeenCalled();
+            expect(eventBus.fire).toHaveBeenCalledWith(OPEN_SCRIPT_EDITOR_EVENT, {
+                elementId: "Task_1",
+                kind: "execution-listener",
+                listenerIndex: 0,
+                eventName: "start",
+                scriptFormat: "javascript",
+                content: "code()",
+            });
+        });
+
+        it("maps taskListener to the task-listener kind", () => {
+            const element = listenerElement([inlineListener("camunda:TaskListener")]);
+            const { opener, eventBus } = build({ Task_1: element });
+
+            opener.openListener("Task_1", "taskListener", 0);
+
+            expect(eventBus.fire).toHaveBeenCalledWith(
+                OPEN_SCRIPT_EDITOR_EVENT,
+                expect.objectContaining({ kind: "task-listener" }),
+            );
+        });
+
+        it("converts an external-resource script by stripping resource", () => {
+            const listener = inlineListener("camunda:ExecutionListener", {
+                script: { scriptFormat: "groovy", resource: "ext.groovy" },
+            });
+            const element = listenerElement([listener]);
+            const { opener, modeling } = build({ Task_1: element });
+
+            const opened = opener.openListener("Task_1", "executionListener", 0);
+
+            expect(opened).toBe(true);
+            expect(modeling.updateModdleProperties).toHaveBeenCalledWith(element, listener, {
+                class: undefined,
+                expression: undefined,
+                delegateExpression: undefined,
+            });
+            expect(modeling.updateModdleProperties).toHaveBeenCalledWith(element, listener.script, {
+                resource: undefined,
+                value: "",
+            });
+        });
+
+        it("converts a class listener by creating a fresh inline script", () => {
+            const listener = {
+                $type: "camunda:ExecutionListener",
+                event: "end",
+                class: "com.example.Listener",
+            };
+            const element = listenerElement([listener]);
+            const { opener, modeling, bpmnFactory } = build({ Task_1: element });
+
+            const opened = opener.openListener("Task_1", "executionListener", 0);
+
+            expect(opened).toBe(true);
+            expect(bpmnFactory.create).toHaveBeenCalledWith("camunda:Script", {
+                scriptFormat: "",
+                value: "",
+            });
+            expect(modeling.updateModdleProperties).toHaveBeenCalledWith(
+                element,
+                listener,
+                expect.objectContaining({ class: undefined, script: expect.anything() }),
+            );
+        });
+
+        it("returns false when the element or listener is missing", () => {
+            const element = listenerElement([inlineListener("camunda:ExecutionListener")]);
+            const { opener, eventBus } = build({ Task_1: element });
+
+            expect(opener.openListener("Unknown", "executionListener", 0)).toBe(false);
+            expect(opener.openListener("Task_1", "executionListener", 5)).toBe(false);
+            expect(opener.openListener("Task_1", "taskListener", 0)).toBe(false);
+            expect(eventBus.fire).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("openFirstScript", () => {
+        it("prefers the script-task inline script over listeners", () => {
+            const element = {
+                id: "Task_1",
+                businessObject: {
+                    $type: "bpmn:ScriptTask",
+                    script: "inline",
+                    extensionElements: {
+                        values: [inlineListener("camunda:ExecutionListener")],
+                    },
+                },
+            };
+            const { opener, eventBus } = build({ Task_1: element });
+
+            expect(opener.openFirstScript(element)).toBe(true);
+            expect(eventBus.fire).toHaveBeenCalledWith(
+                OPEN_SCRIPT_EDITOR_EVENT,
+                expect.objectContaining({ kind: "script-task" }),
+            );
+        });
+
+        it("prefers execution listeners over task listeners", () => {
+            const element = listenerElement([
+                inlineListener("camunda:TaskListener"),
+                inlineListener("camunda:ExecutionListener"),
+            ]);
+            const { opener, eventBus } = build({ Task_1: element });
+
+            expect(opener.openFirstScript(element)).toBe(true);
+            expect(eventBus.fire).toHaveBeenCalledWith(
+                OPEN_SCRIPT_EDITOR_EVENT,
+                expect.objectContaining({ kind: "execution-listener", listenerIndex: 0 }),
+            );
+        });
+
+        it("falls back to the first task listener", () => {
+            const element = listenerElement([inlineListener("camunda:TaskListener")]);
+            const { opener, eventBus } = build({ Task_1: element });
+
+            expect(opener.openFirstScript(element)).toBe(true);
+            expect(eventBus.fire).toHaveBeenCalledWith(
+                OPEN_SCRIPT_EDITOR_EVENT,
+                expect.objectContaining({ kind: "task-listener" }),
+            );
+        });
+
+        it("returns false when the element has no script", () => {
+            const { opener, eventBus } = build();
+
+            const opened = opener.openFirstScript({
+                id: "Task_1",
+                businessObject: { $type: "bpmn:UserTask" },
+            });
+
+            expect(opened).toBe(false);
+            expect(eventBus.fire).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/bpmn-webview/src/app/scriptEditorOpener.ts
+++ b/apps/bpmn-webview/src/app/scriptEditorOpener.ts
@@ -1,0 +1,172 @@
+import { OPEN_SCRIPT_EDITOR_EVENT, OpenScriptEditorEvent } from "./scriptTaskContextPad";
+import { readScriptTaskFormat } from "./scriptModel";
+
+/**
+ * Model-side entry point for opening a script in the host editor, shared by
+ * every surface that can trigger it (context pad, properties-panel buttons,
+ * keyboard shortcut).
+ *
+ * The DOM-injected buttons and the keyboard shortcut must open scripts
+ * identically — including the undoable conversion of non-inline listeners —
+ * so that logic lives here once instead of being duplicated per surface.
+ */
+
+type ListenerType = "executionListener" | "taskListener";
+
+/**
+ * DI service that fires {@link OPEN_SCRIPT_EDITOR_EVENT} for a script task's
+ * inline script or a listener script, converting listener implementations to
+ * inline `<camunda:script>` first when necessary.
+ */
+export class ScriptEditorOpener {
+    static $inject = ["eventBus", "elementRegistry", "modeling", "bpmnFactory"];
+
+    constructor(
+        private readonly eventBus: any,
+        private readonly elementRegistry: any,
+        private readonly modeling: any,
+        private readonly bpmnFactory: any,
+    ) {}
+
+    /**
+     * Opens the first script the element offers, in the order the properties
+     * panel presents them: the script-task inline script, then execution
+     * listeners, then task listeners. A deterministic order lets a single
+     * keyboard shortcut act on elements carrying several scripts.
+     *
+     * @returns `true` if a script editor was opened.
+     */
+    openFirstScript(element: any): boolean {
+        if (this.openScriptTask(element)) {
+            return true;
+        }
+        for (const listenerType of ["executionListener", "taskListener"] as ListenerType[]) {
+            if (this.listenersOf(element, listenerType).length > 0) {
+                return this.openListener(element.id, listenerType, 0);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Opens the inline script of a `bpmn:ScriptTask`. An unset script opens
+     * as an empty document on purpose — the feature exists to hand the user
+     * an editable stub, including for scripts they have not written yet.
+     *
+     * @returns `true` if the element is a script task and the event fired.
+     */
+    openScriptTask(element: any): boolean {
+        const bo = element?.businessObject;
+        if (!bo || bo.$type !== "bpmn:ScriptTask") {
+            return false;
+        }
+
+        this.eventBus.fire(OPEN_SCRIPT_EDITOR_EVENT, {
+            elementId: element.id,
+            kind: "script-task",
+            listenerIndex: undefined,
+            eventName: undefined,
+            scriptFormat: readScriptTaskFormat(bo),
+            content: bo.script || "",
+        } as OpenScriptEditorEvent);
+        return true;
+    }
+
+    /**
+     * Opens the script of the addressed execution/task listener, converting
+     * it to an inline `<camunda:script>` first if it uses another
+     * implementation type. Looks the element up via the registry rather than
+     * the selection because the properties panel also shows the implicit root
+     * process when nothing is selected.
+     *
+     * @returns `true` if the listener exists and the event fired.
+     */
+    openListener(elementId: string, listenerType: ListenerType, listenerIndex: number): boolean {
+        const element = this.elementRegistry.get(elementId);
+        const listener = element
+            ? this.listenersOf(element, listenerType)[listenerIndex]
+            : undefined;
+        if (!element || !listener) {
+            return false;
+        }
+
+        this.ensureInlineScript(element, listener);
+
+        const kind = listenerType === "executionListener" ? "execution-listener" : "task-listener";
+
+        this.eventBus.fire(OPEN_SCRIPT_EDITOR_EVENT, {
+            elementId,
+            kind,
+            listenerIndex,
+            eventName: listener.get?.("event") ?? listener.event ?? undefined,
+            scriptFormat:
+                listener.script.get?.("scriptFormat") ?? listener.script.scriptFormat ?? "",
+            content: listener.script.get?.("value") ?? listener.script.value ?? "",
+        } as OpenScriptEditorEvent);
+        return true;
+    }
+
+    /**
+     * Converts a listener's implementation to an inline `<camunda:script>`
+     * if it isn't one already. No-op when the listener already uses an
+     * inline script.
+     *
+     * Two paths:
+     * - The listener has a `<camunda:script>` with a `resource` attribute
+     *   (external-resource implementation): strip `resource` and seed an
+     *   empty `value` on the existing element.
+     * - The listener has no script element (Java class / expression /
+     *   delegate expression): create a fresh `<camunda:script>` and clear
+     *   the other implementation attributes in the same update so the
+     *   entire switch is one undoable command.
+     */
+    private ensureInlineScript(element: any, listener: any): void {
+        const existingScript = listener.script;
+        const existingValue = existingScript?.get?.("value") ?? existingScript?.value;
+        if (typeof existingValue === "string") {
+            return;
+        }
+
+        if (existingScript) {
+            this.modeling.updateModdleProperties(element, listener, {
+                class: undefined,
+                expression: undefined,
+                delegateExpression: undefined,
+            });
+            this.modeling.updateModdleProperties(element, existingScript, {
+                resource: undefined,
+                value: "",
+            });
+            return;
+        }
+
+        const script = this.bpmnFactory.create("camunda:Script", {
+            scriptFormat: "",
+            value: "",
+        });
+        this.modeling.updateModdleProperties(element, listener, {
+            class: undefined,
+            expression: undefined,
+            delegateExpression: undefined,
+            script,
+        });
+    }
+
+    private listenersOf(element: any, listenerType: ListenerType): any[] {
+        const extensionType =
+            listenerType === "executionListener"
+                ? "camunda:ExecutionListener"
+                : "camunda:TaskListener";
+        return (element?.businessObject?.extensionElements?.values || []).filter(
+            (e: any) => e.$type === extensionType,
+        );
+    }
+}
+
+/**
+ * bpmn-js / didi module exporting the shared script-editor opener service.
+ * Register via `additionalModules` when creating the C7 modeler.
+ */
+export const ScriptEditorOpenerModule = {
+    scriptEditorOpener: ["type", ScriptEditorOpener],
+};

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -49,6 +49,7 @@ import {
     formatErrors,
     initResizer,
     initTheme,
+    installPanelShortcuts,
     observeCanvasSize,
 } from "@miragon/bpmn-modeler-shared";
 import { VsCodeClipboardModule, LabelClipboardModule } from "@miragon/bpmn-modeler-clipboard";
@@ -300,7 +301,7 @@ async function run(): Promise<void> {
         getToggleLabel: (state) =>
             i18n.translate(
                 state === "collapsed" ? "Open properties panel" : "Close properties panel",
-            ),
+            ) + " (Shift+P)",
         onLabelChange: (apply) => i18n.onChange(apply),
     });
     const vsCodeBridgeModule = {
@@ -423,6 +424,16 @@ async function run(): Promise<void> {
     // latest preference across all BPMN editors.
     propertiesPanelHandle.onVisibilityChanged((visible) => {
         host.postMessage(new SetPropertiesPanelStateCommand(visible));
+    });
+
+    // `p` focuses the properties panel (expanding it first if collapsed);
+    // `Shift+P` toggles panel visibility from anywhere except text fields.
+    // Escape stays with keyboardFocus.ts in BPMN — no escapeToCanvas here.
+    installPanelShortcuts({
+        handle: propertiesPanelHandle,
+        focusCanvas: () => bpmnModeler.getService<{ focus(): void }>("canvas").focus(),
+        isCanvasFocused: () =>
+            bpmnModeler.getService<{ isFocused(): boolean }>("canvas").isFocused(),
     });
 
     // Phase 2: restore selection + panel-side UI state (safe now — side-effects done)

--- a/apps/dmn-webview/src/app/modeler.ts
+++ b/apps/dmn-webview/src/app/modeler.ts
@@ -142,6 +142,19 @@ export function syncCanvasSize(container: Element): () => void {
     return observeCanvasSize({ resized: () => getActiveCanvas()?.resized() }, container);
 }
 
+/** True only when the DRD (diagram) view is active — not decision-table or literal-expression. */
+export function isDrdViewActive(): boolean {
+    return modeler?.getActiveView()?.type === "drd";
+}
+
+/** DRD canvas with focus methods; `undefined` outside the DRD view. */
+export function getActiveFocusableCanvas():
+    | (ResizableCanvas & { focus(): void; isFocused(): boolean })
+    | undefined {
+    const viewer = getModeler().getActiveViewer();
+    return viewer?.get("canvas", false) ?? undefined;
+}
+
 /** `undefined` for the decision-table and literal-expression views. */
 function getActiveCanvas(): ResizableCanvas | undefined {
     const viewer = getModeler().getActiveViewer();

--- a/apps/dmn-webview/src/bootstrap.ts
+++ b/apps/dmn-webview/src/bootstrap.ts
@@ -18,6 +18,7 @@ import {
     GetPropertiesPanelStateCommand,
     initResizer,
     initTheme,
+    installPanelShortcuts,
     LogErrorCommand,
     LogWarningCommand,
     NoModelerError,
@@ -33,6 +34,8 @@ import { extras as i18nExtras } from "@miragon/bpmn-modeler-i18n-extras";
 import {
     createModeler,
     exportDiagram,
+    getActiveFocusableCanvas,
+    isDrdViewActive,
     loadDiagram,
     onCommandStackChanged,
     syncCanvasSize,
@@ -145,7 +148,7 @@ async function run(): Promise<void> {
         getToggleLabel: (state) =>
             i18n.translate(
                 state === "collapsed" ? "Open properties panel" : "Close properties panel",
-            ),
+            ) + " (Shift+P)",
         onLabelChange: (apply) => i18n.onChange(apply),
     });
 
@@ -166,6 +169,17 @@ async function run(): Promise<void> {
     propertiesPanelHandle.setVisible(panelState?.visible ?? true);
     propertiesPanelHandle.onVisibilityChanged((visible) => {
         host.postMessage(new SetPropertiesPanelStateCommand(visible));
+    });
+
+    // `p` / `Shift+P` / Escape shortcuts for the properties panel, gated to
+    // the DRD view so they stay inert in decision-table and literal-expression
+    // views (where Escape must not steal focus from cell editing).
+    installPanelShortcuts({
+        handle: propertiesPanelHandle,
+        focusCanvas: () => getActiveFocusableCanvas()?.focus(),
+        isCanvasFocused: () => getActiveFocusableCanvas()?.isFocused() ?? false,
+        isEnabled: () => isDrdViewActive(),
+        escapeToCanvas: true,
     });
 
     stateManager.restorePanelUiState();

--- a/docs/vscode/features/append-menu.md
+++ b/docs/vscode/features/append-menu.md
@@ -47,6 +47,10 @@ By default, the BPMN palette shows only icons to keep the panel compact. Click t
 
 Clicking anywhere outside the panel also closes it.
 
+> **See also:** [Flow Navigation](/vscode/features/flow-navigation) adds
+> Tab / Shift+Tab / Enter traversal along sequence flows — complementary to
+> the append menu for fully keyboard-driven modeling.
+
 ## Search
 
 The search bar filters both panels simultaneously:

--- a/docs/vscode/features/flow-navigation.md
+++ b/docs/vscode/features/flow-navigation.md
@@ -20,6 +20,9 @@ Navigate the BPMN diagram along sequence flows using the keyboard.
 | **Enter** | Sequence flow | Follow the flow to its target |
 | **Enter** | Boundary event (candidate) | Commit the boundary (stay selected, resume navigation from it) |
 | **Shift+Enter** | Sequence flow | Follow the flow to its source |
+| **Enter** | Collapsed subprocess | Drill into the subprocess plane, select first start event |
+| **u** | Inside a subprocess plane | Drill out one level, re-select the subprocess shape |
+| **g** | Call activity / business-rule / service / send task with a link | Jump to the referenced model or implementation file |
 | **Tab** _(nothing selected)_ | Canvas | Select the first start event |
 | **Shift+Tab** _(nothing selected)_ | Canvas | Select the first end event |
 | **p** | Canvas | Focus the properties panel (expands if collapsed) |
@@ -66,6 +69,12 @@ boundary events behave identically to before.
 - **Canvas focus** (`Escape`): pressing Escape refocuses the canvas SVG from
   the properties panel. Once the canvas has focus, Tab/Shift+Tab navigate the
   diagram instead of cycling form fields.
+- **Go to linked file** (`g`): triggers the jump-to-file context-pad entry on
+  the selected element — referenced model on call activities or implementation
+  file on service/send tasks. When an element has no link (or the host reported
+  the reference as unresolvable), the key does nothing. If both a referenced
+  model and an implementation link exist (theoretically on a business-rule task),
+  the referenced model takes precedence.
 - **Properties panel** (`p` / `Shift+P`): `p` on the canvas focuses the first
   field in the properties panel (expanding it if collapsed); `Shift+P` toggles
   panel visibility from anywhere except text fields; Escape returns to the
@@ -73,10 +82,19 @@ boundary events behave identically to before.
   Tab inside the properties panel still performs native field traversal — flow
   navigation only fires while the canvas SVG has focus.
 
-## Known limitations (v1)
+## Subprocess walkthrough
 
-- Subprocess drill-down/up is not wired — navigation stays within the current
-  root plane (expanded inline subprocesses work normally).
+1. Model a collapsed subprocess containing a start event.
+2. Select the collapsed subprocess and press **Enter** — the view drills into
+   the subprocess plane and auto-selects the first start event inside.
+3. Navigate inside the subprocess with **Tab** / **Shift+Tab** as usual.
+4. Press **u** to drill out — the view returns to the parent plane with the
+   subprocess shape selected. Works from any selection state, and from nested
+   subprocesses (one level per press). At the top-level process, **u** does
+   nothing. Breadcrumbs stay in sync automatically.
+
+## Known limitations
+
 - No visual affordance for "Enter will follow this flow" — a future iteration
   can reuse the `canvasFocusIndicator.ts` pattern.
 - Tab on the canvas no longer escapes to the properties panel — use `p` to

--- a/docs/vscode/features/flow-navigation.md
+++ b/docs/vscode/features/flow-navigation.md
@@ -17,6 +17,9 @@ Navigate the BPMN diagram along sequence flows using the keyboard.
 | **Shift+Enter** | Sequence flow | Follow the flow to its source |
 | **Tab** _(nothing selected)_ | Canvas | Select the first start event |
 | **Shift+Tab** _(nothing selected)_ | Canvas | Select the first end event |
+| **p** | Canvas | Focus the properties panel (expands if collapsed) |
+| **Shift+P** | Anywhere (not text field) | Toggle properties panel visibility |
+| **Escape** | Properties panel | Return focus to the canvas |
 
 **Ctrl/Cmd+Tab** and **Alt+Tab** are deliberately passed through so VS Code
 tab switching and OS window switching keep working.
@@ -38,8 +41,12 @@ tab switching and OS window switching keep working.
 - **Canvas focus** (`Escape`): pressing Escape refocuses the canvas SVG from
   the properties panel. Once the canvas has focus, Tab/Shift+Tab navigate the
   diagram instead of cycling form fields.
-- **Properties panel**: Tab inside the properties panel still performs native
-  field traversal — flow navigation only fires while the canvas SVG has focus.
+- **Properties panel** (`p` / `Shift+P`): `p` on the canvas focuses the first
+  field in the properties panel (expanding it if collapsed); `Shift+P` toggles
+  panel visibility from anywhere except text fields; Escape returns to the
+  canvas. The round-trip is `p` → edit properties → Escape → resume navigation.
+  Tab inside the properties panel still performs native field traversal — flow
+  navigation only fires while the canvas SVG has focus.
 
 ## Known limitations (v1)
 
@@ -48,5 +55,5 @@ tab switching and OS window switching keep working.
   root plane (expanded inline subprocesses work normally).
 - No visual affordance for "Enter will follow this flow" — a future iteration
   can reuse the `canvasFocusIndicator.ts` pattern.
-- Consuming Tab on the canvas means Tab no longer escapes to the properties
-  panel. Use Escape + mouse click or Ctrl+Tab to reach other panels.
+- Tab on the canvas no longer escapes to the properties panel — use `p` to
+  focus it, `Shift+P` to toggle visibility, and Escape to return to the canvas.

--- a/docs/vscode/features/flow-navigation.md
+++ b/docs/vscode/features/flow-navigation.md
@@ -10,8 +10,8 @@ Navigate the BPMN diagram along sequence flows using the keyboard.
 | **Tab** | Shape with N outgoing (fan-out) | Select the first outgoing flow |
 | **Tab** | Flow in a fan | Cycle to the next sibling flow (wraps) |
 | **Shift+Tab** | Shape with 1 incoming | Jump backward to the source shape |
-| **Shift+Tab** | Shape with N incoming (fan-in) | Select the first incoming flow |
-| **Shift+Tab** | Flow in a fan | Cycle to the previous sibling flow (wraps) |
+| **Shift+Tab** | Shape with N incoming (fan-in) | Jump to the source of the first incoming flow (sorted top-left) |
+| **Shift+Tab** | Flow in a source fan | Cycle to the previous sibling flow (wraps) |
 | **Tab** | Shape with outgoing + boundary events (mixed fan) | Select the first candidate (flow or boundary) |
 | **Tab** | Flow or boundary candidate in a mixed fan | Cycle to the next candidate (wraps) |
 | **Tab** | Shape with 0 outgoing, 1 boundary | Jump to the boundary event (committed) |
@@ -75,7 +75,6 @@ boundary events behave identically to before.
 
 ## Known limitations (v1)
 
-- A flow whose source **and** target both fan always cycles the source fan.
 - Subprocess drill-down/up is not wired — navigation stays within the current
   root plane (expanded inline subprocesses work normally).
 - No visual affordance for "Enter will follow this flow" — a future iteration

--- a/docs/vscode/features/flow-navigation.md
+++ b/docs/vscode/features/flow-navigation.md
@@ -23,6 +23,7 @@ Navigate the BPMN diagram along sequence flows using the keyboard.
 | **Enter** | Collapsed subprocess | Drill into the subprocess plane, select first start event |
 | **u** | Inside a subprocess plane | Drill out one level, re-select the subprocess shape |
 | **g** | Call activity / business-rule / service / send task with a link | Jump to the referenced model or implementation file |
+| **o** | Script task, or task with execution/task listeners (Camunda 7) | Open the first script in an editor tab (same as the "Open script in editor" button) |
 | **Tab** _(nothing selected)_ | Canvas | Select the first start event |
 | **Shift+Tab** _(nothing selected)_ | Canvas | Select the first end event |
 | **p** | Canvas | Focus the properties panel (expands if collapsed) |

--- a/docs/vscode/features/flow-navigation.md
+++ b/docs/vscode/features/flow-navigation.md
@@ -12,8 +12,13 @@ Navigate the BPMN diagram along sequence flows using the keyboard.
 | **Shift+Tab** | Shape with 1 incoming | Jump backward to the source shape |
 | **Shift+Tab** | Shape with N incoming (fan-in) | Select the first incoming flow |
 | **Shift+Tab** | Flow in a fan | Cycle to the previous sibling flow (wraps) |
+| **Tab** | Shape with outgoing + boundary events (mixed fan) | Select the first candidate (flow or boundary) |
+| **Tab** | Flow or boundary candidate in a mixed fan | Cycle to the next candidate (wraps) |
+| **Tab** | Shape with 0 outgoing, 1 boundary | Jump to the boundary event (committed) |
+| **Tab** | Committed boundary event | Step along its own outgoing flows |
 | **Shift+Tab** | Boundary event (0 incoming) | Jump to the host shape |
 | **Enter** | Sequence flow | Follow the flow to its target |
+| **Enter** | Boundary event (candidate) | Commit the boundary (stay selected, resume navigation from it) |
 | **Shift+Enter** | Sequence flow | Follow the flow to its source |
 | **Tab** _(nothing selected)_ | Canvas | Select the first start event |
 | **Shift+Tab** _(nothing selected)_ | Canvas | Select the first end event |
@@ -33,6 +38,26 @@ tab switching and OS window switching keep working.
 5. Append elements with **a**, then press **Shift+Tab** to walk back to the
    gateway.
 6. Repeat from step 3 for the next branch.
+
+## Boundary-event walkthrough
+
+1. Model a task with one outgoing sequence flow and one or two attached
+   boundary events.
+2. Select the task and press **Tab** — the first candidate in the mixed fan
+   (sorted top-left by representative position) is selected. Boundary events
+   show as *candidates*; flows show as normal fan entries.
+3. Press **Tab** to cycle through the candidates (flows and boundary events
+   together, wrapping at the end).
+4. When a boundary event is highlighted, press **Enter** to *commit* — the
+   boundary stays selected and subsequent Tab/Shift+Tab navigate from the
+   boundary's own outgoing flows.
+5. Press **Shift+Tab** on a boundary with no incoming flows to jump back to
+   the host task.
+
+**Behaviour change:** a 1-to-1 sequence flow whose source has attached
+boundary events now cycles within the mixed fan on Tab instead of jumping
+straight to its target. **Enter** still follows the flow. Diagrams without
+boundary events behave identically to before.
 
 ## Interaction with other keyboard features
 

--- a/docs/vscode/features/flow-navigation.md
+++ b/docs/vscode/features/flow-navigation.md
@@ -1,0 +1,52 @@
+# Flow Navigation (keyboard diagram traversal)
+
+Navigate the BPMN diagram along sequence flows using the keyboard.
+
+## Key bindings
+
+| Key | Context | Action |
+|---|---|---|
+| **Tab** | Shape with 1 outgoing | Jump forward to the target shape |
+| **Tab** | Shape with N outgoing (fan-out) | Select the first outgoing flow |
+| **Tab** | Flow in a fan | Cycle to the next sibling flow (wraps) |
+| **Shift+Tab** | Shape with 1 incoming | Jump backward to the source shape |
+| **Shift+Tab** | Shape with N incoming (fan-in) | Select the first incoming flow |
+| **Shift+Tab** | Flow in a fan | Cycle to the previous sibling flow (wraps) |
+| **Shift+Tab** | Boundary event (0 incoming) | Jump to the host shape |
+| **Enter** | Sequence flow | Follow the flow to its target |
+| **Shift+Enter** | Sequence flow | Follow the flow to its source |
+| **Tab** _(nothing selected)_ | Canvas | Select the first start event |
+| **Shift+Tab** _(nothing selected)_ | Canvas | Select the first end event |
+
+**Ctrl/Cmd+Tab** and **Alt+Tab** are deliberately passed through so VS Code
+tab switching and OS window switching keep working.
+
+## Gateway walkthrough
+
+1. Model a gateway with two or three outgoing branches.
+2. Select the gateway and press **Tab** — the first outgoing flow is selected.
+3. Press **Tab** again to cycle to the next flow (wraps around at the end).
+4. Press **Enter** to follow the selected flow into its branch.
+5. Append elements with **a**, then press **Shift+Tab** to walk back to the
+   gateway.
+6. Repeat from step 3 for the next branch.
+
+## Interaction with other keyboard features
+
+- **Append menu** (`a`): flow navigation and append-menu are complementary —
+  navigate to a shape, then press `a` to append a new element.
+- **Canvas focus** (`Escape`): pressing Escape refocuses the canvas SVG from
+  the properties panel. Once the canvas has focus, Tab/Shift+Tab navigate the
+  diagram instead of cycling form fields.
+- **Properties panel**: Tab inside the properties panel still performs native
+  field traversal — flow navigation only fires while the canvas SVG has focus.
+
+## Known limitations (v1)
+
+- A flow whose source **and** target both fan always cycles the source fan.
+- Subprocess drill-down/up is not wired — navigation stays within the current
+  root plane (expanded inline subprocesses work normally).
+- No visual affordance for "Enter will follow this flow" — a future iteration
+  can reuse the `canvasFocusIndicator.ts` pattern.
+- Consuming Tab on the canvas means Tab no longer escapes to the properties
+  panel. Use Escape + mouse click or Ctrl+Tab to reach other panels.

--- a/docs/vscode/features/index.md
+++ b/docs/vscode/features/index.md
@@ -8,6 +8,9 @@ Here's what you get, roughly in the order you reach for it.
 - **[Append Menu](/vscode/features/append-menu)** — a two-panel popup that
   combines element templates and standard BPMN elements. Searchable,
   keyboard-driven, favourites pinned on top.
+- **[Flow Navigation](/vscode/features/flow-navigation)** — traverse the
+  diagram along sequence flows with Tab / Shift+Tab and follow branches
+  with Enter. Complements the append menu for fully keyboard-driven modeling.
 - **[Element Template Chooser](/vscode/features/element-template-chooser)** —
   browse, preview, and apply Camunda element templates from the properties
   panel. Category filters, instant search, full template preview.

--- a/docs/vscode/features/inline-scripting.md
+++ b/docs/vscode/features/inline-scripting.md
@@ -38,7 +38,7 @@ written back into the BPMN model so subsequent opens skip the prompt.
 
 ## Usage
 
-There are three entry points. They all open the same kind of editor tab
+There are four entry points. They all open the same kind of editor tab
 beside the diagram.
 
 ### 1. Script Task — Context Pad
@@ -84,6 +84,14 @@ implementation. Clicking it converts the listener to an inline
 > (e.g. a Java class reference) with an empty inline script. Press
 > <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Z</kbd> on the diagram to revert if
 > you opened the editor by mistake.
+
+### 4. Keyboard Shortcut — <kbd>o</kbd>
+
+With a single element selected on the canvas, press <kbd>o</kbd> to open
+its first script — the same action as clicking the button. "First" follows
+the properties-panel order: the script task's inline script, then execution
+listeners, then task listeners. On elements without any script the key does
+nothing. The same listener-conversion heads-up as above applies.
 
 ## Generate Script Files for Script Tasks
 

--- a/libs/bpmn-i18n-extras/src/languages/de.ts
+++ b/libs/bpmn-i18n-extras/src/languages/de.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "Wird bearbeitet in",
+    "Element actions": "Elementaktionen",
     "Read-only": "Schreibgeschützt",
 };
 

--- a/libs/bpmn-i18n-extras/src/languages/en.ts
+++ b/libs/bpmn-i18n-extras/src/languages/en.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "Being edited in",
+    "Element actions": "Element actions",
     "Read-only": "Read-only",
 };
 

--- a/libs/bpmn-i18n-extras/src/languages/es.ts
+++ b/libs/bpmn-i18n-extras/src/languages/es.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "Se está editando en",
+    "Element actions": "Acciones del elemento",
     "Read-only": "Solo lectura",
 };
 

--- a/libs/bpmn-i18n-extras/src/languages/fr.ts
+++ b/libs/bpmn-i18n-extras/src/languages/fr.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "En cours d'édition dans",
+    "Element actions": "Actions de l'élément",
     "Read-only": "Lecture seule",
 };
 

--- a/libs/bpmn-i18n-extras/src/languages/it.ts
+++ b/libs/bpmn-i18n-extras/src/languages/it.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "In modifica in",
+    "Element actions": "Azioni elemento",
     "Read-only": "Sola lettura",
 };
 

--- a/libs/bpmn-i18n-extras/src/languages/ja.ts
+++ b/libs/bpmn-i18n-extras/src/languages/ja.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "編集中:",
+    "Element actions": "要素アクション",
     "Read-only": "読み取り専用",
 };
 

--- a/libs/bpmn-i18n-extras/src/languages/ko.ts
+++ b/libs/bpmn-i18n-extras/src/languages/ko.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "편집 중:",
+    "Element actions": "요소 작업",
     "Read-only": "읽기 전용",
 };
 

--- a/libs/bpmn-i18n-extras/src/languages/nl-nl.ts
+++ b/libs/bpmn-i18n-extras/src/languages/nl-nl.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "Wordt bewerkt in",
+    "Element actions": "Elementacties",
     "Read-only": "Alleen-lezen",
 };
 

--- a/libs/bpmn-i18n-extras/src/languages/pt-br.ts
+++ b/libs/bpmn-i18n-extras/src/languages/pt-br.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "Sendo editado em",
+    "Element actions": "Ações do elemento",
     "Read-only": "Somente leitura",
 };
 

--- a/libs/bpmn-i18n-extras/src/languages/ru.ts
+++ b/libs/bpmn-i18n-extras/src/languages/ru.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "Редактируется в",
+    "Element actions": "Действия элемента",
     "Read-only": "Только чтение",
 };
 

--- a/libs/bpmn-i18n-extras/src/languages/zh-Hans.ts
+++ b/libs/bpmn-i18n-extras/src/languages/zh-Hans.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "正在编辑于",
+    "Element actions": "元素操作",
     "Read-only": "只读",
 };
 

--- a/libs/bpmn-i18n-extras/src/languages/zh-Hant.ts
+++ b/libs/bpmn-i18n-extras/src/languages/zh-Hant.ts
@@ -8,6 +8,7 @@
  */
 const dictionary: Record<string, string> = {
     "Being edited in": "正在編輯於",
+    "Element actions": "元素操作",
     "Read-only": "唯讀",
 };
 

--- a/libs/bpmn-i18n-extras/src/overlayNeeded.spec.ts
+++ b/libs/bpmn-i18n-extras/src/overlayNeeded.spec.ts
@@ -32,7 +32,7 @@ const norm = (value: string): string =>
         .replace(/[.\s]+$/, "");
 
 // Kept in sync with SOURCE_ONLY in tools/build-overlay.mjs.
-const SOURCE_ONLY = new Set(["Read-only", "Being edited in"]);
+const SOURCE_ONLY = new Set(["Read-only", "Being edited in", "Element actions"]);
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const { keys: harvested } = JSON.parse(

--- a/libs/bpmn-i18n-extras/tools/build-overlay.mjs
+++ b/libs/bpmn-i18n-extras/tools/build-overlay.mjs
@@ -66,7 +66,7 @@ const sharedByNorm = new Set(Object.keys(shared.en).map(norm));
 // that the harvest driver never reaches — it doesn't exercise the script-lock /
 // code-link feature, so these are absent from harvested.json but genuinely
 // needed and absent from the shared library. Keep them until upstreamed.
-const SOURCE_ONLY = new Set(["Read-only", "Being edited in"]);
+const SOURCE_ONLY = new Set(["Read-only", "Being edited in", "Element actions"]);
 
 const load = async (locale) => (await import(join(LANG_DIR, `${locale}.ts`))).default;
 const en = await load("en");

--- a/libs/flow-navigation/README.md
+++ b/libs/flow-navigation/README.md
@@ -37,6 +37,9 @@ new BpmnModeler({ additionalModules: [FlowNavigationModule] });
 | Enter | Sequence flow | Jump to flow target |
 | Enter | Boundary candidate | Commit (stay selected, navigate from it) |
 | Shift+Enter | Sequence flow | Jump to flow source |
+| Enter | Collapsed subprocess (1 selected) | Drill into its plane, select first start event |
+| u | Inside a subprocess plane | Drill out one level, re-select the subprocess |
+| g | Element with a link (call activity, service/send/business-rule task) | Jump to referenced model or implementation file |
 | Ctrl/Cmd+Tab | — | Pass through to VS Code / OS |
 
 When nothing is selected, Tab picks the first start event (sorted top-left);
@@ -54,10 +57,8 @@ boundary events now cycles within the mixed fan on Tab instead of jumping to
 its target. Enter still follows the flow. Diagrams without boundary events
 behave identically to v1.
 
-## Known limitations (v1)
+## Known limitations
 
-- Subprocess drill-down/up is not wired — navigation stays within the current
-  root plane (expanded inline subprocesses work normally).
 - No visual "Enter follows this" affordance yet — a future iteration can reuse
   the `canvasFocusIndicator.ts` pattern.
 - Tab on the focused canvas no longer escapes to the properties panel — use

--- a/libs/flow-navigation/README.md
+++ b/libs/flow-navigation/README.md
@@ -1,0 +1,51 @@
+# `@miragon/bpmn-modeler-flow-navigation`
+
+Adds keyboard-driven diagram traversal to the bpmn-js modeler: **Tab** moves
+the selection forward along sequence flows, **Shift+Tab** backward. At a
+fan-out (element with multiple outgoing flows) Tab cycles through the outgoing
+flows and **Enter** follows the selected flow to its target.
+
+## Why this exists
+
+Keyboard-first modeling works well up to the point of branching: after
+appending a task behind a gateway the selection sits on the new task and there
+is no keyboard way back to the gateway to append the next branch. This module
+adds the missing traversal so the user never has to reach for the mouse
+mid-flow.
+
+## Usage
+
+```ts
+import { FlowNavigationModule } from "@miragon/bpmn-modeler-flow-navigation";
+
+new BpmnModeler({ additionalModules: [FlowNavigationModule] });
+```
+
+## Key bindings
+
+| Key | Selection | Action |
+|---|---|---|
+| Tab | Shape (1 outgoing) | Jump to target shape |
+| Tab | Shape (N outgoing) | Select first outgoing flow |
+| Tab | Flow (in fan) | Cycle to next sibling flow |
+| Shift+Tab | Shape (1 incoming) | Jump to source shape |
+| Shift+Tab | Shape (N incoming) | Select first incoming flow |
+| Shift+Tab | Flow (in fan) | Cycle to previous sibling flow |
+| Shift+Tab | Boundary event (0 incoming) | Jump to host shape |
+| Enter | Sequence flow | Jump to flow target |
+| Shift+Enter | Sequence flow | Jump to flow source |
+| Ctrl/Cmd+Tab | — | Pass through to VS Code / OS |
+
+When nothing is selected, Tab picks the first start event (sorted top-left);
+Shift+Tab picks the first end event.
+
+## Known limitations (v1)
+
+- A flow whose source **and** target both fan always cycles the source fan.
+- Subprocess drill-down/up is not wired — navigation stays within the current
+  root plane (expanded inline subprocesses work normally).
+- No visual "Enter follows this" affordance yet — a future iteration can reuse
+  the `canvasFocusIndicator.ts` pattern.
+- Consuming Tab on the focused canvas removes Tab-to-properties-panel as an
+  escape route. Ctrl/Cmd/Alt+Tab are deliberately passed through; mouse focus
+  is unaffected.

--- a/libs/flow-navigation/README.md
+++ b/libs/flow-navigation/README.md
@@ -46,6 +46,11 @@ Shift+Tab picks the first end event.
   root plane (expanded inline subprocesses work normally).
 - No visual "Enter follows this" affordance yet — a future iteration can reuse
   the `canvasFocusIndicator.ts` pattern.
-- Consuming Tab on the focused canvas removes Tab-to-properties-panel as an
-  escape route. Ctrl/Cmd/Alt+Tab are deliberately passed through; mouse focus
-  is unaffected.
+- Tab on the focused canvas no longer escapes to the properties panel — use
+  `p` to focus it, `Shift+P` to toggle visibility, and Escape to return.
+  Ctrl/Cmd/Alt+Tab are deliberately passed through; mouse focus is unaffected.
+
+## Related shortcuts
+
+`p` (focus panel), `Shift+P` (toggle panel), and Escape (return to canvas) are
+wired in `libs/shared/src/lib/propertiesPanelFocus.ts`, not in this module.

--- a/libs/flow-navigation/README.md
+++ b/libs/flow-navigation/README.md
@@ -25,19 +25,34 @@ new BpmnModeler({ additionalModules: [FlowNavigationModule] });
 
 | Key | Selection | Action |
 |---|---|---|
-| Tab | Shape (1 outgoing) | Jump to target shape |
-| Tab | Shape (N outgoing) | Select first outgoing flow |
-| Tab | Flow (in fan) | Cycle to next sibling flow |
+| Tab | Shape (1 outgoing, 0 boundaries) | Jump to target shape |
+| Tab | Shape (N outgoing + boundaries) | Select first candidate in mixed fan |
+| Tab | Shape (0 outgoing, 1 boundary) | Jump to boundary (committed) |
+| Tab | Flow or boundary candidate (in fan) | Cycle to next candidate |
+| Tab | Committed boundary event | Step along its own outgoing flows |
 | Shift+Tab | Shape (1 incoming) | Jump to source shape |
 | Shift+Tab | Shape (N incoming) | Select first incoming flow |
 | Shift+Tab | Flow (in fan) | Cycle to previous sibling flow |
 | Shift+Tab | Boundary event (0 incoming) | Jump to host shape |
 | Enter | Sequence flow | Jump to flow target |
+| Enter | Boundary candidate | Commit (stay selected, navigate from it) |
 | Shift+Enter | Sequence flow | Jump to flow source |
 | Ctrl/Cmd+Tab | — | Pass through to VS Code / OS |
 
 When nothing is selected, Tab picks the first start event (sorted top-left);
 Shift+Tab picks the first end event.
+
+The **mixed fan** (C) for a shape is defined as the union of its outgoing
+sequence flows and its attached boundary events, sorted y-then-x by
+*representative shape* (flow → its target, boundary event → itself). Tab from
+the shape or any candidate in the fan cycles through C; Enter on a boundary
+candidate *commits* it — the boundary stays selected and subsequent navigation
+continues from the boundary's own outgoing flows.
+
+**Behaviour change (v2):** a 1-to-1 sequence flow whose source has attached
+boundary events now cycles within the mixed fan on Tab instead of jumping to
+its target. Enter still follows the flow. Diagrams without boundary events
+behave identically to v1.
 
 ## Known limitations (v1)
 

--- a/libs/flow-navigation/README.md
+++ b/libs/flow-navigation/README.md
@@ -31,8 +31,8 @@ new BpmnModeler({ additionalModules: [FlowNavigationModule] });
 | Tab | Flow or boundary candidate (in fan) | Cycle to next candidate |
 | Tab | Committed boundary event | Step along its own outgoing flows |
 | Shift+Tab | Shape (1 incoming) | Jump to source shape |
-| Shift+Tab | Shape (N incoming) | Select first incoming flow |
-| Shift+Tab | Flow (in fan) | Cycle to previous sibling flow |
+| Shift+Tab | Shape (N incoming) | Jump to the source of the first incoming flow (sorted top-left) |
+| Shift+Tab | Flow in a source fan | Cycle to previous sibling flow |
 | Shift+Tab | Boundary event (0 incoming) | Jump to host shape |
 | Enter | Sequence flow | Jump to flow target |
 | Enter | Boundary candidate | Commit (stay selected, navigate from it) |
@@ -56,7 +56,6 @@ behave identically to v1.
 
 ## Known limitations (v1)
 
-- A flow whose source **and** target both fan always cycles the source fan.
 - Subprocess drill-down/up is not wired — navigation stays within the current
   root plane (expanded inline subprocesses work normally).
 - No visual "Enter follows this" affordance yet — a future iteration can reuse

--- a/libs/flow-navigation/package.json
+++ b/libs/flow-navigation/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@miragon/bpmn-modeler-flow-navigation",
+    "version": "0.0.1",
+    "private": true,
+    "scripts": {
+        "build": "tsc --noEmit",
+        "test": "vitest run"
+    },
+    "peerDependencies": {
+        "bpmn-js": "18.19.0"
+    },
+    "devDependencies": {
+        "typescript": "6.0.3",
+        "vitest": "4.1.9"
+    }
+}

--- a/libs/flow-navigation/src/ContextPadKeyboard.spec.ts
+++ b/libs/flow-navigation/src/ContextPadKeyboard.spec.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextPadKeyboard } from "./ContextPadKeyboard";
+
+// ---------------------------------------------------------------------------
+// Test harness — mirrors FlowNavigation.spec.ts style.
+// ---------------------------------------------------------------------------
+
+function build() {
+    let listener!: (ctx: { keyEvent: KeyboardEvent }) => boolean | undefined;
+
+    const keyboard = {
+        addListener: vi.fn((l: typeof listener) => {
+            listener = l;
+        }),
+        isCmd: vi.fn((e: KeyboardEvent) => !!(e.ctrlKey || e.metaKey)),
+    };
+
+    const selection = {
+        get: vi.fn((): { id: string }[] => []),
+    };
+
+    const padEntries: Record<string, Record<string, unknown>> = {};
+    const contextPad = {
+        getEntries: vi.fn(() => padEntries),
+        getPad: vi.fn(() => ({
+            html: {
+                getBoundingClientRect: () => ({
+                    left: 100,
+                    bottom: 200,
+                    top: 150,
+                    right: 140,
+                    width: 40,
+                    height: 50,
+                }),
+            },
+        })),
+        isShown: vi.fn(() => true),
+        open: vi.fn(),
+        triggerEntry: vi.fn(),
+    };
+
+    const registeredProviders: Record<string, unknown> = {};
+    const popupMenu = {
+        registerProvider: vi.fn((id: string, provider: unknown) => {
+            registeredProviders[id] = provider;
+        }),
+        isOpen: vi.fn(() => false),
+        open: vi.fn(),
+    };
+
+    const canvas = {};
+
+    const services: Record<string, unknown> = {};
+    const injector = {
+        get: vi.fn((name: string) => services[name] ?? null),
+    };
+
+    const translate = vi.fn((key: string) => key);
+
+    new ContextPadKeyboard(
+        keyboard as never,
+        selection as never,
+        contextPad as never,
+        popupMenu as never,
+        canvas as never,
+        injector as never,
+        translate as never,
+    );
+
+    function dispatch(key: string, opts?: { ctrl?: boolean; alt?: boolean }): boolean | undefined {
+        return listener({
+            keyEvent: {
+                key,
+                ctrlKey: opts?.ctrl ?? false,
+                metaKey: false,
+                altKey: opts?.alt ?? false,
+            } as unknown as KeyboardEvent,
+        });
+    }
+
+    return {
+        keyboard,
+        selection,
+        contextPad,
+        popupMenu,
+        injector,
+        services,
+        translate,
+        registeredProviders,
+        padEntries,
+        dispatch,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ContextPadKeyboard", () => {
+    it("registers context-pad-actions provider", () => {
+        const { registeredProviders } = build();
+
+        expect(registeredProviders["context-pad-actions"]).toBeDefined();
+    });
+
+    it("m + single selection opens popup menu with pad-derived position", () => {
+        const { selection, popupMenu, padEntries, dispatch } = build();
+        const task = { id: "task", type: "bpmn:Task", x: 200, y: 200 };
+        selection.get.mockReturnValue([task]);
+        padEntries.replace = { title: "Replace", action: vi.fn() };
+
+        const result = dispatch("m");
+
+        expect(result).toBe(true);
+        expect(popupMenu.open).toHaveBeenCalledWith(
+            task,
+            "context-pad-actions",
+            { x: 100, y: 206 },
+            expect.objectContaining({ title: "Element actions", search: true, width: 300 }),
+        );
+    });
+
+    it("no selection → undefined (key not consumed)", () => {
+        const { dispatch } = build();
+
+        expect(dispatch("m")).toBeUndefined();
+    });
+
+    it("Cmd+m → undefined", () => {
+        const { selection, dispatch } = build();
+        selection.get.mockReturnValue([{ id: "t" }]);
+
+        expect(dispatch("m", { ctrl: true })).toBeUndefined();
+    });
+
+    it("Alt+m → undefined", () => {
+        const { selection, dispatch } = build();
+        selection.get.mockReturnValue([{ id: "t" }]);
+
+        expect(dispatch("m", { alt: true })).toBeUndefined();
+    });
+
+    it("directEditing active → undefined", () => {
+        const { selection, services, padEntries, dispatch } = build();
+        selection.get.mockReturnValue([{ id: "t" }]);
+        padEntries.replace = { title: "Replace", action: vi.fn() };
+        services.directEditing = { isActive: () => true };
+
+        expect(dispatch("m")).toBeUndefined();
+    });
+
+    it("popupMenu already open → undefined", () => {
+        const { selection, popupMenu, padEntries, dispatch } = build();
+        selection.get.mockReturnValue([{ id: "t" }]);
+        padEntries.replace = { title: "Replace", action: vi.fn() };
+        popupMenu.isOpen.mockReturnValue(true);
+
+        expect(dispatch("m")).toBeUndefined();
+    });
+
+    it("provider delegates through getEntries and triggerEntry", () => {
+        const { registeredProviders, contextPad } = build();
+        const provider = registeredProviders["context-pad-actions"] as {
+            getPopupMenuEntries(target: unknown): Record<string, { action: () => void }>;
+        };
+        const target = { id: "t" };
+        contextPad.getEntries.mockReturnValue({
+            replace: { title: "Replace", action: { click: vi.fn() } },
+        });
+
+        const entries = provider.getPopupMenuEntries(target);
+        entries.replace.action();
+
+        expect(contextPad.triggerEntry).toHaveBeenCalledWith("replace", "click", expect.any(Event));
+    });
+
+    it("provider re-opens pad when isShown() is false before triggering", () => {
+        const { registeredProviders, contextPad } = build();
+        const provider = registeredProviders["context-pad-actions"] as {
+            getPopupMenuEntries(target: unknown): Record<string, { action: () => void }>;
+        };
+        const target = { id: "t" };
+        contextPad.getEntries.mockReturnValue({
+            connect: { title: "Connect", action: vi.fn() },
+        });
+        contextPad.isShown.mockReturnValue(false);
+
+        const entries = provider.getPopupMenuEntries(target);
+        entries.connect.action();
+
+        expect(contextPad.open).toHaveBeenCalledWith(target, true);
+        expect(contextPad.triggerEntry).toHaveBeenCalled();
+    });
+
+    it("empty entries → not opened, key not consumed", () => {
+        const { selection, popupMenu, dispatch } = build();
+        selection.get.mockReturnValue([{ id: "t" }]);
+
+        expect(dispatch("m")).toBeUndefined();
+        expect(popupMenu.open).not.toHaveBeenCalled();
+    });
+});

--- a/libs/flow-navigation/src/ContextPadKeyboard.ts
+++ b/libs/flow-navigation/src/ContextPadKeyboard.ts
@@ -1,0 +1,136 @@
+/**
+ * Opens an element-actions popup menu on "m" that mirrors the context
+ * pad's entries for keyboard-only operation.
+ *
+ * The stock context pad DOM is non-focusable and has no upstream keyboard
+ * support. Instead of hacking focus into it, this service reuses the
+ * diagram-js popup menu (ArrowUp/Down, Enter, Escape, and fuzzy search
+ * come for free) with a dedicated provider id.
+ */
+import { buildMenuEntries, type MenuEntry, type PadEntry } from "./contextPadMenu";
+
+// ---------------------------------------------------------------------------
+// Structural service interfaces — satisfied by diagram-js at runtime,
+// mocked with plain objects in tests.
+// ---------------------------------------------------------------------------
+
+interface Keyboard {
+    addListener(listener: (ctx: { keyEvent: KeyboardEvent }) => boolean | undefined): void;
+    isCmd(event: KeyboardEvent): boolean;
+}
+
+interface Selection {
+    get(): { id: string }[];
+}
+
+interface ContextPad {
+    getEntries(target: unknown): Record<string, PadEntry>;
+    getPad(target: unknown): { html: HTMLElement };
+    isShown(): boolean;
+    open(target: unknown, force: boolean): void;
+    triggerEntry(entryId: string, action: string, event: Event): void;
+}
+
+interface PopupMenu {
+    registerProvider(
+        id: string,
+        provider: { getPopupMenuEntries(target: unknown): Record<string, MenuEntry> },
+    ): void;
+    isOpen(): boolean;
+    open(
+        target: unknown,
+        id: string,
+        position: { x: number; y: number },
+        options: { title: string; search: boolean; width: number },
+    ): void;
+}
+
+interface Injector {
+    get(name: string, strict: false): unknown;
+}
+
+type Translate = (key: string) => string;
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class ContextPadKeyboard {
+    static $inject = [
+        "keyboard",
+        "selection",
+        "contextPad",
+        "popupMenu",
+        "canvas",
+        "injector",
+        "translate",
+    ];
+
+    private readonly contextPad: ContextPad;
+    private readonly translate: Translate;
+
+    constructor(
+        keyboard: Keyboard,
+        selection: Selection,
+        contextPad: ContextPad,
+        popupMenu: PopupMenu,
+        _canvas: unknown,
+        injector: Injector,
+        translate: Translate,
+    ) {
+        this.contextPad = contextPad;
+        this.translate = translate;
+
+        popupMenu.registerProvider("context-pad-actions", this);
+
+        keyboard.addListener((ctx) =>
+            this.handleKeyDown(ctx.keyEvent, keyboard, selection, popupMenu, injector),
+        );
+    }
+
+    /** Called by the popup menu system to get entries for the given element. */
+    getPopupMenuEntries(target: unknown): Record<string, MenuEntry> {
+        const contextPad = this.contextPad;
+        return buildMenuEntries(contextPad.getEntries(target), (id) => {
+            if (!contextPad.isShown()) contextPad.open(target, true);
+            contextPad.triggerEntry(id, "click", new Event("click"));
+        });
+    }
+
+    private handleKeyDown(
+        event: KeyboardEvent,
+        keyboard: Keyboard,
+        selection: Selection,
+        popupMenu: PopupMenu,
+        injector: Injector,
+    ): boolean | undefined {
+        if (event.key !== "m") return undefined;
+        if (keyboard.isCmd(event) || event.altKey) return undefined;
+
+        const directEditing = injector.get("directEditing", false) as {
+            isActive(): boolean;
+        } | null;
+        if (directEditing?.isActive()) return undefined;
+
+        if (popupMenu.isOpen()) return undefined;
+
+        const selected = selection.get();
+        if (selected.length !== 1) return undefined;
+
+        const target = selected[0];
+        const entries = this.getPopupMenuEntries(target);
+        if (Object.keys(entries).length === 0) return undefined;
+
+        const padHtml = this.contextPad.getPad(target).html;
+        const rect = padHtml.getBoundingClientRect();
+        const position = { x: rect.left, y: rect.bottom + 6 };
+
+        popupMenu.open(target, "context-pad-actions", position, {
+            title: this.translate("Element actions"),
+            search: true,
+            width: 300,
+        });
+
+        return true;
+    }
+}

--- a/libs/flow-navigation/src/DeleteSelectionBehavior.spec.ts
+++ b/libs/flow-navigation/src/DeleteSelectionBehavior.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DeleteSelectionBehavior } from "./DeleteSelectionBehavior";
+import type { NavElement } from "./traversal";
+
+// ---------------------------------------------------------------------------
+// Graph builders
+// ---------------------------------------------------------------------------
+
+function shape(id: string, type: string, x: number, y: number): NavElement {
+    return { id, type, x, y, incoming: [], outgoing: [] };
+}
+
+function flow(id: string, src: NavElement, tgt: NavElement): NavElement {
+    const f: NavElement = {
+        id,
+        type: "bpmn:SequenceFlow",
+        x: 0,
+        y: 0,
+        incoming: [],
+        outgoing: [],
+        source: src,
+        target: tgt,
+    };
+    src.outgoing.push(f);
+    tgt.incoming.push(f);
+    return f;
+}
+
+// ---------------------------------------------------------------------------
+// Test harness — captures eventBus handlers and drives the
+// preExecute → postExecuted lifecycle with a shared context.
+// ---------------------------------------------------------------------------
+
+function build() {
+    type Handler = (event: { context: Record<string, unknown> }) => void;
+    const handlers: Record<string, { priority: number; callback: Handler }[]> = {};
+
+    const eventBus = {
+        on: vi.fn((...args: unknown[]) => {
+            const event = args[0] as string;
+            const priority = typeof args[1] === "number" ? args[1] : 1000;
+            const callback = (typeof args[1] === "number" ? args[2] : args[1]) as Handler;
+            if (!handlers[event]) handlers[event] = [];
+            handlers[event].push({ priority, callback });
+        }),
+    };
+
+    const selection = { select: vi.fn() };
+    const canvas = { scrollToElement: vi.fn() };
+
+    const registry = new Map<string, NavElement>();
+    const elementRegistry = {
+        get: vi.fn((id: string) => registry.get(id)),
+    };
+
+    new DeleteSelectionBehavior(
+        eventBus as never,
+        selection as never,
+        canvas as never,
+        elementRegistry as never,
+    );
+
+    /** Simulates the delete command lifecycle: preExecute → remove → postExecuted. */
+    function fireDelete(elements: NavElement[]) {
+        const context: Record<string, unknown> = { elements };
+        const event = { context };
+
+        const pre = (handlers["commandStack.elements.delete.preExecute"] ?? []).sort(
+            (a, b) => b.priority - a.priority,
+        );
+        for (const h of pre) h.callback(event);
+
+        for (const el of elements) registry.delete(el.id);
+
+        const post = (handlers["commandStack.elements.delete.postExecuted"] ?? []).sort(
+            (a, b) => b.priority - a.priority,
+        );
+        for (const h of post) h.callback(event);
+    }
+
+    return { eventBus, selection, canvas, elementRegistry, registry, fireDelete, handlers };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteSelectionBehavior", () => {
+    it("selects and scrolls to predecessor after delete", () => {
+        const { selection, canvas, registry, fireDelete } = build();
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        flow("f1", a, b);
+        registry.set("a", a);
+        registry.set("b", b);
+
+        fireDelete([b]);
+
+        expect(selection.select).toHaveBeenCalledWith(a);
+        expect(canvas.scrollToElement).toHaveBeenCalledWith(a);
+    });
+
+    it("no-ops when registry lost the anchor", () => {
+        const { selection, canvas, fireDelete } = build();
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        flow("f1", a, b);
+        // 'a' not in registry — simulates it being deleted by a cascade.
+
+        fireDelete([b]);
+
+        expect(selection.select).not.toHaveBeenCalled();
+        expect(canvas.scrollToElement).not.toHaveBeenCalled();
+    });
+
+    it("no-ops when delete anchor is unresolvable", () => {
+        const { selection, canvas, fireDelete } = build();
+        const isolated = shape("x", "bpmn:Task", 100, 100);
+
+        fireDelete([isolated]);
+
+        expect(selection.select).not.toHaveBeenCalled();
+        expect(canvas.scrollToElement).not.toHaveBeenCalled();
+    });
+
+    it("registers postExecuted at priority 250", () => {
+        const { handlers } = build();
+
+        const postHandlers = handlers["commandStack.elements.delete.postExecuted"] ?? [];
+        expect(postHandlers).toHaveLength(1);
+        expect(postHandlers[0].priority).toBe(250);
+    });
+});

--- a/libs/flow-navigation/src/DeleteSelectionBehavior.ts
+++ b/libs/flow-navigation/src/DeleteSelectionBehavior.ts
@@ -1,0 +1,73 @@
+/**
+ * Selects the predecessor element after a delete operation so the user
+ * stays oriented on the canvas — without this, deletion clears the
+ * selection and leaves the user stranded.
+ *
+ * Hooks into the `elements.delete` command (shared by Del/Backspace,
+ * context-pad trash, and cut) at preExecute to capture the anchor while
+ * incoming flows are still intact, then re-selects at postExecuted after
+ * the deletion cascade has finished.
+ */
+import { resolveDeleteAnchor, type NavElement } from "./traversal";
+
+// ---------------------------------------------------------------------------
+// Structural service interfaces — satisfied by diagram-js at runtime,
+// mocked with plain objects in tests.
+// ---------------------------------------------------------------------------
+
+interface EventBus {
+    on(event: string, callback: (e: DeleteEvent) => void): void;
+    on(event: string, priority: number, callback: (e: DeleteEvent) => void): void;
+}
+
+interface DeleteEvent {
+    context: {
+        elements: NavElement[];
+        selectionAnchorId?: string;
+    };
+}
+
+interface Selection {
+    select(element: NavElement): void;
+}
+
+interface Canvas {
+    scrollToElement(element: NavElement): void;
+}
+
+interface ElementRegistry {
+    get(id: string): NavElement | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class DeleteSelectionBehavior {
+    static $inject = ["eventBus", "selection", "canvas", "elementRegistry"];
+
+    constructor(
+        eventBus: EventBus,
+        selection: Selection,
+        canvas: Canvas,
+        elementRegistry: ElementRegistry,
+    ) {
+        eventBus.on("commandStack.elements.delete.preExecute", (e) => {
+            const anchor = resolveDeleteAnchor(e.context.elements);
+            if (anchor) {
+                e.context.selectionAnchorId = anchor.id;
+            }
+        });
+
+        eventBus.on("commandStack.elements.delete.postExecuted", 250, (e) => {
+            const anchorId = e.context.selectionAnchorId;
+            if (!anchorId) return;
+
+            const element = elementRegistry.get(anchorId);
+            if (!element) return;
+
+            selection.select(element);
+            canvas.scrollToElement(element);
+        });
+    }
+}

--- a/libs/flow-navigation/src/FlowNavigation.spec.ts
+++ b/libs/flow-navigation/src/FlowNavigation.spec.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FlowNavigation } from "./FlowNavigation";
+import type { NavElement } from "./traversal";
+
+// ---------------------------------------------------------------------------
+// Graph builders
+// ---------------------------------------------------------------------------
+
+function shape(id: string, type: string, x: number, y: number): NavElement {
+    return { id, type, x, y, incoming: [], outgoing: [] };
+}
+
+function flow(id: string, src: NavElement, tgt: NavElement): NavElement {
+    const f: NavElement = {
+        id,
+        type: "bpmn:SequenceFlow",
+        x: 0,
+        y: 0,
+        incoming: [],
+        outgoing: [],
+        source: src,
+        target: tgt,
+    };
+    src.outgoing.push(f);
+    tgt.incoming.push(f);
+    return f;
+}
+
+// ---------------------------------------------------------------------------
+// Test harness — mirrors NavigateContextPadProvider.spec.ts style.
+// ---------------------------------------------------------------------------
+
+function build() {
+    let listener!: (ctx: { keyEvent: KeyboardEvent }) => boolean | undefined;
+
+    const keyboard = {
+        addListener: vi.fn((l: typeof listener) => {
+            listener = l;
+        }),
+        isCmd: vi.fn((e: KeyboardEvent) => !!(e.ctrlKey || e.metaKey)),
+        isShift: vi.fn((e: KeyboardEvent) => !!e.shiftKey),
+    };
+
+    const selection = {
+        get: vi.fn((): NavElement[] => []),
+        select: vi.fn(),
+    };
+
+    const rootElement: NavElement & { children: NavElement[] } = {
+        id: "root",
+        type: "bpmn:Process",
+        x: 0,
+        y: 0,
+        incoming: [],
+        outgoing: [],
+        children: [],
+    };
+
+    const canvas = {
+        getRootElement: vi.fn(() => rootElement),
+        scrollToElement: vi.fn(),
+    };
+
+    const services: Record<string, unknown> = {};
+    const injector = {
+        get: vi.fn((name: string) => services[name] ?? null),
+    };
+
+    new FlowNavigation(keyboard as never, selection as never, canvas as never, injector as never);
+
+    function dispatch(
+        key: string,
+        opts?: { shift?: boolean; ctrl?: boolean; alt?: boolean },
+    ): boolean | undefined {
+        return listener({
+            keyEvent: {
+                key,
+                shiftKey: opts?.shift ?? false,
+                ctrlKey: opts?.ctrl ?? false,
+                metaKey: false,
+                altKey: opts?.alt ?? false,
+            } as unknown as KeyboardEvent,
+        });
+    }
+
+    return {
+        keyboard,
+        selection,
+        canvas,
+        injector,
+        services,
+        rootElement,
+        dispatch,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("FlowNavigation", () => {
+    it("registers a keyboard listener on construction", () => {
+        const { keyboard } = build();
+
+        expect(keyboard.addListener).toHaveBeenCalledTimes(1);
+    });
+
+    it("Tab selects next element and scrolls to it", () => {
+        const { selection, canvas, dispatch } = build();
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        flow("f1", a, b);
+        selection.get.mockReturnValue([a]);
+
+        const result = dispatch("Tab");
+
+        expect(result).toBe(true);
+        expect(selection.select).toHaveBeenCalledWith(b);
+        expect(canvas.scrollToElement).toHaveBeenCalledWith(b);
+    });
+
+    it("Tab at end returns true without changing selection", () => {
+        const { selection, canvas, dispatch } = build();
+        const end = shape("end", "bpmn:EndEvent", 400, 200);
+        selection.get.mockReturnValue([end]);
+
+        const result = dispatch("Tab");
+
+        expect(result).toBe(true);
+        expect(selection.select).not.toHaveBeenCalled();
+        expect(canvas.scrollToElement).not.toHaveBeenCalled();
+    });
+
+    it("Ctrl+Tab → undefined (not consumed)", () => {
+        const { dispatch } = build();
+
+        expect(dispatch("Tab", { ctrl: true })).toBeUndefined();
+    });
+
+    it("Alt+Tab → undefined (not consumed)", () => {
+        const { dispatch } = build();
+
+        expect(dispatch("Tab", { alt: true })).toBeUndefined();
+    });
+
+    it("Enter on non-flow → undefined", () => {
+        const { selection, dispatch } = build();
+        const task = shape("task", "bpmn:Task", 200, 200);
+        selection.get.mockReturnValue([task]);
+
+        expect(dispatch("Enter")).toBeUndefined();
+    });
+
+    it("Enter on flow selects target and returns true", () => {
+        const { selection, canvas, dispatch } = build();
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const f = flow("f1", a, b);
+        selection.get.mockReturnValue([f]);
+
+        const result = dispatch("Enter");
+
+        expect(result).toBe(true);
+        expect(selection.select).toHaveBeenCalledWith(b);
+        expect(canvas.scrollToElement).toHaveBeenCalledWith(b);
+    });
+
+    it("Shift+Enter on flow selects source", () => {
+        const { selection, dispatch } = build();
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const f = flow("f1", a, b);
+        selection.get.mockReturnValue([f]);
+
+        const result = dispatch("Enter", { shift: true });
+
+        expect(result).toBe(true);
+        expect(selection.select).toHaveBeenCalledWith(a);
+    });
+
+    it("directEditing active suppresses all keys", () => {
+        const { services, dispatch } = build();
+        services.directEditing = { isActive: () => true };
+
+        expect(dispatch("Tab")).toBeUndefined();
+        expect(dispatch("Enter")).toBeUndefined();
+    });
+
+    it("popupMenu open suppresses all keys", () => {
+        const { services, dispatch } = build();
+        services.popupMenu = { isOpen: () => true };
+
+        expect(dispatch("Tab")).toBeUndefined();
+        expect(dispatch("Enter")).toBeUndefined();
+    });
+
+    it("multi-select anchors on last element", () => {
+        const { selection, dispatch } = build();
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const c = shape("c", "bpmn:Task", 300, 100);
+        flow("f1", a, b);
+        flow("f2", b, c);
+        selection.get.mockReturnValue([a, b]);
+
+        dispatch("Tab");
+
+        expect(selection.select).toHaveBeenCalledWith(c);
+    });
+
+    it("empty selection uses resolveEntry", () => {
+        const { selection, rootElement, dispatch } = build();
+        const start = shape("start", "bpmn:StartEvent", 100, 200);
+        rootElement.children = [start];
+        selection.get.mockReturnValue([]);
+
+        dispatch("Tab");
+
+        expect(selection.select).toHaveBeenCalledWith(start);
+    });
+
+    it("ignores unrelated keys", () => {
+        const { dispatch } = build();
+
+        expect(dispatch("a")).toBeUndefined();
+        expect(dispatch("Escape")).toBeUndefined();
+        expect(dispatch(" ")).toBeUndefined();
+    });
+});

--- a/libs/flow-navigation/src/FlowNavigation.spec.ts
+++ b/libs/flow-navigation/src/FlowNavigation.spec.ts
@@ -27,12 +27,27 @@ function flow(id: string, src: NavElement, tgt: NavElement): NavElement {
     return f;
 }
 
+function attach(id: string, host: NavElement, x: number, y: number): NavElement {
+    const boundary: NavElement = {
+        id,
+        type: "bpmn:BoundaryEvent",
+        x,
+        y,
+        incoming: [],
+        outgoing: [],
+        host,
+    };
+    (host.attachers ??= []).push(boundary);
+    return boundary;
+}
+
 // ---------------------------------------------------------------------------
 // Test harness — mirrors NavigateContextPadProvider.spec.ts style.
 // ---------------------------------------------------------------------------
 
 function build() {
     let listener!: (ctx: { keyEvent: KeyboardEvent }) => boolean | undefined;
+    let selectionChangedHandler: (() => void) | undefined;
 
     const keyboard = {
         addListener: vi.fn((l: typeof listener) => {
@@ -67,7 +82,21 @@ function build() {
         get: vi.fn((name: string) => services[name] ?? null),
     };
 
-    new FlowNavigation(keyboard as never, selection as never, canvas as never, injector as never);
+    const eventBus = {
+        on: vi.fn((event: string, cb: () => void) => {
+            if (event === "selection.changed") {
+                selectionChangedHandler = cb;
+            }
+        }),
+    };
+
+    new FlowNavigation(
+        keyboard as never,
+        selection as never,
+        canvas as never,
+        injector as never,
+        eventBus as never,
+    );
 
     function dispatch(
         key: string,
@@ -84,6 +113,10 @@ function build() {
         });
     }
 
+    function fireSelectionChanged(): void {
+        selectionChangedHandler?.();
+    }
+
     return {
         keyboard,
         selection,
@@ -92,6 +125,8 @@ function build() {
         services,
         rootElement,
         dispatch,
+        eventBus,
+        fireSelectionChanged,
     };
 }
 
@@ -226,5 +261,96 @@ describe("FlowNavigation", () => {
         expect(dispatch("a")).toBeUndefined();
         expect(dispatch("Escape")).toBeUndefined();
         expect(dispatch(" ")).toBeUndefined();
+    });
+
+    // --- Boundary-event candidate state tests ---
+
+    it("Tab→Enter→Tab: boundary candidate → commit → step from boundary", () => {
+        const { selection, dispatch } = build();
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const end = shape("end", "bpmn:Task", 400, 300);
+        const be = attach("be", task, 200, 100);
+        const beEnd = shape("beEnd", "bpmn:EndEvent", 400, 100);
+        flow("f1", task, end);
+        flow("f2", be, beEnd);
+        selection.get.mockReturnValue([task]);
+
+        // Tab enters the mixed fan — boundary at y=100 sorts first → candidate.
+        dispatch("Tab");
+        expect(selection.select).toHaveBeenCalledWith(be);
+
+        // Enter commits the boundary event.
+        selection.get.mockReturnValue([be]);
+        selection.select.mockClear();
+        const enterResult = dispatch("Enter");
+        expect(enterResult).toBe(true);
+        expect(selection.select).toHaveBeenCalledWith(be);
+
+        // Tab from committed boundary follows its own outgoing flow.
+        selection.select.mockClear();
+        dispatch("Tab");
+        expect(selection.select).toHaveBeenCalledWith(beEnd);
+    });
+
+    it("Enter on boundary without candidate state → undefined", () => {
+        const { selection, dispatch } = build();
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const be = attach("be", task, 200, 280);
+        selection.get.mockReturnValue([be]);
+
+        expect(dispatch("Enter")).toBeUndefined();
+    });
+
+    it("external selection.changed clears boundary candidate state", () => {
+        const { selection, dispatch, fireSelectionChanged } = build();
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const end = shape("end", "bpmn:Task", 400, 300);
+        const be = attach("be", task, 200, 100);
+        flow("f1", task, end);
+        selection.get.mockReturnValue([task]);
+
+        // Tab enters the mixed fan — boundary is candidate.
+        dispatch("Tab");
+        expect(selection.select).toHaveBeenCalledWith(be);
+
+        // External selection change (e.g. mouse click) clears candidate.
+        selection.get.mockReturnValue([be]);
+        fireSelectionChanged();
+
+        // Enter on boundary without candidate state → undefined.
+        selection.select.mockClear();
+        expect(dispatch("Enter")).toBeUndefined();
+    });
+
+    it("selection.changed during applySelection does not clear candidate state", () => {
+        const { selection, dispatch, fireSelectionChanged } = build();
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const end = shape("end", "bpmn:Task", 400, 300);
+        const be = attach("be", task, 200, 100);
+        const beEnd = shape("beEnd", "bpmn:EndEvent", 400, 100);
+        flow("f1", task, end);
+        flow("f2", be, beEnd);
+
+        // selection.select triggers selection.changed synchronously.
+        selection.select.mockImplementation(() => fireSelectionChanged());
+        selection.get.mockReturnValue([task]);
+
+        // Tab enters the fan — selection.changed fires during applySelection.
+        dispatch("Tab");
+        expect(selection.select).toHaveBeenCalledWith(be);
+
+        // boundaryCandidateId survived — Enter commits.
+        selection.get.mockReturnValue([be]);
+        selection.select.mockClear();
+        selection.select.mockImplementation(() => {});
+        const enterResult = dispatch("Enter");
+        expect(enterResult).toBe(true);
+        expect(selection.select).toHaveBeenCalledWith(be);
+    });
+
+    it("registers selection.changed listener on eventBus", () => {
+        const { eventBus } = build();
+
+        expect(eventBus.on).toHaveBeenCalledWith("selection.changed", expect.any(Function));
     });
 });

--- a/libs/flow-navigation/src/FlowNavigation.spec.ts
+++ b/libs/flow-navigation/src/FlowNavigation.spec.ts
@@ -348,6 +348,22 @@ describe("FlowNavigation", () => {
         expect(selection.select).toHaveBeenCalledWith(be);
     });
 
+    it("Shift+Tab from merge with two incoming selects first source shape", () => {
+        const { selection, canvas, dispatch } = build();
+        const t1 = shape("t1", "bpmn:Task", 100, 100);
+        const t2 = shape("t2", "bpmn:Task", 100, 200);
+        const merge = shape("merge", "bpmn:ExclusiveGateway", 200, 150);
+        flow("f1", t1, merge);
+        flow("f2", t2, merge);
+        selection.get.mockReturnValue([merge]);
+
+        const result = dispatch("Tab", { shift: true });
+
+        expect(result).toBe(true);
+        expect(selection.select).toHaveBeenCalledWith(t1);
+        expect(canvas.scrollToElement).toHaveBeenCalledWith(t1);
+    });
+
     it("registers selection.changed listener on eventBus", () => {
         const { eventBus } = build();
 

--- a/libs/flow-navigation/src/FlowNavigation.ts
+++ b/libs/flow-navigation/src/FlowNavigation.ts
@@ -1,0 +1,131 @@
+/**
+ * bpmn-js service that wires Tab / Shift+Tab / Enter keyboard shortcuts
+ * to sequence-flow-based diagram traversal.
+ *
+ * Registered via `FlowNavigationModule` as an `additionalModule` on the
+ * bpmn-js modeler — the keyboard listener fires only while the canvas
+ * SVG has focus, so properties-panel Tab and OS-level Ctrl+Tab are
+ * unaffected.
+ */
+import {
+    resolveEntry,
+    resolveFollow,
+    resolveStep,
+    type Direction,
+    type NavElement,
+} from "./traversal";
+
+// ---------------------------------------------------------------------------
+// Structural service interfaces — satisfied by diagram-js at runtime,
+// mocked with plain objects in tests.
+// ---------------------------------------------------------------------------
+
+interface Keyboard {
+    addListener(listener: (ctx: { keyEvent: KeyboardEvent }) => boolean | undefined): void;
+    isCmd(event: KeyboardEvent): boolean;
+    isShift(event: KeyboardEvent): boolean;
+}
+
+interface Selection {
+    get(): NavElement[];
+    select(element: NavElement): void;
+}
+
+interface Canvas {
+    getRootElement(): NavElement & { children: NavElement[] };
+    scrollToElement(element: NavElement): void;
+}
+
+interface Injector {
+    get(name: string, strict: false): unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class FlowNavigation {
+    static $inject = ["keyboard", "selection", "canvas", "injector"];
+
+    private readonly keyboard: Keyboard;
+    private readonly selection: Selection;
+    private readonly canvas: Canvas;
+    private readonly injector: Injector;
+
+    constructor(keyboard: Keyboard, selection: Selection, canvas: Canvas, injector: Injector) {
+        this.keyboard = keyboard;
+        this.selection = selection;
+        this.canvas = canvas;
+        this.injector = injector;
+
+        keyboard.addListener((ctx) => this.handleKeyDown(ctx.keyEvent));
+    }
+
+    private handleKeyDown(event: KeyboardEvent): boolean | undefined {
+        if (event.key !== "Tab" && event.key !== "Enter") return undefined;
+
+        // Ctrl/Cmd+Tab must keep bubbling to VS Code / OS.
+        if (this.keyboard.isCmd(event) || event.altKey) return undefined;
+
+        // Belt-and-braces: don't hijack keys while inline editing or a menu is open.
+        const directEditing = this.injector.get("directEditing", false) as {
+            isActive(): boolean;
+        } | null;
+        if (directEditing?.isActive()) return undefined;
+        const popupMenu = this.injector.get("popupMenu", false) as { isOpen(): boolean } | null;
+        if (popupMenu?.isOpen()) return undefined;
+
+        const direction: Direction = this.keyboard.isShift(event) ? "backward" : "forward";
+        const selected = this.selection.get();
+        const root = this.canvas.getRootElement();
+
+        if (selected.length === 0) {
+            return this.handleEmpty(root, direction, event.key);
+        }
+
+        const anchor = selected[selected.length - 1];
+
+        // Stale-selection guard: if the anchor belongs to a different root
+        // plane (e.g. user drilled into a subprocess), treat as empty.
+        if (anchor.parent) {
+            let anchorRoot: NavElement = anchor;
+            while (anchorRoot.parent) {
+                anchorRoot = anchorRoot.parent;
+            }
+            if (anchorRoot.id !== root.id) {
+                return this.handleEmpty(root, direction, event.key);
+            }
+        }
+
+        if (event.key === "Tab") {
+            return this.handleTab(anchor, direction);
+        }
+
+        return this.handleEnter(anchor, direction);
+    }
+
+    private handleEmpty(root: NavElement, direction: Direction, key: string): boolean | undefined {
+        const entry = resolveEntry(root.children ?? [], direction);
+        if (entry) this.applySelection(entry);
+        // Tab is always consumed so focus never leaves the canvas.
+        return key === "Tab" ? true : undefined;
+    }
+
+    private handleTab(anchor: NavElement, direction: Direction): true {
+        const next = resolveStep(anchor, direction);
+        if (next) this.applySelection(next);
+        return true;
+    }
+
+    private handleEnter(anchor: NavElement, direction: Direction): boolean | undefined {
+        const next = resolveFollow(anchor, direction);
+        if (!next) return undefined;
+        this.applySelection(next);
+        return true;
+    }
+
+    private applySelection(element: NavElement): void {
+        this.selection.select(element);
+        this.canvas.scrollToElement(element);
+    }
+}

--- a/libs/flow-navigation/src/FlowNavigation.ts
+++ b/libs/flow-navigation/src/FlowNavigation.ts
@@ -13,6 +13,7 @@ import {
     resolveStep,
     type Direction,
     type NavElement,
+    type StepResult,
 } from "./traversal";
 
 // ---------------------------------------------------------------------------
@@ -40,25 +41,44 @@ interface Injector {
     get(name: string, strict: false): unknown;
 }
 
+interface EventBus {
+    on(event: string, callback: () => void): void;
+}
+
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
 
 export class FlowNavigation {
-    static $inject = ["keyboard", "selection", "canvas", "injector"];
+    static $inject = ["keyboard", "selection", "canvas", "injector", "eventBus"];
 
     private readonly keyboard: Keyboard;
     private readonly selection: Selection;
     private readonly canvas: Canvas;
     private readonly injector: Injector;
 
-    constructor(keyboard: Keyboard, selection: Selection, canvas: Canvas, injector: Injector) {
+    private boundaryCandidateId: string | null = null;
+    private applyingSelection = false;
+
+    constructor(
+        keyboard: Keyboard,
+        selection: Selection,
+        canvas: Canvas,
+        injector: Injector,
+        eventBus: EventBus,
+    ) {
         this.keyboard = keyboard;
         this.selection = selection;
         this.canvas = canvas;
         this.injector = injector;
 
         keyboard.addListener((ctx) => this.handleKeyDown(ctx.keyEvent));
+
+        eventBus.on("selection.changed", () => {
+            if (!this.applyingSelection) {
+                this.boundaryCandidateId = null;
+            }
+        });
     }
 
     private handleKeyDown(event: KeyboardEvent): boolean | undefined {
@@ -106,26 +126,32 @@ export class FlowNavigation {
 
     private handleEmpty(root: NavElement, direction: Direction, key: string): boolean | undefined {
         const entry = resolveEntry(root.children ?? [], direction);
-        if (entry) this.applySelection(entry);
+        if (entry) this.applySelection({ element: entry, boundaryCandidate: false });
         // Tab is always consumed so focus never leaves the canvas.
         return key === "Tab" ? true : undefined;
     }
 
     private handleTab(anchor: NavElement, direction: Direction): true {
-        const next = resolveStep(anchor, direction);
+        const next = resolveStep(anchor, direction, anchor.id === this.boundaryCandidateId);
         if (next) this.applySelection(next);
         return true;
     }
 
     private handleEnter(anchor: NavElement, direction: Direction): boolean | undefined {
-        const next = resolveFollow(anchor, direction);
+        const next = resolveFollow(anchor, direction, anchor.id === this.boundaryCandidateId);
         if (!next) return undefined;
         this.applySelection(next);
         return true;
     }
 
-    private applySelection(element: NavElement): void {
-        this.selection.select(element);
-        this.canvas.scrollToElement(element);
+    private applySelection(result: StepResult): void {
+        this.boundaryCandidateId = result.boundaryCandidate ? result.element.id : null;
+        this.applyingSelection = true;
+        try {
+            this.selection.select(result.element);
+        } finally {
+            this.applyingSelection = false;
+        }
+        this.canvas.scrollToElement(result.element);
     }
 }

--- a/libs/flow-navigation/src/LinkNavigation.spec.ts
+++ b/libs/flow-navigation/src/LinkNavigation.spec.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { LinkNavigation } from "./LinkNavigation";
+
+// ---------------------------------------------------------------------------
+// Test harness — mirrors PlaneNavigation.spec.ts style.
+// ---------------------------------------------------------------------------
+
+function build() {
+    let listener!: (ctx: { keyEvent: KeyboardEvent }) => boolean | undefined;
+
+    const keyboard = {
+        addListener: vi.fn((l: typeof listener) => {
+            listener = l;
+        }),
+        isCmd: vi.fn((e: KeyboardEvent) => !!(e.ctrlKey || e.metaKey)),
+        isShift: vi.fn((e: KeyboardEvent) => !!e.shiftKey),
+    };
+
+    const selection = {
+        get: vi.fn((): { id: string }[] => []),
+    };
+
+    let padEntries: Record<string, unknown> = {};
+    let padShown = false;
+
+    const contextPad = {
+        getEntries: vi.fn(() => padEntries),
+        isShown: vi.fn(() => padShown),
+        open: vi.fn(),
+        triggerEntry: vi.fn(),
+    };
+
+    const services: Record<string, unknown> = {};
+    const injector = {
+        get: vi.fn((name: string) => services[name] ?? null),
+    };
+
+    new LinkNavigation(
+        keyboard as never,
+        selection as never,
+        contextPad as never,
+        injector as never,
+    );
+
+    function dispatch(
+        key: string,
+        opts?: { shift?: boolean; ctrl?: boolean; alt?: boolean },
+    ): boolean | undefined {
+        return listener({
+            keyEvent: {
+                key,
+                shiftKey: opts?.shift ?? false,
+                ctrlKey: opts?.ctrl ?? false,
+                metaKey: false,
+                altKey: opts?.alt ?? false,
+            } as unknown as KeyboardEvent,
+        });
+    }
+
+    return {
+        selection,
+        contextPad,
+        services,
+        dispatch,
+        setPadEntries(entries: Record<string, unknown>) {
+            padEntries = entries;
+        },
+        setPadShown(shown: boolean) {
+            padShown = shown;
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LinkNavigation", () => {
+    it("g with navigate-to-referenced-model → entry triggered", () => {
+        const { selection, contextPad, setPadEntries, dispatch } = build();
+
+        selection.get.mockReturnValue([{ id: "callActivity1" }]);
+        setPadEntries({ "navigate-to-referenced-model": { action: { click: vi.fn() } } });
+
+        const result = dispatch("g");
+
+        expect(result).toBe(true);
+        expect(contextPad.triggerEntry).toHaveBeenCalledWith(
+            "navigate-to-referenced-model",
+            "click",
+            expect.any(Event),
+        );
+    });
+
+    it("g with only go-to-implementation → that entry triggered", () => {
+        const { selection, contextPad, setPadEntries, dispatch } = build();
+
+        selection.get.mockReturnValue([{ id: "serviceTask1" }]);
+        setPadEntries({ "go-to-implementation": { action: { click: vi.fn() } } });
+
+        const result = dispatch("g");
+
+        expect(result).toBe(true);
+        expect(contextPad.triggerEntry).toHaveBeenCalledWith(
+            "go-to-implementation",
+            "click",
+            expect.any(Event),
+        );
+    });
+
+    it("both entries present → model-navigation wins", () => {
+        const { selection, contextPad, setPadEntries, dispatch } = build();
+
+        selection.get.mockReturnValue([{ id: "businessRuleTask1" }]);
+        setPadEntries({
+            "navigate-to-referenced-model": { action: { click: vi.fn() } },
+            "go-to-implementation": { action: { click: vi.fn() } },
+        });
+
+        const result = dispatch("g");
+
+        expect(result).toBe(true);
+        expect(contextPad.triggerEntry).toHaveBeenCalledWith(
+            "navigate-to-referenced-model",
+            "click",
+            expect.any(Event),
+        );
+        expect(contextPad.triggerEntry).toHaveBeenCalledTimes(1);
+    });
+
+    it("no link entry → undefined, nothing triggered", () => {
+        const { selection, contextPad, setPadEntries, dispatch } = build();
+
+        selection.get.mockReturnValue([{ id: "task1" }]);
+        setPadEntries({ append: {}, delete: {} });
+
+        expect(dispatch("g")).toBeUndefined();
+        expect(contextPad.triggerEntry).not.toHaveBeenCalled();
+    });
+
+    it("pad not shown → open called before triggerEntry", () => {
+        const { selection, contextPad, setPadEntries, setPadShown, dispatch } = build();
+
+        selection.get.mockReturnValue([{ id: "callActivity1" }]);
+        setPadEntries({ "navigate-to-referenced-model": {} });
+        setPadShown(false);
+
+        dispatch("g");
+
+        expect(contextPad.open).toHaveBeenCalledWith({ id: "callActivity1" }, true);
+        expect(contextPad.triggerEntry).toHaveBeenCalled();
+
+        const openOrder = contextPad.open.mock.invocationCallOrder[0];
+        const triggerOrder = contextPad.triggerEntry.mock.invocationCallOrder[0];
+        expect(openOrder).toBeLessThan(triggerOrder);
+    });
+
+    it("pad already shown → no extra open call", () => {
+        const { selection, contextPad, setPadEntries, setPadShown, dispatch } = build();
+
+        selection.get.mockReturnValue([{ id: "callActivity1" }]);
+        setPadEntries({ "navigate-to-referenced-model": {} });
+        setPadShown(true);
+
+        dispatch("g");
+
+        expect(contextPad.open).not.toHaveBeenCalled();
+        expect(contextPad.triggerEntry).toHaveBeenCalled();
+    });
+
+    // --- Guards ---
+
+    it("0 selected → undefined", () => {
+        const { selection, contextPad, dispatch } = build();
+
+        selection.get.mockReturnValue([]);
+
+        expect(dispatch("g")).toBeUndefined();
+        expect(contextPad.triggerEntry).not.toHaveBeenCalled();
+    });
+
+    it("2+ selected → undefined", () => {
+        const { selection, contextPad, dispatch } = build();
+
+        selection.get.mockReturnValue([{ id: "a" }, { id: "b" }]);
+
+        expect(dispatch("g")).toBeUndefined();
+        expect(contextPad.triggerEntry).not.toHaveBeenCalled();
+    });
+
+    it("Cmd modifier → undefined", () => {
+        const { selection, contextPad, setPadEntries, dispatch } = build();
+
+        selection.get.mockReturnValue([{ id: "callActivity1" }]);
+        setPadEntries({ "navigate-to-referenced-model": {} });
+
+        expect(dispatch("g", { ctrl: true })).toBeUndefined();
+        expect(contextPad.triggerEntry).not.toHaveBeenCalled();
+    });
+
+    it("Alt modifier → undefined", () => {
+        const { selection, contextPad, setPadEntries, dispatch } = build();
+
+        selection.get.mockReturnValue([{ id: "callActivity1" }]);
+        setPadEntries({ "navigate-to-referenced-model": {} });
+
+        expect(dispatch("g", { alt: true })).toBeUndefined();
+        expect(contextPad.triggerEntry).not.toHaveBeenCalled();
+    });
+
+    it("Shift modifier → undefined", () => {
+        const { selection, contextPad, setPadEntries, dispatch } = build();
+
+        selection.get.mockReturnValue([{ id: "callActivity1" }]);
+        setPadEntries({ "navigate-to-referenced-model": {} });
+
+        expect(dispatch("g", { shift: true })).toBeUndefined();
+        expect(contextPad.triggerEntry).not.toHaveBeenCalled();
+    });
+
+    it("other key → undefined", () => {
+        const { dispatch } = build();
+
+        expect(dispatch("a")).toBeUndefined();
+        expect(dispatch("Enter")).toBeUndefined();
+        expect(dispatch("Tab")).toBeUndefined();
+    });
+
+    it("directEditing active → undefined", () => {
+        const { selection, contextPad, services, setPadEntries, dispatch } = build();
+
+        services.directEditing = { isActive: () => true };
+        selection.get.mockReturnValue([{ id: "callActivity1" }]);
+        setPadEntries({ "navigate-to-referenced-model": {} });
+
+        expect(dispatch("g")).toBeUndefined();
+        expect(contextPad.triggerEntry).not.toHaveBeenCalled();
+    });
+
+    it("popupMenu open → undefined", () => {
+        const { selection, contextPad, services, setPadEntries, dispatch } = build();
+
+        services.popupMenu = { isOpen: () => true };
+        selection.get.mockReturnValue([{ id: "callActivity1" }]);
+        setPadEntries({ "navigate-to-referenced-model": {} });
+
+        expect(dispatch("g")).toBeUndefined();
+        expect(contextPad.triggerEntry).not.toHaveBeenCalled();
+    });
+});

--- a/libs/flow-navigation/src/LinkNavigation.ts
+++ b/libs/flow-navigation/src/LinkNavigation.ts
@@ -1,0 +1,88 @@
+/**
+ * Wires the "g" keyboard shortcut to trigger the first applicable
+ * link-navigation context-pad entry on the selected element.
+ *
+ * Two existing context-pad providers add jump-to-file entries:
+ * model-navigation ("navigate-to-referenced-model") and code-link
+ * ("go-to-implementation"). This service triggers whichever one is
+ * present — preferring the referenced model when both exist — so
+ * flow-navigation users never have to leave the keyboard.
+ */
+
+// ---------------------------------------------------------------------------
+// Structural service interfaces — satisfied by diagram-js at runtime,
+// mocked with plain objects in tests.
+// ---------------------------------------------------------------------------
+
+interface Keyboard {
+    addListener(listener: (ctx: { keyEvent: KeyboardEvent }) => boolean | undefined): void;
+    isCmd(event: KeyboardEvent): boolean;
+    isShift(event: KeyboardEvent): boolean;
+}
+
+interface Selection {
+    get(): { id: string }[];
+}
+
+interface ContextPad {
+    getEntries(target: unknown): Record<string, unknown>;
+    isShown(): boolean;
+    open(target: unknown, force: boolean): void;
+    triggerEntry(entryId: string, action: string, event: Event): void;
+}
+
+interface Injector {
+    get(name: string, strict: false): unknown;
+}
+
+const LINK_ENTRY_IDS = ["navigate-to-referenced-model", "go-to-implementation"];
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class LinkNavigation {
+    static $inject = ["keyboard", "selection", "contextPad", "injector"];
+
+    constructor(
+        keyboard: Keyboard,
+        selection: Selection,
+        contextPad: ContextPad,
+        injector: Injector,
+    ) {
+        keyboard.addListener((ctx) =>
+            this.handleKeyDown(ctx.keyEvent, keyboard, selection, contextPad, injector),
+        );
+    }
+
+    private handleKeyDown(
+        event: KeyboardEvent,
+        keyboard: Keyboard,
+        selection: Selection,
+        contextPad: ContextPad,
+        injector: Injector,
+    ): boolean | undefined {
+        if (event.key !== "g") return undefined;
+        if (keyboard.isCmd(event) || event.altKey || keyboard.isShift(event)) return undefined;
+
+        const directEditing = injector.get("directEditing", false) as {
+            isActive(): boolean;
+        } | null;
+        if (directEditing?.isActive()) return undefined;
+
+        const popupMenu = injector.get("popupMenu", false) as { isOpen(): boolean } | null;
+        if (popupMenu?.isOpen()) return undefined;
+
+        const selected = selection.get();
+        if (selected.length !== 1) return undefined;
+
+        const target = selected[0];
+        const entries = contextPad.getEntries(target);
+        const id = LINK_ENTRY_IDS.find((candidate) => candidate in entries);
+        if (!id) return undefined;
+
+        if (!contextPad.isShown()) contextPad.open(target, true);
+        contextPad.triggerEntry(id, "click", new Event("click"));
+        return true;
+    }
+}

--- a/libs/flow-navigation/src/PlaneNavigation.spec.ts
+++ b/libs/flow-navigation/src/PlaneNavigation.spec.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PlaneNavigation } from "./PlaneNavigation";
+import type { NavElement } from "./traversal";
+
+// ---------------------------------------------------------------------------
+// Graph builders
+// ---------------------------------------------------------------------------
+
+function shape(id: string, type: string, x: number, y: number): NavElement {
+    return { id, type, x, y, incoming: [], outgoing: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Test harness — mirrors FlowNavigation.spec.ts style.
+// ---------------------------------------------------------------------------
+
+function build() {
+    let listener!: (ctx: { keyEvent: KeyboardEvent }) => boolean | undefined;
+
+    const keyboard = {
+        addListener: vi.fn((l: typeof listener) => {
+            listener = l;
+        }),
+        isCmd: vi.fn((e: KeyboardEvent) => !!(e.ctrlKey || e.metaKey)),
+        isShift: vi.fn((e: KeyboardEvent) => !!e.shiftKey),
+    };
+
+    const selection = {
+        get: vi.fn((): NavElement[] => []),
+        select: vi.fn(),
+    };
+
+    const rootElement: NavElement = {
+        id: "root",
+        type: "bpmn:Process",
+        x: 0,
+        y: 0,
+        incoming: [],
+        outgoing: [],
+    };
+
+    const roots: Record<string, NavElement> = {};
+
+    const canvas = {
+        getRootElement: vi.fn((): NavElement => rootElement),
+        findRoot: vi.fn((id: string) => roots[id]),
+        setRootElement: vi.fn(),
+        scrollToElement: vi.fn(),
+    };
+
+    const registry: Record<string, NavElement> = {};
+
+    const elementRegistry = {
+        get: vi.fn((id: string) => registry[id]),
+    };
+
+    const services: Record<string, unknown> = {};
+    const injector = {
+        get: vi.fn((name: string) => services[name] ?? null),
+    };
+
+    new PlaneNavigation(
+        keyboard as never,
+        selection as never,
+        canvas as never,
+        elementRegistry as never,
+        injector as never,
+    );
+
+    function dispatch(
+        key: string,
+        opts?: { shift?: boolean; ctrl?: boolean; alt?: boolean },
+    ): boolean | undefined {
+        return listener({
+            keyEvent: {
+                key,
+                shiftKey: opts?.shift ?? false,
+                ctrlKey: opts?.ctrl ?? false,
+                metaKey: false,
+                altKey: opts?.alt ?? false,
+            } as unknown as KeyboardEvent,
+        });
+    }
+
+    return {
+        keyboard,
+        selection,
+        canvas,
+        rootElement,
+        roots,
+        registry,
+        elementRegistry,
+        injector,
+        services,
+        dispatch,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PlaneNavigation", () => {
+    // --- Drill-in (Enter) ---
+
+    it("Enter on collapsed subprocess drills into its plane and selects start event", () => {
+        const { selection, canvas, roots, dispatch } = build();
+
+        const subprocess = shape("sub1", "bpmn:SubProcess", 200, 200);
+        const startEvent = shape("start1", "bpmn:StartEvent", 100, 100);
+        const planeRoot: NavElement = {
+            id: "sub1_plane",
+            type: "bpmn:Process",
+            x: 0,
+            y: 0,
+            incoming: [],
+            outgoing: [],
+            children: [startEvent],
+        };
+        roots["sub1_plane"] = planeRoot;
+        selection.get.mockReturnValue([subprocess]);
+
+        const result = dispatch("Enter");
+
+        expect(result).toBe(true);
+        expect(canvas.setRootElement).toHaveBeenCalledWith(planeRoot);
+        expect(selection.select).toHaveBeenCalledWith(startEvent);
+        expect(canvas.scrollToElement).toHaveBeenCalledWith(startEvent);
+    });
+
+    it("Enter on shape without a plane → undefined", () => {
+        const { selection, canvas, dispatch } = build();
+
+        const task = shape("task1", "bpmn:Task", 200, 200);
+        selection.get.mockReturnValue([task]);
+
+        expect(dispatch("Enter")).toBeUndefined();
+        expect(canvas.setRootElement).not.toHaveBeenCalled();
+    });
+
+    it("Enter with 0 selected → undefined", () => {
+        const { selection, canvas, dispatch } = build();
+
+        selection.get.mockReturnValue([]);
+
+        expect(dispatch("Enter")).toBeUndefined();
+        expect(canvas.setRootElement).not.toHaveBeenCalled();
+    });
+
+    it("Enter with 2+ selected → undefined", () => {
+        const { selection, canvas, roots, dispatch } = build();
+
+        const sub1 = shape("sub1", "bpmn:SubProcess", 100, 100);
+        const sub2 = shape("sub2", "bpmn:SubProcess", 200, 200);
+        roots["sub1_plane"] = { ...shape("sub1_plane", "bpmn:Process", 0, 0), children: [] };
+        selection.get.mockReturnValue([sub1, sub2]);
+
+        expect(dispatch("Enter")).toBeUndefined();
+        expect(canvas.setRootElement).not.toHaveBeenCalled();
+    });
+
+    it("Enter with Cmd → undefined", () => {
+        const { selection, canvas, roots, dispatch } = build();
+
+        const subprocess = shape("sub1", "bpmn:SubProcess", 200, 200);
+        roots["sub1_plane"] = { ...shape("sub1_plane", "bpmn:Process", 0, 0), children: [] };
+        selection.get.mockReturnValue([subprocess]);
+
+        expect(dispatch("Enter", { ctrl: true })).toBeUndefined();
+        expect(canvas.setRootElement).not.toHaveBeenCalled();
+    });
+
+    it("Enter with Alt → undefined", () => {
+        const { selection, canvas, roots, dispatch } = build();
+
+        const subprocess = shape("sub1", "bpmn:SubProcess", 200, 200);
+        roots["sub1_plane"] = { ...shape("sub1_plane", "bpmn:Process", 0, 0), children: [] };
+        selection.get.mockReturnValue([subprocess]);
+
+        expect(dispatch("Enter", { alt: true })).toBeUndefined();
+        expect(canvas.setRootElement).not.toHaveBeenCalled();
+    });
+
+    it("Shift+Enter on collapsed subprocess → undefined (no drill-in)", () => {
+        const { selection, canvas, roots, dispatch } = build();
+
+        const subprocess = shape("sub1", "bpmn:SubProcess", 200, 200);
+        roots["sub1_plane"] = { ...shape("sub1_plane", "bpmn:Process", 0, 0), children: [] };
+        selection.get.mockReturnValue([subprocess]);
+
+        expect(dispatch("Enter", { shift: true })).toBeUndefined();
+        expect(canvas.setRootElement).not.toHaveBeenCalled();
+    });
+
+    it("Enter into empty subprocess plane → root changes, no selection, still consumed", () => {
+        const { selection, canvas, roots, dispatch } = build();
+
+        const subprocess = shape("sub1", "bpmn:SubProcess", 200, 200);
+        const emptyPlane: NavElement = {
+            id: "sub1_plane",
+            type: "bpmn:Process",
+            x: 0,
+            y: 0,
+            incoming: [],
+            outgoing: [],
+            children: [],
+        };
+        roots["sub1_plane"] = emptyPlane;
+        selection.get.mockReturnValue([subprocess]);
+
+        const result = dispatch("Enter");
+
+        expect(result).toBe(true);
+        expect(canvas.setRootElement).toHaveBeenCalledWith(emptyPlane);
+        expect(selection.select).not.toHaveBeenCalled();
+    });
+
+    // --- Drill-out (u) ---
+
+    it("u inside a plane → parent root set, subprocess selected", () => {
+        const { canvas, selection, registry, dispatch } = build();
+
+        const parentRoot: NavElement = {
+            id: "root",
+            type: "bpmn:Process",
+            x: 0,
+            y: 0,
+            incoming: [],
+            outgoing: [],
+        };
+        const subprocess = shape("sub1", "bpmn:SubProcess", 200, 200);
+        subprocess.parent = parentRoot;
+        registry["sub1"] = subprocess;
+
+        const planeRoot: NavElement = {
+            id: "sub1_plane",
+            type: "bpmn:Process",
+            x: 0,
+            y: 0,
+            incoming: [],
+            outgoing: [],
+        };
+        canvas.getRootElement.mockReturnValue(planeRoot);
+
+        const result = dispatch("u");
+
+        expect(result).toBe(true);
+        expect(canvas.setRootElement).toHaveBeenCalledWith(parentRoot);
+        expect(selection.select).toHaveBeenCalledWith(subprocess);
+        expect(canvas.scrollToElement).toHaveBeenCalledWith(subprocess);
+    });
+
+    it("u at top level → undefined", () => {
+        const { canvas, dispatch } = build();
+
+        expect(dispatch("u")).toBeUndefined();
+        expect(canvas.setRootElement).not.toHaveBeenCalled();
+    });
+
+    it("nested plane goes up exactly one level", () => {
+        const { canvas, selection, registry, dispatch } = build();
+
+        const sub1Plane: NavElement = {
+            id: "sub1_plane",
+            type: "bpmn:Process",
+            x: 0,
+            y: 0,
+            incoming: [],
+            outgoing: [],
+        };
+
+        const sub2 = shape("sub2", "bpmn:SubProcess", 100, 100);
+        sub2.parent = sub1Plane;
+        registry["sub2"] = sub2;
+
+        const sub2Plane: NavElement = {
+            id: "sub2_plane",
+            type: "bpmn:Process",
+            x: 0,
+            y: 0,
+            incoming: [],
+            outgoing: [],
+        };
+        canvas.getRootElement.mockReturnValue(sub2Plane);
+
+        const result = dispatch("u");
+
+        expect(result).toBe(true);
+        expect(canvas.setRootElement).toHaveBeenCalledWith(sub1Plane);
+        expect(selection.select).toHaveBeenCalledWith(sub2);
+    });
+
+    // --- Guard tests ---
+
+    it("directEditing active suppresses Enter and u", () => {
+        const { services, canvas, dispatch } = build();
+        services.directEditing = { isActive: () => true };
+
+        expect(dispatch("Enter")).toBeUndefined();
+        expect(dispatch("u")).toBeUndefined();
+        expect(canvas.setRootElement).not.toHaveBeenCalled();
+    });
+
+    it("popupMenu open suppresses Enter and u", () => {
+        const { services, canvas, dispatch } = build();
+        services.popupMenu = { isOpen: () => true };
+
+        expect(dispatch("Enter")).toBeUndefined();
+        expect(dispatch("u")).toBeUndefined();
+        expect(canvas.setRootElement).not.toHaveBeenCalled();
+    });
+
+    it("ignores unrelated keys", () => {
+        const { dispatch } = build();
+
+        expect(dispatch("Tab")).toBeUndefined();
+        expect(dispatch("a")).toBeUndefined();
+        expect(dispatch("Escape")).toBeUndefined();
+    });
+});

--- a/libs/flow-navigation/src/PlaneNavigation.ts
+++ b/libs/flow-navigation/src/PlaneNavigation.ts
@@ -1,0 +1,127 @@
+/**
+ * bpmn-js service that wires Enter / u keyboard shortcuts to plane
+ * drill-in / drill-out for collapsed subprocesses.
+ *
+ * Enter on a collapsed subprocess jumps into its plane and auto-selects
+ * the first start event so the user can keep tabbing immediately.
+ * u jumps out one level and re-selects the subprocess shape.
+ * bpmn-js's drilldown machinery handles viewport centering automatically.
+ */
+import { resolveEntry, type NavElement } from "./traversal";
+
+/** Local constant to avoid importing from bpmn-js (keeps the lib dependency-free). */
+const PLANE_SUFFIX = "_plane";
+
+// ---------------------------------------------------------------------------
+// Structural service interfaces — satisfied by diagram-js at runtime,
+// mocked with plain objects in tests.
+// ---------------------------------------------------------------------------
+
+interface Keyboard {
+    addListener(listener: (ctx: { keyEvent: KeyboardEvent }) => boolean | undefined): void;
+    isCmd(event: KeyboardEvent): boolean;
+    isShift(event: KeyboardEvent): boolean;
+}
+
+interface Selection {
+    get(): NavElement[];
+    select(element: NavElement): void;
+}
+
+interface Canvas {
+    getRootElement(): NavElement;
+    findRoot(id: string): NavElement | undefined;
+    setRootElement(root: NavElement): void;
+    scrollToElement(element: NavElement): void;
+}
+
+interface ElementRegistry {
+    get(id: string): NavElement | undefined;
+}
+
+interface Injector {
+    get(name: string, strict: false): unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class PlaneNavigation {
+    static $inject = ["keyboard", "selection", "canvas", "elementRegistry", "injector"];
+
+    private readonly keyboard: Keyboard;
+    private readonly selection: Selection;
+    private readonly canvas: Canvas;
+    private readonly elementRegistry: ElementRegistry;
+    private readonly injector: Injector;
+
+    constructor(
+        keyboard: Keyboard,
+        selection: Selection,
+        canvas: Canvas,
+        elementRegistry: ElementRegistry,
+        injector: Injector,
+    ) {
+        this.keyboard = keyboard;
+        this.selection = selection;
+        this.canvas = canvas;
+        this.elementRegistry = elementRegistry;
+        this.injector = injector;
+
+        keyboard.addListener((ctx) => this.handleKeyDown(ctx.keyEvent));
+    }
+
+    private handleKeyDown(event: KeyboardEvent): boolean | undefined {
+        if (event.key !== "Enter" && event.key !== "u") return undefined;
+        if (this.keyboard.isCmd(event) || event.altKey) return undefined;
+
+        const directEditing = this.injector.get("directEditing", false) as {
+            isActive(): boolean;
+        } | null;
+        if (directEditing?.isActive()) return undefined;
+        const popupMenu = this.injector.get("popupMenu", false) as { isOpen(): boolean } | null;
+        if (popupMenu?.isOpen()) return undefined;
+
+        if (event.key === "Enter") {
+            return this.drillIn(event);
+        }
+        return this.drillOut();
+    }
+
+    private drillIn(event: KeyboardEvent): boolean | undefined {
+        if (this.keyboard.isShift(event)) return undefined;
+
+        const selected = this.selection.get();
+        if (selected.length !== 1) return undefined;
+
+        const plane = this.canvas.findRoot(selected[0].id + PLANE_SUFFIX);
+        if (!plane) return undefined;
+
+        this.canvas.setRootElement(plane);
+        const entry = resolveEntry(plane.children ?? [], "forward");
+        if (entry) {
+            this.selection.select(entry);
+            this.canvas.scrollToElement(entry);
+        }
+        return true;
+    }
+
+    /** Walk up shape.parent to find the root of the plane the shape lives in. */
+    private drillOut(): boolean | undefined {
+        const rootId = this.canvas.getRootElement().id;
+        if (!rootId.endsWith(PLANE_SUFFIX)) return undefined;
+
+        const shape = this.elementRegistry.get(rootId.slice(0, -PLANE_SUFFIX.length));
+        if (!shape) return undefined;
+
+        let parentRoot: NavElement = shape;
+        while (parentRoot.parent) {
+            parentRoot = parentRoot.parent;
+        }
+        this.canvas.setRootElement(parentRoot);
+        this.selection.select(shape);
+        this.canvas.scrollToElement(shape);
+        return true;
+    }
+}

--- a/libs/flow-navigation/src/contextPadMenu.spec.ts
+++ b/libs/flow-navigation/src/contextPadMenu.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildMenuEntries, type PadEntry } from "./contextPadMenu";
+
+describe("buildMenuEntries", () => {
+    it("uses title as label, falls back to entryId", () => {
+        const trigger = vi.fn();
+        const entries: Record<string, PadEntry> = {
+            myEntry: { title: "My Title", action: vi.fn() },
+            noTitle: { action: vi.fn() },
+        };
+
+        const result = buildMenuEntries(entries, trigger);
+
+        expect(result.myEntry.label).toBe("My Title");
+        expect(result.noTitle.label).toBe("noTitle");
+    });
+
+    it("passes through className and imageUrl", () => {
+        const trigger = vi.fn();
+        const entries: Record<string, PadEntry> = {
+            styled: {
+                title: "Styled",
+                className: "bpmn-icon-task",
+                imageUrl: "https://example.com/icon.svg",
+                action: vi.fn(),
+            },
+        };
+
+        const result = buildMenuEntries(entries, trigger);
+
+        expect(result.styled.className).toBe("bpmn-icon-task");
+        expect(result.styled.imageUrl).toBe("https://example.com/icon.svg");
+    });
+
+    it("filters out entries without an action", () => {
+        const trigger = vi.fn();
+        const entries: Record<string, PadEntry> = {
+            noAction: { title: "No Action" },
+            hasAction: { title: "Has Action", action: vi.fn() },
+        };
+
+        const result = buildMenuEntries(entries, trigger);
+
+        expect(result.noAction).toBeUndefined();
+        expect(result.hasAction).toBeDefined();
+    });
+
+    it("filters out drag-only entries (action without click)", () => {
+        const trigger = vi.fn();
+        const entries: Record<string, PadEntry> = {
+            dragOnly: { title: "Drag", action: { dragstart: vi.fn() } },
+            clickable: { title: "Click", action: { click: vi.fn() } },
+        };
+
+        const result = buildMenuEntries(entries, trigger);
+
+        expect(result.dragOnly).toBeUndefined();
+        expect(result.clickable).toBeDefined();
+    });
+
+    it("adds shortcut hints on append, replace, delete", () => {
+        const trigger = vi.fn();
+        const entries: Record<string, PadEntry> = {
+            append: { title: "Append", action: vi.fn() },
+            replace: { title: "Replace", action: vi.fn() },
+            delete: { title: "Delete", action: vi.fn() },
+            connect: { title: "Connect", action: vi.fn() },
+        };
+
+        const result = buildMenuEntries(entries, trigger);
+
+        expect(result.append.description).toBe("A");
+        expect(result.replace.description).toBe("R");
+        expect(result.delete.description).toBe("Del");
+        expect(result.connect.description).toBeUndefined();
+    });
+
+    it("preserves insertion order", () => {
+        const trigger = vi.fn();
+        const entries: Record<string, PadEntry> = {
+            first: { title: "First", action: vi.fn() },
+            second: { title: "Second", action: vi.fn() },
+            third: { title: "Third", action: vi.fn() },
+        };
+
+        const result = buildMenuEntries(entries, trigger);
+
+        expect(Object.keys(result)).toEqual(["first", "second", "third"]);
+    });
+
+    it("action calls trigger with the entry id", () => {
+        const trigger = vi.fn();
+        const entries: Record<string, PadEntry> = {
+            myEntry: { title: "My Entry", action: vi.fn() },
+        };
+
+        const result = buildMenuEntries(entries, trigger);
+        result.myEntry.action();
+
+        expect(trigger).toHaveBeenCalledWith("myEntry");
+    });
+});

--- a/libs/flow-navigation/src/contextPadMenu.ts
+++ b/libs/flow-navigation/src/contextPadMenu.ts
@@ -27,9 +27,11 @@ export interface MenuEntry {
 }
 
 const SHORTCUT_HINTS: Record<string, string> = {
-    append: "A",
-    replace: "R",
-    delete: "Del",
+    "append": "A",
+    "replace": "R",
+    "delete": "Del",
+    "navigate-to-referenced-model": "G",
+    "go-to-implementation": "G",
 };
 
 /**

--- a/libs/flow-navigation/src/contextPadMenu.ts
+++ b/libs/flow-navigation/src/contextPadMenu.ts
@@ -32,6 +32,7 @@ const SHORTCUT_HINTS: Record<string, string> = {
     "delete": "Del",
     "navigate-to-referenced-model": "G",
     "go-to-implementation": "G",
+    "edit-script": "O",
 };
 
 /**

--- a/libs/flow-navigation/src/contextPadMenu.ts
+++ b/libs/flow-navigation/src/contextPadMenu.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure mapping from context-pad entries to popup-menu entries.
+ *
+ * Keeps the entry-to-menu transformation testable with plain object
+ * literals, free from DOM or DI dependencies.
+ */
+
+type PadAction = (...args: unknown[]) => unknown;
+
+/** Structural subset of a diagram-js context-pad entry. */
+export interface PadEntry {
+    title?: string;
+    className?: string;
+    imageUrl?: string;
+    html?: string;
+    group?: string;
+    action?: Record<string, PadAction> | PadAction;
+}
+
+/** Structural subset of a diagram-js popup-menu entry. */
+export interface MenuEntry {
+    label: string;
+    className?: string;
+    imageUrl?: string;
+    description?: string;
+    action: () => void;
+}
+
+const SHORTCUT_HINTS: Record<string, string> = {
+    append: "A",
+    replace: "R",
+    delete: "Del",
+};
+
+/**
+ * Builds popup-menu entries from context-pad entries, filtering out
+ * entries without a click action and adding keyboard shortcut hints
+ * for entries that have dedicated keys.
+ */
+export function buildMenuEntries(
+    padEntries: Record<string, PadEntry>,
+    trigger: (entryId: string) => void,
+): Record<string, MenuEntry> {
+    const result: Record<string, MenuEntry> = {};
+
+    for (const [id, entry] of Object.entries(padEntries)) {
+        if (!hasClickAction(entry)) continue;
+
+        const menuEntry: MenuEntry = {
+            label: entry.title ?? id,
+            action: () => trigger(id),
+        };
+        if (entry.className) menuEntry.className = entry.className;
+        if (entry.imageUrl) menuEntry.imageUrl = entry.imageUrl;
+        if (SHORTCUT_HINTS[id]) menuEntry.description = SHORTCUT_HINTS[id];
+
+        result[id] = menuEntry;
+    }
+
+    return result;
+}
+
+function hasClickAction(entry: PadEntry): boolean {
+    if (typeof entry.action === "function") return true;
+    if (
+        entry.action &&
+        typeof entry.action === "object" &&
+        typeof entry.action.click === "function"
+    )
+        return true;
+    return false;
+}

--- a/libs/flow-navigation/src/index.ts
+++ b/libs/flow-navigation/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * bpmn-js DI module that adds Tab / Shift+Tab / Enter keyboard navigation
+ * along sequence flows to the BPMN modeler.
+ *
+ * Register as an `additionalModule` when creating the bpmn-js modeler:
+ * ```ts
+ * import { FlowNavigationModule } from "@miragon/bpmn-modeler-flow-navigation";
+ *
+ * new BpmnModeler({ additionalModules: [FlowNavigationModule] });
+ * ```
+ */
+import { FlowNavigation } from "./FlowNavigation";
+
+export const FlowNavigationModule = {
+    __init__: ["flowNavigation"],
+    flowNavigation: ["type", FlowNavigation],
+};

--- a/libs/flow-navigation/src/index.ts
+++ b/libs/flow-navigation/src/index.ts
@@ -9,9 +9,13 @@
  * new BpmnModeler({ additionalModules: [FlowNavigationModule] });
  * ```
  */
+import { ContextPadKeyboard } from "./ContextPadKeyboard";
+import { DeleteSelectionBehavior } from "./DeleteSelectionBehavior";
 import { FlowNavigation } from "./FlowNavigation";
 
 export const FlowNavigationModule = {
-    __init__: ["flowNavigation"],
+    __init__: ["flowNavigation", "deleteSelectionBehavior", "contextPadKeyboard"],
     flowNavigation: ["type", FlowNavigation],
+    deleteSelectionBehavior: ["type", DeleteSelectionBehavior],
+    contextPadKeyboard: ["type", ContextPadKeyboard],
 };

--- a/libs/flow-navigation/src/index.ts
+++ b/libs/flow-navigation/src/index.ts
@@ -1,6 +1,7 @@
 /**
- * bpmn-js DI module that adds Tab / Shift+Tab / Enter keyboard navigation
- * along sequence flows to the BPMN modeler.
+ * bpmn-js DI module that adds Tab / Shift+Tab / Enter / u / g keyboard
+ * navigation along sequence flows, into/out of collapsed subprocesses,
+ * and to linked files (referenced models or implementations).
  *
  * Register as an `additionalModule` when creating the bpmn-js modeler:
  * ```ts
@@ -12,10 +13,20 @@
 import { ContextPadKeyboard } from "./ContextPadKeyboard";
 import { DeleteSelectionBehavior } from "./DeleteSelectionBehavior";
 import { FlowNavigation } from "./FlowNavigation";
+import { LinkNavigation } from "./LinkNavigation";
+import { PlaneNavigation } from "./PlaneNavigation";
 
 export const FlowNavigationModule = {
-    __init__: ["flowNavigation", "deleteSelectionBehavior", "contextPadKeyboard"],
+    __init__: [
+        "flowNavigation",
+        "deleteSelectionBehavior",
+        "contextPadKeyboard",
+        "planeNavigation",
+        "linkNavigation",
+    ],
     flowNavigation: ["type", FlowNavigation],
     deleteSelectionBehavior: ["type", DeleteSelectionBehavior],
     contextPadKeyboard: ["type", ContextPadKeyboard],
+    planeNavigation: ["type", PlaneNavigation],
+    linkNavigation: ["type", LinkNavigation],
 };

--- a/libs/flow-navigation/src/traversal.spec.ts
+++ b/libs/flow-navigation/src/traversal.spec.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveEntry, resolveFollow, resolveStep, type NavElement } from "./traversal";
+
+// ---------------------------------------------------------------------------
+// Graph builders — plain objects satisfying NavElement structurally.
+// ---------------------------------------------------------------------------
+
+function shape(id: string, type: string, x: number, y: number): NavElement {
+    return { id, type, x, y, incoming: [], outgoing: [] };
+}
+
+function flow(id: string, src: NavElement, tgt: NavElement): NavElement {
+    const f: NavElement = {
+        id,
+        type: "bpmn:SequenceFlow",
+        x: 0,
+        y: 0,
+        incoming: [],
+        outgoing: [],
+        source: src,
+        target: tgt,
+    };
+    src.outgoing.push(f);
+    tgt.incoming.push(f);
+    return f;
+}
+
+// ---------------------------------------------------------------------------
+// resolveStep — Tab / Shift+Tab
+// ---------------------------------------------------------------------------
+
+describe("resolveStep", () => {
+    it("linear forward: single outgoing jumps to target shape", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        flow("f1", a, b);
+
+        expect(resolveStep(a, "forward")).toBe(b);
+    });
+
+    it("linear backward: single incoming jumps to source shape", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        flow("f1", a, b);
+
+        expect(resolveStep(b, "backward")).toBe(a);
+    });
+
+    it("fan-out: Tab from gateway selects first outgoing flow (sorted by target y-then-x)", () => {
+        const gw = shape("gw", "bpmn:ExclusiveGateway", 200, 200);
+        const top = shape("top", "bpmn:Task", 300, 100);
+        const mid = shape("mid", "bpmn:Task", 300, 200);
+        const bot = shape("bot", "bpmn:Task", 300, 300);
+        const f1 = flow("f1", gw, top);
+        flow("f2", gw, mid);
+        flow("f3", gw, bot);
+
+        expect(resolveStep(gw, "forward")).toBe(f1);
+    });
+
+    it("fan cycling forward: Tab on flow cycles to next sibling with wrap", () => {
+        const gw = shape("gw", "bpmn:ExclusiveGateway", 200, 200);
+        const t1 = shape("t1", "bpmn:Task", 300, 100);
+        const t2 = shape("t2", "bpmn:Task", 300, 200);
+        const t3 = shape("t3", "bpmn:Task", 300, 300);
+        const f1 = flow("f1", gw, t1);
+        const f2 = flow("f2", gw, t2);
+        const f3 = flow("f3", gw, t3);
+
+        expect(resolveStep(f1, "forward")).toBe(f2);
+        expect(resolveStep(f2, "forward")).toBe(f3);
+        expect(resolveStep(f3, "forward")).toBe(f1);
+    });
+
+    it("fan cycling backward: Shift+Tab on flow cycles to previous sibling with wrap", () => {
+        const gw = shape("gw", "bpmn:ExclusiveGateway", 200, 200);
+        const t1 = shape("t1", "bpmn:Task", 300, 100);
+        const t2 = shape("t2", "bpmn:Task", 300, 200);
+        const t3 = shape("t3", "bpmn:Task", 300, 300);
+        const f1 = flow("f1", gw, t1);
+        const f2 = flow("f2", gw, t2);
+        const f3 = flow("f3", gw, t3);
+
+        expect(resolveStep(f3, "backward")).toBe(f2);
+        expect(resolveStep(f2, "backward")).toBe(f1);
+        expect(resolveStep(f1, "backward")).toBe(f3);
+    });
+
+    it("round-trip identity: Tab then Shift+Tab returns to the same flow", () => {
+        const gw = shape("gw", "bpmn:ExclusiveGateway", 200, 200);
+        const t1 = shape("t1", "bpmn:Task", 300, 100);
+        const t2 = shape("t2", "bpmn:Task", 300, 200);
+        const f1 = flow("f1", gw, t1);
+        flow("f2", gw, t2);
+
+        const next = resolveStep(f1, "forward");
+        expect(resolveStep(next!, "backward")).toBe(f1);
+    });
+
+    it("fan-in merge: Tab on flow cycles through target's incoming", () => {
+        const t1 = shape("t1", "bpmn:Task", 100, 100);
+        const t2 = shape("t2", "bpmn:Task", 100, 200);
+        const merge = shape("merge", "bpmn:ExclusiveGateway", 200, 150);
+        const f1 = flow("f1", t1, merge);
+        const f2 = flow("f2", t2, merge);
+
+        expect(resolveStep(f1, "forward")).toBe(f2);
+        expect(resolveStep(f2, "forward")).toBe(f1);
+    });
+
+    it("1-to-1 flow (mouse-selected): Tab → target, Shift+Tab → source", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const f = flow("f1", a, b);
+
+        expect(resolveStep(f, "forward")).toBe(b);
+        expect(resolveStep(f, "backward")).toBe(a);
+    });
+
+    it("end shape forward → null", () => {
+        const end = shape("end", "bpmn:EndEvent", 400, 200);
+
+        expect(resolveStep(end, "forward")).toBeNull();
+    });
+
+    it("start shape backward → null", () => {
+        const start = shape("start", "bpmn:StartEvent", 100, 200);
+
+        expect(resolveStep(start, "backward")).toBeNull();
+    });
+
+    it("boundary event backward → host shape", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const boundary: NavElement = {
+            ...shape("be", "bpmn:BoundaryEvent", 200, 280),
+            host: task,
+        };
+
+        expect(resolveStep(boundary, "backward")).toBe(task);
+    });
+
+    it("label normalization: resolves through labelTarget", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        flow("f1", a, b);
+        const label: NavElement = {
+            ...shape("lbl", "label", 100, 80),
+            labelTarget: a,
+        };
+
+        expect(resolveStep(label, "forward")).toBe(b);
+    });
+
+    it("message flows are filtered: only bpmn:SequenceFlow counts", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const mf: NavElement = {
+            id: "mf1",
+            type: "bpmn:MessageFlow",
+            x: 0,
+            y: 0,
+            incoming: [],
+            outgoing: [],
+            source: a,
+            target: b,
+        };
+        a.outgoing.push(mf);
+        b.incoming.push(mf);
+
+        expect(resolveStep(a, "forward")).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// resolveFollow — Enter / Shift+Enter
+// ---------------------------------------------------------------------------
+
+describe("resolveFollow", () => {
+    it("Enter on flow → target", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const f = flow("f1", a, b);
+
+        expect(resolveFollow(f, "forward")).toBe(b);
+    });
+
+    it("Shift+Enter on flow → source", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const f = flow("f1", a, b);
+
+        expect(resolveFollow(f, "backward")).toBe(a);
+    });
+
+    it("Enter on shape → null", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+
+        expect(resolveFollow(a, "forward")).toBeNull();
+    });
+
+    it("Enter on message flow → null (not bpmn:SequenceFlow)", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const mf: NavElement = {
+            id: "mf1",
+            type: "bpmn:MessageFlow",
+            x: 0,
+            y: 0,
+            incoming: [],
+            outgoing: [],
+            source: a,
+            target: b,
+        };
+
+        expect(resolveFollow(mf, "forward")).toBeNull();
+    });
+
+    it("Enter on flow label → resolves through labelTarget", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const f = flow("f1", a, b);
+        const label: NavElement = {
+            ...shape("lbl", "label", 150, 80),
+            labelTarget: f,
+        };
+
+        expect(resolveFollow(label, "forward")).toBe(b);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEntry — empty selection
+// ---------------------------------------------------------------------------
+
+describe("resolveEntry", () => {
+    it("forward → start event", () => {
+        const start = shape("start", "bpmn:StartEvent", 100, 200);
+        const task = shape("task", "bpmn:Task", 200, 200);
+        flow("f1", start, task);
+
+        expect(resolveEntry([start, task], "forward")).toBe(start);
+    });
+
+    it("forward → topmost start event when multiple exist", () => {
+        const s1 = shape("s1", "bpmn:StartEvent", 100, 300);
+        const s2 = shape("s2", "bpmn:StartEvent", 100, 100);
+
+        expect(resolveEntry([s1, s2], "forward")).toBe(s2);
+    });
+
+    it("backward → end event", () => {
+        const end = shape("end", "bpmn:EndEvent", 400, 200);
+        const task = shape("task", "bpmn:Task", 200, 200);
+        flow("f1", task, end);
+
+        expect(resolveEntry([task, end], "backward")).toBe(end);
+    });
+
+    it("empty diagram → null", () => {
+        expect(resolveEntry([], "forward")).toBeNull();
+    });
+
+    it("no start event: fallback to node with 0 sequence-incoming", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+
+        expect(resolveEntry([task], "forward")).toBe(task);
+    });
+
+    it("filters out labels and connections from candidates", () => {
+        const start = shape("start", "bpmn:StartEvent", 100, 200);
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const f = flow("f1", start, task);
+        const label: NavElement = {
+            ...shape("lbl", "label", 150, 180),
+            labelTarget: f,
+        };
+
+        expect(resolveEntry([start, task, f, label], "forward")).toBe(start);
+    });
+
+    it("collaboration: finds start events inside participants", () => {
+        const start = shape("start", "bpmn:StartEvent", 150, 250);
+        const participant: NavElement = {
+            ...shape("p1", "bpmn:Participant", 100, 200),
+            children: [start],
+        };
+
+        expect(resolveEntry([participant], "forward")).toBe(start);
+    });
+});

--- a/libs/flow-navigation/src/traversal.spec.ts
+++ b/libs/flow-navigation/src/traversal.spec.ts
@@ -118,15 +118,40 @@ describe("resolveStep", () => {
         expect(resolveStep(next!.element, "backward")?.element).toBe(f1);
     });
 
-    it("fan-in merge: Tab on flow cycles through target's incoming", () => {
+    it("fan-in: Tab on flow goes to target, Shift+Tab goes to source", () => {
         const t1 = shape("t1", "bpmn:Task", 100, 100);
         const t2 = shape("t2", "bpmn:Task", 100, 200);
         const merge = shape("merge", "bpmn:ExclusiveGateway", 200, 150);
         const f1 = flow("f1", t1, merge);
-        const f2 = flow("f2", t2, merge);
+        flow("f2", t2, merge);
 
-        expect(resolveStep(f1, "forward")?.element).toBe(f2);
-        expect(resolveStep(f2, "forward")?.element).toBe(f1);
+        expect(resolveStep(f1, "forward")?.element).toBe(merge);
+        expect(resolveStep(f1, "backward")?.element).toBe(t1);
+    });
+
+    it("fan-in backward: Shift+Tab from merge jumps to first source (y-then-x)", () => {
+        const t1 = shape("t1", "bpmn:Task", 100, 100);
+        const t2 = shape("t2", "bpmn:Task", 100, 200);
+        const merge = shape("merge", "bpmn:ExclusiveGateway", 200, 150);
+        flow("f1", t1, merge);
+        flow("f2", t2, merge);
+
+        const result = resolveStep(merge, "backward");
+        expect(result?.element).toBe(t1);
+        expect(result?.boundaryCandidate).toBe(false);
+    });
+
+    it("fan-in regression: backward from merge yields shape, Enter cannot bounce back", () => {
+        const t1 = shape("t1", "bpmn:Task", 100, 100);
+        const t2 = shape("t2", "bpmn:Task", 100, 200);
+        const merge = shape("merge", "bpmn:ExclusiveGateway", 200, 150);
+        flow("f1", t1, merge);
+        flow("f2", t2, merge);
+
+        const step = resolveStep(merge, "backward");
+        expect(step?.element).toBe(t1);
+
+        expect(resolveFollow(step!.element, "forward")).toBeNull();
     });
 
     it("1-to-1 flow (mouse-selected): Tab → target, Shift+Tab → source", () => {

--- a/libs/flow-navigation/src/traversal.spec.ts
+++ b/libs/flow-navigation/src/traversal.spec.ts
@@ -32,6 +32,20 @@ function flow(id: string, src: NavElement, tgt: NavElement): NavElement {
     return f;
 }
 
+function attach(id: string, host: NavElement, x: number, y: number): NavElement {
+    const boundary: NavElement = {
+        id,
+        type: "bpmn:BoundaryEvent",
+        x,
+        y,
+        incoming: [],
+        outgoing: [],
+        host,
+    };
+    (host.attachers ??= []).push(boundary);
+    return boundary;
+}
+
 // ---------------------------------------------------------------------------
 // resolveStep — Tab / Shift+Tab
 // ---------------------------------------------------------------------------
@@ -42,7 +56,7 @@ describe("resolveStep", () => {
         const b = shape("b", "bpmn:Task", 200, 100);
         flow("f1", a, b);
 
-        expect(resolveStep(a, "forward")).toBe(b);
+        expect(resolveStep(a, "forward")?.element).toBe(b);
     });
 
     it("linear backward: single incoming jumps to source shape", () => {
@@ -50,7 +64,7 @@ describe("resolveStep", () => {
         const b = shape("b", "bpmn:Task", 200, 100);
         flow("f1", a, b);
 
-        expect(resolveStep(b, "backward")).toBe(a);
+        expect(resolveStep(b, "backward")?.element).toBe(a);
     });
 
     it("fan-out: Tab from gateway selects first outgoing flow (sorted by target y-then-x)", () => {
@@ -62,7 +76,7 @@ describe("resolveStep", () => {
         flow("f2", gw, mid);
         flow("f3", gw, bot);
 
-        expect(resolveStep(gw, "forward")).toBe(f1);
+        expect(resolveStep(gw, "forward")?.element).toBe(f1);
     });
 
     it("fan cycling forward: Tab on flow cycles to next sibling with wrap", () => {
@@ -74,9 +88,9 @@ describe("resolveStep", () => {
         const f2 = flow("f2", gw, t2);
         const f3 = flow("f3", gw, t3);
 
-        expect(resolveStep(f1, "forward")).toBe(f2);
-        expect(resolveStep(f2, "forward")).toBe(f3);
-        expect(resolveStep(f3, "forward")).toBe(f1);
+        expect(resolveStep(f1, "forward")?.element).toBe(f2);
+        expect(resolveStep(f2, "forward")?.element).toBe(f3);
+        expect(resolveStep(f3, "forward")?.element).toBe(f1);
     });
 
     it("fan cycling backward: Shift+Tab on flow cycles to previous sibling with wrap", () => {
@@ -88,9 +102,9 @@ describe("resolveStep", () => {
         const f2 = flow("f2", gw, t2);
         const f3 = flow("f3", gw, t3);
 
-        expect(resolveStep(f3, "backward")).toBe(f2);
-        expect(resolveStep(f2, "backward")).toBe(f1);
-        expect(resolveStep(f1, "backward")).toBe(f3);
+        expect(resolveStep(f3, "backward")?.element).toBe(f2);
+        expect(resolveStep(f2, "backward")?.element).toBe(f1);
+        expect(resolveStep(f1, "backward")?.element).toBe(f3);
     });
 
     it("round-trip identity: Tab then Shift+Tab returns to the same flow", () => {
@@ -101,7 +115,7 @@ describe("resolveStep", () => {
         flow("f2", gw, t2);
 
         const next = resolveStep(f1, "forward");
-        expect(resolveStep(next!, "backward")).toBe(f1);
+        expect(resolveStep(next!.element, "backward")?.element).toBe(f1);
     });
 
     it("fan-in merge: Tab on flow cycles through target's incoming", () => {
@@ -111,8 +125,8 @@ describe("resolveStep", () => {
         const f1 = flow("f1", t1, merge);
         const f2 = flow("f2", t2, merge);
 
-        expect(resolveStep(f1, "forward")).toBe(f2);
-        expect(resolveStep(f2, "forward")).toBe(f1);
+        expect(resolveStep(f1, "forward")?.element).toBe(f2);
+        expect(resolveStep(f2, "forward")?.element).toBe(f1);
     });
 
     it("1-to-1 flow (mouse-selected): Tab → target, Shift+Tab → source", () => {
@@ -120,8 +134,8 @@ describe("resolveStep", () => {
         const b = shape("b", "bpmn:Task", 200, 100);
         const f = flow("f1", a, b);
 
-        expect(resolveStep(f, "forward")).toBe(b);
-        expect(resolveStep(f, "backward")).toBe(a);
+        expect(resolveStep(f, "forward")?.element).toBe(b);
+        expect(resolveStep(f, "backward")?.element).toBe(a);
     });
 
     it("end shape forward → null", () => {
@@ -143,7 +157,7 @@ describe("resolveStep", () => {
             host: task,
         };
 
-        expect(resolveStep(boundary, "backward")).toBe(task);
+        expect(resolveStep(boundary, "backward")?.element).toBe(task);
     });
 
     it("label normalization: resolves through labelTarget", () => {
@@ -155,7 +169,7 @@ describe("resolveStep", () => {
             labelTarget: a,
         };
 
-        expect(resolveStep(label, "forward")).toBe(b);
+        expect(resolveStep(label, "forward")?.element).toBe(b);
     });
 
     it("message flows are filtered: only bpmn:SequenceFlow counts", () => {
@@ -175,6 +189,115 @@ describe("resolveStep", () => {
         b.incoming.push(mf);
 
         expect(resolveStep(a, "forward")).toBeNull();
+    });
+
+    // --- Boundary-event fan-out tests ---
+
+    it("mixed fan: Tab from shape with flow + boundary enters fan (boundary first by y)", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const end = shape("end", "bpmn:Task", 400, 200);
+        const be = attach("be", task, 200, 100);
+        flow("f1", task, end);
+
+        const result = resolveStep(task, "forward");
+        // Boundary at y=100 sorts before flow target at y=200.
+        expect(result?.element).toBe(be);
+        expect(result?.boundaryCandidate).toBe(true);
+    });
+
+    it("mixed fan cycling: Tab on flow cycles to boundary candidate, then wraps", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const end = shape("end", "bpmn:Task", 400, 300);
+        const be = attach("be", task, 200, 100);
+        const f1 = flow("f1", task, end);
+
+        // Sorted by representative: be(200,100), f1→end(400,300).
+        // From f1 forward → wraps to be.
+        const r1 = resolveStep(f1, "forward");
+        expect(r1?.element).toBe(be);
+        expect(r1?.boundaryCandidate).toBe(true);
+
+        // From be (as candidate) forward → cycles to f1.
+        const r2 = resolveStep(be, "forward", true);
+        expect(r2?.element).toBe(f1);
+        expect(r2?.boundaryCandidate).toBe(false);
+    });
+
+    it("mixed fan cycling backward: Shift+Tab reverses the ring", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const end = shape("end", "bpmn:Task", 400, 300);
+        const be = attach("be", task, 200, 100);
+        const f1 = flow("f1", task, end);
+
+        // From f1 backward → be (reverse of forward wrap).
+        const r1 = resolveStep(f1, "backward");
+        expect(r1?.element).toBe(be);
+        expect(r1?.boundaryCandidate).toBe(true);
+
+        // From be (candidate) backward → f1.
+        const r2 = resolveStep(be, "backward", true);
+        expect(r2?.element).toBe(f1);
+        expect(r2?.boundaryCandidate).toBe(false);
+    });
+
+    it("F=0, B=1: single boundary jumps committed (single-path semantics)", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const be = attach("be", task, 200, 280);
+
+        const result = resolveStep(task, "forward");
+        expect(result?.element).toBe(be);
+        expect(result?.boundaryCandidate).toBe(false);
+    });
+
+    it("F=0, B≥2: Tab from shape enters boundary-only fan as candidate", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const be1 = attach("be1", task, 200, 100);
+        attach("be2", task, 200, 300);
+
+        const result = resolveStep(task, "forward");
+        // be1 at y=100 sorts first.
+        expect(result?.element).toBe(be1);
+        expect(result?.boundaryCandidate).toBe(true);
+    });
+
+    it("committed boundary steps along its own outgoing flows", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const be = attach("be", task, 200, 280);
+        const end = shape("end", "bpmn:EndEvent", 400, 280);
+        flow("f2", be, end);
+
+        // Not a candidate — stepping from the boundary as a normal shape.
+        const result = resolveStep(be, "forward", false);
+        expect(result?.element).toBe(end);
+        expect(result?.boundaryCandidate).toBe(false);
+    });
+
+    it("stale boundary candidate flag: host fan ≤ 1, falls through to shape step", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const be = attach("be", task, 200, 280);
+        const end = shape("end", "bpmn:EndEvent", 400, 280);
+        flow("f2", be, end);
+        // Host fan = [be] only (no outgoing flows on task), length 1 → stale.
+
+        const result = resolveStep(be, "forward", true);
+        // Falls through to stepFromShape → boundary's own outgoing.
+        expect(result?.element).toBe(end);
+        expect(result?.boundaryCandidate).toBe(false);
+    });
+
+    it("gateway without boundaries: regression check — behaves as pure flow fan", () => {
+        const gw = shape("gw", "bpmn:ExclusiveGateway", 200, 200);
+        const t1 = shape("t1", "bpmn:Task", 300, 100);
+        const t2 = shape("t2", "bpmn:Task", 300, 300);
+        const f1 = flow("f1", gw, t1);
+        const f2 = flow("f2", gw, t2);
+
+        const r1 = resolveStep(gw, "forward");
+        expect(r1?.element).toBe(f1);
+        expect(r1?.boundaryCandidate).toBe(false);
+
+        expect(resolveStep(f1, "forward")?.element).toBe(f2);
+        expect(resolveStep(f2, "forward")?.element).toBe(f1);
     });
 });
 
@@ -286,7 +409,7 @@ describe("resolveFollow", () => {
         const b = shape("b", "bpmn:Task", 200, 100);
         const f = flow("f1", a, b);
 
-        expect(resolveFollow(f, "forward")).toBe(b);
+        expect(resolveFollow(f, "forward")?.element).toBe(b);
     });
 
     it("Shift+Enter on flow → source", () => {
@@ -294,7 +417,7 @@ describe("resolveFollow", () => {
         const b = shape("b", "bpmn:Task", 200, 100);
         const f = flow("f1", a, b);
 
-        expect(resolveFollow(f, "backward")).toBe(a);
+        expect(resolveFollow(f, "backward")?.element).toBe(a);
     });
 
     it("Enter on shape → null", () => {
@@ -329,7 +452,23 @@ describe("resolveFollow", () => {
             labelTarget: f,
         };
 
-        expect(resolveFollow(label, "forward")).toBe(b);
+        expect(resolveFollow(label, "forward")?.element).toBe(b);
+    });
+
+    it("Enter commits boundary candidate (stays selected, candidate cleared)", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const be = attach("be", task, 200, 280);
+
+        const result = resolveFollow(be, "forward", true);
+        expect(result?.element).toBe(be);
+        expect(result?.boundaryCandidate).toBe(false);
+    });
+
+    it("Enter on boundary without candidate flag → null", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const be = attach("be", task, 200, 280);
+
+        expect(resolveFollow(be, "forward", false)).toBeNull();
     });
 });
 

--- a/libs/flow-navigation/src/traversal.spec.ts
+++ b/libs/flow-navigation/src/traversal.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveEntry, resolveFollow, resolveStep, type NavElement } from "./traversal";
+import {
+    resolveDeleteAnchor,
+    resolveEntry,
+    resolveFollow,
+    resolveStep,
+    type NavElement,
+} from "./traversal";
 
 // ---------------------------------------------------------------------------
 // Graph builders — plain objects satisfying NavElement structurally.
@@ -169,6 +175,104 @@ describe("resolveStep", () => {
         b.incoming.push(mf);
 
         expect(resolveStep(a, "forward")).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDeleteAnchor — select predecessor after delete
+// ---------------------------------------------------------------------------
+
+describe("resolveDeleteAnchor", () => {
+    it("single incoming → source", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        flow("f1", a, b);
+
+        expect(resolveDeleteAnchor([b])).toBe(a);
+    });
+
+    it("fan-in → first by y-then-x", () => {
+        const t1 = shape("t1", "bpmn:Task", 100, 200);
+        const t2 = shape("t2", "bpmn:Task", 100, 100);
+        const merge = shape("merge", "bpmn:ExclusiveGateway", 200, 150);
+        flow("f1", t1, merge);
+        flow("f2", t2, merge);
+
+        expect(resolveDeleteAnchor([merge])).toBe(t2);
+    });
+
+    it("deleted-set skip → next surviving incoming source", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 100, 200);
+        const c = shape("c", "bpmn:Task", 200, 150);
+        flow("f1", a, c);
+        flow("f2", b, c);
+
+        expect(resolveDeleteAnchor([c, a])).toBe(b);
+    });
+
+    it("all incoming deleted → first outgoing target", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const c = shape("c", "bpmn:Task", 300, 100);
+        flow("f1", a, b);
+        flow("f2", b, c);
+
+        expect(resolveDeleteAnchor([b, a])).toBe(c);
+    });
+
+    it("boundary event → host", () => {
+        const task = shape("task", "bpmn:Task", 200, 200);
+        const boundary: NavElement = {
+            ...shape("be", "bpmn:BoundaryEvent", 200, 280),
+            host: task,
+        };
+
+        expect(resolveDeleteAnchor([boundary])).toBe(task);
+    });
+
+    it("isolated element → null", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+
+        expect(resolveDeleteAnchor([a])).toBeNull();
+    });
+
+    it("deleted connection → source", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const f = flow("f1", a, b);
+
+        expect(resolveDeleteAnchor([f])).toBe(a);
+    });
+
+    it("deleted connection with deleted source → target", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const f = flow("f1", a, b);
+
+        expect(resolveDeleteAnchor([f, a])).toBe(b);
+    });
+
+    it("label → resolves through labelTarget", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        flow("f1", a, b);
+        const label: NavElement = {
+            ...shape("lbl", "label", 200, 80),
+            labelTarget: b,
+        };
+
+        expect(resolveDeleteAnchor([label])).toBe(a);
+    });
+
+    it("multi-delete chain [B, C] of A→B→C → A", () => {
+        const a = shape("a", "bpmn:Task", 100, 100);
+        const b = shape("b", "bpmn:Task", 200, 100);
+        const c = shape("c", "bpmn:Task", 300, 100);
+        flow("f1", a, b);
+        flow("f2", b, c);
+
+        expect(resolveDeleteAnchor([b, c])).toBe(a);
     });
 });
 

--- a/libs/flow-navigation/src/traversal.ts
+++ b/libs/flow-navigation/src/traversal.ts
@@ -153,6 +153,45 @@ export function resolveFollow(current: NavElement, direction: Direction): NavEle
 }
 
 /**
+ * Resolve which element to select after a delete operation.
+ *
+ * Uses the first deleted element as the primary anchor: for shapes,
+ * prefers the first surviving incoming source (y-then-x order), then
+ * outgoing target, then boundary-event host. For connections, prefers
+ * the surviving source, then target.
+ */
+export function resolveDeleteAnchor(deleted: NavElement[]): NavElement | null {
+    if (deleted.length === 0) return null;
+
+    const deletedIds = new Set(deleted.map((el) => el.id));
+    const primary = normalize(deleted[0]);
+
+    // Connection: prefer surviving source, then target.
+    if (primary.source != null && primary.target != null) {
+        if (!deletedIds.has(primary.source.id)) return primary.source;
+        if (!deletedIds.has(primary.target.id)) return primary.target;
+        return null;
+    }
+
+    // Shape: first surviving incoming source (y-then-x order).
+    const inc = sortByEndpoint(sequenceFlows(primary.incoming), "source");
+    for (const f of inc) {
+        if (!deletedIds.has(f.source!.id)) return f.source!;
+    }
+
+    // Fallback: first surviving outgoing target.
+    const out = sortByEndpoint(sequenceFlows(primary.outgoing), "target");
+    for (const f of out) {
+        if (!deletedIds.has(f.target!.id)) return f.target!;
+    }
+
+    // Boundary event: host.
+    if (primary.host && !deletedIds.has(primary.host.id)) return primary.host;
+
+    return null;
+}
+
+/**
  * Pick an entry point when no element is selected.
  *
  * Forward prefers start events (sorted y-then-x), then nodes with

--- a/libs/flow-navigation/src/traversal.ts
+++ b/libs/flow-navigation/src/traversal.ts
@@ -125,22 +125,16 @@ function stepFromShape(shape: NavElement, direction: Direction): StepResult | nu
     const inc = sequenceFlows(shape.incoming);
     if (inc.length === 0)
         return shape.host ? { element: shape.host, boundaryCandidate: false } : null;
-    if (inc.length === 1) return { element: inc[0].source!, boundaryCandidate: false };
-    return { element: sortByEndpoint(inc, "source")[0], boundaryCandidate: false };
+    return { element: sortByEndpoint(inc, "source")[0].source!, boundaryCandidate: false };
 }
 
 function stepFromFlow(flow: NavElement, direction: Direction): StepResult | null {
     const srcCandidates = fanOutCandidates(flow.source!);
-    const tgtIn = sequenceFlows(flow.target!.incoming);
 
     // Source fan (including boundary events) takes priority.
     if (srcCandidates.length > 1) {
         const next = cycleBy(srcCandidates, representative, flow, direction);
         return toStepResult(next);
-    }
-    if (tgtIn.length > 1) {
-        const next = cycleBy(tgtIn, (f) => f.source!, flow, direction);
-        return { element: next, boundaryCandidate: false };
     }
 
     // No fan — linear traversal.

--- a/libs/flow-navigation/src/traversal.ts
+++ b/libs/flow-navigation/src/traversal.ts
@@ -1,0 +1,185 @@
+/**
+ * Pure, DOM-free traversal resolution for keyboard flow navigation.
+ *
+ * All functions operate on structural `NavElement` types so unit tests can
+ * pass plain object literals without pulling in the bpmn-js runtime.
+ */
+
+/**
+ * Structural shape/connection type that both real bpmn-js elements and
+ * test object literals satisfy.
+ */
+export interface NavElement {
+    id: string;
+    type: string;
+    x: number;
+    y: number;
+    incoming: NavElement[];
+    outgoing: NavElement[];
+    source?: NavElement;
+    target?: NavElement;
+    labelTarget?: NavElement;
+    host?: NavElement;
+    parent?: NavElement;
+    children?: NavElement[];
+}
+
+export type Direction = "forward" | "backward";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function normalize(el: NavElement): NavElement {
+    if (el.type === "label" && el.labelTarget) return el.labelTarget;
+    return el;
+}
+
+function isSequenceFlow(el: NavElement): boolean {
+    return el.type === "bpmn:SequenceFlow";
+}
+
+function sequenceFlows(connections: NavElement[]): NavElement[] {
+    return connections.filter(isSequenceFlow);
+}
+
+/** y-then-x comparator over element bounds. */
+function byBounds(a: NavElement, b: NavElement): number {
+    const dy = a.y - b.y;
+    return dy !== 0 ? dy : a.x - b.x;
+}
+
+function sortByEndpoint(flows: NavElement[], endpoint: "source" | "target"): NavElement[] {
+    return [...flows].sort((a, b) => byBounds(a[endpoint]!, b[endpoint]!));
+}
+
+function cycleInFan(
+    flows: NavElement[],
+    sortEndpoint: "source" | "target",
+    current: NavElement,
+    direction: Direction,
+): NavElement {
+    const sorted = sortByEndpoint(flows, sortEndpoint);
+    const idx = sorted.findIndex((f) => f.id === current.id);
+    const step = direction === "forward" ? 1 : -1;
+    const next = (idx + step + sorted.length) % sorted.length;
+    return sorted[next];
+}
+
+// ---------------------------------------------------------------------------
+// Shape / flow step (Tab / Shift+Tab)
+// ---------------------------------------------------------------------------
+
+function stepFromShape(shape: NavElement, direction: Direction): NavElement | null {
+    if (direction === "forward") {
+        const out = sequenceFlows(shape.outgoing);
+        if (out.length === 0) return null;
+        if (out.length === 1) return out[0].target!;
+        // Fan-out: select the first outgoing flow so the user can cycle/confirm.
+        return sortByEndpoint(out, "target")[0];
+    }
+
+    const inc = sequenceFlows(shape.incoming);
+    if (inc.length === 0) return shape.host ?? null;
+    if (inc.length === 1) return inc[0].source!;
+    return sortByEndpoint(inc, "source")[0];
+}
+
+function stepFromFlow(flow: NavElement, direction: Direction): NavElement | null {
+    const srcOut = sequenceFlows(flow.source!.outgoing);
+    const tgtIn = sequenceFlows(flow.target!.incoming);
+
+    // Source fan takes priority (documented v1 limitation when both ends fan).
+    if (srcOut.length > 1) {
+        return cycleInFan(srcOut, "target", flow, direction);
+    }
+    if (tgtIn.length > 1) {
+        return cycleInFan(tgtIn, "source", flow, direction);
+    }
+
+    // No fan — linear traversal.
+    return direction === "forward" ? flow.target! : flow.source!;
+}
+
+// ---------------------------------------------------------------------------
+// Collect flow nodes (handles collaborations with participants)
+// ---------------------------------------------------------------------------
+
+function gatherFlowNodes(children: NavElement[]): NavElement[] {
+    const nodes: NavElement[] = [];
+    for (const el of children) {
+        if (el.type === "label" || el.source != null) continue;
+        if (el.type === "bpmn:Participant" && el.children) {
+            nodes.push(...gatherFlowNodes(el.children));
+        } else {
+            nodes.push(el);
+        }
+    }
+    return nodes;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the next element for Tab / Shift+Tab.
+ *
+ * Shapes with a single sequence-flow connection jump straight to the
+ * opposite shape. Shapes at a fan-out/-in select the first flow so the
+ * user can cycle through siblings. Flows in a fan cycle with wrap;
+ * 1-to-1 flows step to their target/source directly.
+ */
+export function resolveStep(current: NavElement, direction: Direction): NavElement | null {
+    const el = normalize(current);
+
+    if (el.source != null && el.target != null) {
+        return stepFromFlow(el, direction);
+    }
+    return stepFromShape(el, direction);
+}
+
+/**
+ * Resolve the element for Enter / Shift+Enter on a sequence flow.
+ *
+ * Enter jumps to the flow's target, Shift+Enter to its source.
+ * Returns `null` for non-sequence-flow elements so the caller can
+ * decide not to consume the key.
+ */
+export function resolveFollow(current: NavElement, direction: Direction): NavElement | null {
+    const el = normalize(current);
+    if (el.type !== "bpmn:SequenceFlow" || !el.source || !el.target) return null;
+    return direction === "forward" ? el.target : el.source;
+}
+
+/**
+ * Pick an entry point when no element is selected.
+ *
+ * Forward prefers start events (sorted y-then-x), then nodes with
+ * zero sequence-incoming, then the top-left-most flow node.
+ * Backward mirrors with end events / zero outgoing.
+ */
+export function resolveEntry(rootChildren: NavElement[], direction: Direction): NavElement | null {
+    const nodes = gatherFlowNodes(rootChildren);
+    if (nodes.length === 0) return null;
+
+    if (direction === "forward") {
+        const starts = nodes.filter((n) => n.type === "bpmn:StartEvent").sort(byBounds);
+        if (starts.length > 0) return starts[0];
+
+        const noIncoming = nodes
+            .filter((n) => sequenceFlows(n.incoming).length === 0)
+            .sort(byBounds);
+        if (noIncoming.length > 0) return noIncoming[0];
+
+        return [...nodes].sort(byBounds)[0];
+    }
+
+    const ends = nodes.filter((n) => n.type === "bpmn:EndEvent").sort(byBounds);
+    if (ends.length > 0) return ends[0];
+
+    const noOutgoing = nodes.filter((n) => sequenceFlows(n.outgoing).length === 0).sort(byBounds);
+    if (noOutgoing.length > 0) return noOutgoing[0];
+
+    return [...nodes].sort(byBounds)[0];
+}

--- a/libs/flow-navigation/src/traversal.ts
+++ b/libs/flow-navigation/src/traversal.ts
@@ -22,9 +22,24 @@ export interface NavElement {
     host?: NavElement;
     parent?: NavElement;
     children?: NavElement[];
+    /** Inverse of `host` — diagram-js maintains it on every shape. */
+    attachers?: NavElement[];
 }
 
 export type Direction = "forward" | "backward";
+
+/**
+ * Result of a step/follow resolution.
+ *
+ * `boundaryCandidate` distinguishes a boundary event being previewed
+ * in a mixed fan (true) from one the user has committed to (false).
+ * The caller holds this flag as state so the next keypress knows
+ * whether to cycle within the host fan or step from the boundary.
+ */
+export interface StepResult {
+    element: NavElement;
+    boundaryCandidate: boolean;
+}
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -49,18 +64,41 @@ function byBounds(a: NavElement, b: NavElement): number {
     return dy !== 0 ? dy : a.x - b.x;
 }
 
+/** Flows sort by their target shape; boundary events represent themselves. */
+function representative(candidate: NavElement): NavElement {
+    return candidate.target ?? candidate;
+}
+
+/**
+ * Outgoing sequence flows ∪ attached boundary events, sorted y-then-x
+ * by representative shape — the mixed fan a user cycles through.
+ */
+function fanOutCandidates(shape: NavElement): NavElement[] {
+    const flows = sequenceFlows(shape.outgoing);
+    const boundaries = shape.attachers ?? [];
+    return [...flows, ...boundaries].sort((a, b) => byBounds(representative(a), representative(b)));
+}
+
+/** Boundary events produce candidate results; flows do not. */
+function toStepResult(candidate: NavElement): StepResult {
+    return {
+        element: candidate,
+        boundaryCandidate: candidate.source == null && candidate.host != null,
+    };
+}
+
 function sortByEndpoint(flows: NavElement[], endpoint: "source" | "target"): NavElement[] {
     return [...flows].sort((a, b) => byBounds(a[endpoint]!, b[endpoint]!));
 }
 
-function cycleInFan(
-    flows: NavElement[],
-    sortEndpoint: "source" | "target",
+function cycleBy(
+    items: NavElement[],
+    keyOf: (item: NavElement) => NavElement,
     current: NavElement,
     direction: Direction,
 ): NavElement {
-    const sorted = sortByEndpoint(flows, sortEndpoint);
-    const idx = sorted.findIndex((f) => f.id === current.id);
+    const sorted = [...items].sort((a, b) => byBounds(keyOf(a), keyOf(b)));
+    const idx = sorted.findIndex((item) => item.id === current.id);
     const step = direction === "forward" ? 1 : -1;
     const next = (idx + step + sorted.length) % sorted.length;
     return sorted[next];
@@ -70,35 +108,45 @@ function cycleInFan(
 // Shape / flow step (Tab / Shift+Tab)
 // ---------------------------------------------------------------------------
 
-function stepFromShape(shape: NavElement, direction: Direction): NavElement | null {
+function stepFromShape(shape: NavElement, direction: Direction): StepResult | null {
     if (direction === "forward") {
-        const out = sequenceFlows(shape.outgoing);
-        if (out.length === 0) return null;
-        if (out.length === 1) return out[0].target!;
-        // Fan-out: select the first outgoing flow so the user can cycle/confirm.
-        return sortByEndpoint(out, "target")[0];
+        const candidates = fanOutCandidates(shape);
+        if (candidates.length === 0) return null;
+        if (candidates.length === 1) {
+            const only = candidates[0];
+            // Single flow, no boundaries: jump straight to target (unchanged shortcut).
+            if (only.target) return { element: only.target, boundaryCandidate: false };
+            // Single boundary, no flows: committed jump (single-path semantics).
+            return { element: only, boundaryCandidate: false };
+        }
+        return toStepResult(candidates[0]);
     }
 
     const inc = sequenceFlows(shape.incoming);
-    if (inc.length === 0) return shape.host ?? null;
-    if (inc.length === 1) return inc[0].source!;
-    return sortByEndpoint(inc, "source")[0];
+    if (inc.length === 0)
+        return shape.host ? { element: shape.host, boundaryCandidate: false } : null;
+    if (inc.length === 1) return { element: inc[0].source!, boundaryCandidate: false };
+    return { element: sortByEndpoint(inc, "source")[0], boundaryCandidate: false };
 }
 
-function stepFromFlow(flow: NavElement, direction: Direction): NavElement | null {
-    const srcOut = sequenceFlows(flow.source!.outgoing);
+function stepFromFlow(flow: NavElement, direction: Direction): StepResult | null {
+    const srcCandidates = fanOutCandidates(flow.source!);
     const tgtIn = sequenceFlows(flow.target!.incoming);
 
-    // Source fan takes priority (documented v1 limitation when both ends fan).
-    if (srcOut.length > 1) {
-        return cycleInFan(srcOut, "target", flow, direction);
+    // Source fan (including boundary events) takes priority.
+    if (srcCandidates.length > 1) {
+        const next = cycleBy(srcCandidates, representative, flow, direction);
+        return toStepResult(next);
     }
     if (tgtIn.length > 1) {
-        return cycleInFan(tgtIn, "source", flow, direction);
+        const next = cycleBy(tgtIn, (f) => f.source!, flow, direction);
+        return { element: next, boundaryCandidate: false };
     }
 
     // No fan — linear traversal.
-    return direction === "forward" ? flow.target! : flow.source!;
+    return direction === "forward"
+        ? { element: flow.target!, boundaryCandidate: false }
+        : { element: flow.source!, boundaryCandidate: false };
 }
 
 // ---------------------------------------------------------------------------
@@ -125,13 +173,26 @@ function gatherFlowNodes(children: NavElement[]): NavElement[] {
 /**
  * Resolve the next element for Tab / Shift+Tab.
  *
- * Shapes with a single sequence-flow connection jump straight to the
- * opposite shape. Shapes at a fan-out/-in select the first flow so the
- * user can cycle through siblings. Flows in a fan cycle with wrap;
- * 1-to-1 flows step to their target/source directly.
+ * When `currentIsBoundaryCandidate` is true the current element is a
+ * boundary event being previewed in its host's mixed fan — Tab cycles
+ * within the fan instead of stepping along the boundary's own flows.
+ * A stale flag (host fan collapsed to ≤ 1) falls through to normal
+ * shape step as self-healing.
  */
-export function resolveStep(current: NavElement, direction: Direction): NavElement | null {
+export function resolveStep(
+    current: NavElement,
+    direction: Direction,
+    currentIsBoundaryCandidate = false,
+): StepResult | null {
     const el = normalize(current);
+
+    if (currentIsBoundaryCandidate && el.host) {
+        const hostCandidates = fanOutCandidates(el.host);
+        if (hostCandidates.length > 1) {
+            const next = cycleBy(hostCandidates, representative, el, direction);
+            return toStepResult(next);
+        }
+    }
 
     if (el.source != null && el.target != null) {
         return stepFromFlow(el, direction);
@@ -140,16 +201,32 @@ export function resolveStep(current: NavElement, direction: Direction): NavEleme
 }
 
 /**
- * Resolve the element for Enter / Shift+Enter on a sequence flow.
+ * Resolve the element for Enter / Shift+Enter.
  *
- * Enter jumps to the flow's target, Shift+Enter to its source.
- * Returns `null` for non-sequence-flow elements so the caller can
- * decide not to consume the key.
+ * On a sequence flow Enter jumps to the target, Shift+Enter to the
+ * source. On a boundary candidate Enter commits it (element stays
+ * selected, candidate state cleared). Returns `null` for non-flow
+ * non-candidate elements so the key bubbles to direct editing.
  */
-export function resolveFollow(current: NavElement, direction: Direction): NavElement | null {
+export function resolveFollow(
+    current: NavElement,
+    direction: Direction,
+    currentIsBoundaryCandidate = false,
+): StepResult | null {
     const el = normalize(current);
-    if (el.type !== "bpmn:SequenceFlow" || !el.source || !el.target) return null;
-    return direction === "forward" ? el.target : el.source;
+
+    if (el.type === "bpmn:SequenceFlow" && el.source && el.target) {
+        return {
+            element: direction === "forward" ? el.target : el.source,
+            boundaryCandidate: false,
+        };
+    }
+
+    if (currentIsBoundaryCandidate) {
+        return { element: el, boundaryCandidate: false };
+    }
+
+    return null;
 }
 
 /**

--- a/libs/flow-navigation/tsconfig.json
+++ b/libs/flow-navigation/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "skipLibCheck": true
+    },
+    "include": ["src/**/*.ts"]
+}

--- a/libs/flow-navigation/vitest.config.ts
+++ b/libs/flow-navigation/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        name: "flow-navigation",
+        environment: "node",
+        include: ["src/**/*.{spec,test}.ts"],
+    },
+});

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -11,3 +11,4 @@ export * from "./lib/propertiesPanelResizer";
 export * from "./lib/processVariables";
 export * from "./lib/variableManifest";
 export * from "./lib/bpmnFlowOrder";
+export * from "./lib/propertiesPanelFocus";

--- a/libs/shared/src/lib/propertiesPanelFocus.spec.ts
+++ b/libs/shared/src/lib/propertiesPanelFocus.spec.ts
@@ -1,0 +1,436 @@
+// @vitest-environment jsdom
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PropertiesPanelHandle } from "./propertiesPanelResizer";
+import {
+    focusPropertiesPanel,
+    installPanelShortcuts,
+    isTextEditingSurface,
+    togglePropertiesPanel,
+} from "./propertiesPanelFocus";
+import type { PanelFocusOptions } from "./propertiesPanelFocus";
+
+/** Runs the scheduled callback synchronously instead of via rAF. */
+const syncSchedule: PanelFocusOptions["schedule"] = (cb) => cb();
+
+function createHandle(visible = true): PropertiesPanelHandle & { setVisible: ReturnType<typeof vi.fn> } {
+    let state = visible;
+    const setVisible = vi.fn((v: boolean) => {
+        state = v;
+    });
+    return {
+        isVisible: () => state,
+        setVisible,
+        onVisibilityChanged: () => {},
+    };
+}
+
+function createPanel(...fieldTags: string[]): { panel: HTMLDivElement; opts: PanelFocusOptions } {
+    const panel = document.createElement("div");
+    panel.id = "js-properties-panel";
+
+    const scrollContainer = document.createElement("div");
+    scrollContainer.classList.add("bio-properties-panel-scroll-container");
+    panel.appendChild(scrollContainer);
+
+    for (const tag of fieldTags) {
+        const el = document.createElement(tag);
+        scrollContainer.appendChild(el);
+    }
+
+    document.body.appendChild(panel);
+    return { panel, opts: { getPanelRoot: () => panel, schedule: syncSchedule } };
+}
+
+function cleanupPanels(): void {
+    document.querySelectorAll("#js-properties-panel").forEach((el) => el.remove());
+}
+
+// ────────────────────────────────────────────────────────────────────
+// isTextEditingSurface
+// ────────────────────────────────────────────────────────────────────
+
+describe("isTextEditingSurface", () => {
+    it("returns true for <input>", () => {
+        expect(isTextEditingSurface(document.createElement("input"))).toBe(true);
+    });
+
+    it("returns true for <textarea>", () => {
+        expect(isTextEditingSurface(document.createElement("textarea"))).toBe(true);
+    });
+
+    it("returns true for contenteditable element", () => {
+        const div = document.createElement("div");
+        div.contentEditable = "true";
+        expect(isTextEditingSurface(div)).toBe(true);
+    });
+
+    it("returns false for a plain <div>", () => {
+        expect(isTextEditingSurface(document.createElement("div"))).toBe(false);
+    });
+
+    it("returns false for null", () => {
+        expect(isTextEditingSurface(null)).toBe(false);
+    });
+
+    it("returns false for contenteditable=inherit", () => {
+        const div = document.createElement("div");
+        div.contentEditable = "inherit";
+        expect(isTextEditingSurface(div)).toBe(false);
+    });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// focusPropertiesPanel
+// ────────────────────────────────────────────────────────────────────
+
+describe("focusPropertiesPanel", () => {
+    afterEach(cleanupPanels);
+
+    it("expands a collapsed panel and focuses the first field", () => {
+        const handle = createHandle(false);
+        const { opts } = createPanel("input", "select");
+
+        focusPropertiesPanel(handle, opts);
+
+        expect(handle.setVisible).toHaveBeenCalledWith(true);
+        expect(document.activeElement?.tagName).toBe("INPUT");
+    });
+
+    it("does not call setVisible when panel is already visible", () => {
+        const handle = createHandle(true);
+        const { opts } = createPanel("input");
+
+        focusPropertiesPanel(handle, opts);
+
+        expect(handle.setVisible).not.toHaveBeenCalled();
+        expect(document.activeElement?.tagName).toBe("INPUT");
+    });
+
+    it("skips disabled inputs", () => {
+        const handle = createHandle(true);
+        const { panel, opts } = createPanel();
+        const scrollContainer = panel.querySelector(".bio-properties-panel-scroll-container")!;
+
+        const disabled = document.createElement("input");
+        disabled.disabled = true;
+        scrollContainer.appendChild(disabled);
+
+        const enabled = document.createElement("input");
+        scrollContainer.appendChild(enabled);
+
+        focusPropertiesPanel(handle, opts);
+        expect(document.activeElement).toBe(enabled);
+    });
+
+    it("skips hidden inputs", () => {
+        const handle = createHandle(true);
+        const { panel, opts } = createPanel();
+        const scrollContainer = panel.querySelector(".bio-properties-panel-scroll-container")!;
+
+        const hidden = document.createElement("input");
+        hidden.type = "hidden";
+        scrollContainer.appendChild(hidden);
+
+        const text = document.createElement("input");
+        scrollContainer.appendChild(text);
+
+        focusPropertiesPanel(handle, opts);
+        expect(document.activeElement).toBe(text);
+    });
+
+    it("falls back to tabIndex=-1 on the scroll container when no focusable fields exist", () => {
+        const handle = createHandle(true);
+        const { panel, opts } = createPanel();
+        const scrollContainer = panel.querySelector(".bio-properties-panel-scroll-container")!;
+
+        focusPropertiesPanel(handle, opts);
+
+        expect((scrollContainer as HTMLElement).tabIndex).toBe(-1);
+        expect(document.activeElement).toBe(scrollContainer);
+    });
+
+    it("is a no-op when the panel root is missing", () => {
+        const handle = createHandle(true);
+        const opts: PanelFocusOptions = { getPanelRoot: () => null, schedule: syncSchedule };
+
+        focusPropertiesPanel(handle, opts);
+        expect(handle.setVisible).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when the panel is empty (childElementCount === 0)", () => {
+        const panel = document.createElement("div");
+        panel.id = "js-properties-panel";
+        document.body.appendChild(panel);
+
+        const handle = createHandle(false);
+        const opts: PanelFocusOptions = { getPanelRoot: () => panel, schedule: syncSchedule };
+
+        focusPropertiesPanel(handle, opts);
+        expect(handle.setVisible).not.toHaveBeenCalled();
+    });
+
+    it("focuses a button when only group-header buttons exist", () => {
+        const handle = createHandle(true);
+        const { opts } = createPanel("button");
+
+        focusPropertiesPanel(handle, opts);
+        expect(document.activeElement?.tagName).toBe("BUTTON");
+    });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// togglePropertiesPanel
+// ────────────────────────────────────────────────────────────────────
+
+describe("togglePropertiesPanel", () => {
+    afterEach(cleanupPanels);
+
+    it("collapses visible panel and calls focusCanvas when focus was inside", () => {
+        const handle = createHandle(true);
+        const focusCanvas = vi.fn();
+        const { panel, opts } = createPanel("input");
+
+        // Put focus inside the panel
+        const input = panel.querySelector("input")!;
+        input.focus();
+
+        togglePropertiesPanel(handle, focusCanvas, opts);
+
+        expect(handle.setVisible).toHaveBeenCalledWith(false);
+        expect(focusCanvas).toHaveBeenCalledTimes(1);
+    });
+
+    it("collapses visible panel without calling focusCanvas when focus is elsewhere", () => {
+        const handle = createHandle(true);
+        const focusCanvas = vi.fn();
+        const { opts } = createPanel("input");
+
+        // Focus is on the body, not inside the panel
+        (document.activeElement as HTMLElement)?.blur?.();
+
+        togglePropertiesPanel(handle, focusCanvas, opts);
+
+        expect(handle.setVisible).toHaveBeenCalledWith(false);
+        expect(focusCanvas).not.toHaveBeenCalled();
+    });
+
+    it("expands collapsed panel without moving focus", () => {
+        const handle = createHandle(false);
+        const focusCanvas = vi.fn();
+        const opts: PanelFocusOptions = { getPanelRoot: () => null, schedule: syncSchedule };
+
+        togglePropertiesPanel(handle, focusCanvas, opts);
+
+        expect(handle.setVisible).toHaveBeenCalledWith(true);
+        expect(focusCanvas).not.toHaveBeenCalled();
+    });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// installPanelShortcuts
+// ────────────────────────────────────────────────────────────────────
+
+describe("installPanelShortcuts", () => {
+    const focusCanvas = vi.fn();
+    const isCanvasFocused = vi.fn<() => boolean>();
+    const isEnabled = vi.fn<() => boolean>();
+
+    let handle: ReturnType<typeof createHandle>;
+    let opts: PanelFocusOptions;
+
+    function dispatchKeydown(
+        key: string,
+        modifiers: { shift?: boolean; ctrl?: boolean; meta?: boolean; alt?: boolean; defaultPrevented?: boolean } = {},
+    ): KeyboardEvent {
+        const event = new KeyboardEvent("keydown", {
+            key,
+            shiftKey: modifiers.shift ?? false,
+            ctrlKey: modifiers.ctrl ?? false,
+            metaKey: modifiers.meta ?? false,
+            altKey: modifiers.alt ?? false,
+            bubbles: true,
+            cancelable: true,
+        });
+        if (modifiers.defaultPrevented) event.preventDefault();
+        document.dispatchEvent(event);
+        return event;
+    }
+
+    beforeAll(() => {
+        handle = createHandle(true);
+        const panelSetup = createPanel("input", "select");
+        opts = panelSetup.opts;
+
+        installPanelShortcuts(
+            { handle, focusCanvas, isCanvasFocused, isEnabled },
+            opts,
+        );
+    });
+
+    beforeEach(() => {
+        focusCanvas.mockReset();
+        isCanvasFocused.mockReset();
+        isEnabled.mockReset();
+        handle.setVisible.mockClear();
+
+        isCanvasFocused.mockReturnValue(false);
+        isEnabled.mockReturnValue(true);
+        // Reset handle visibility to true
+        handle.setVisible(true);
+        handle.setVisible.mockClear();
+        // Move focus away from panel fields left focused by prior tests
+        (document.activeElement as HTMLElement)?.blur?.();
+    });
+
+    afterAll(cleanupPanels);
+
+    it("'p' focuses the panel when the canvas has focus", () => {
+        isCanvasFocused.mockReturnValue(true);
+        const event = dispatchKeydown("p");
+        expect(document.activeElement?.tagName).toBe("INPUT");
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("'p' is inert when the canvas does not have focus", () => {
+        isCanvasFocused.mockReturnValue(false);
+        const event = dispatchKeydown("p");
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("Shift+P toggles the panel from the canvas", () => {
+        isCanvasFocused.mockReturnValue(true);
+        const event = dispatchKeydown("P", { shift: true });
+        expect(handle.setVisible).toHaveBeenCalledWith(false);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("Shift+P toggles the panel from a non-text element inside the panel", () => {
+        // Focus a non-text element (e.g. a button)
+        const panel = document.getElementById("js-properties-panel")!;
+        const btn = document.createElement("button");
+        panel.appendChild(btn);
+        btn.focus();
+
+        const event = dispatchKeydown("P", { shift: true });
+        expect(handle.setVisible).toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(true);
+
+        btn.remove();
+    });
+
+    it("Shift+P is inert inside a text input", () => {
+        const input = document.createElement("input");
+        document.body.appendChild(input);
+        input.focus();
+
+        const event = dispatchKeydown("P", { shift: true });
+        expect(handle.setVisible).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+
+        input.remove();
+    });
+
+    it("Shift+P is inert inside a contenteditable", () => {
+        const div = document.createElement("div");
+        div.contentEditable = "true";
+        div.tabIndex = 0;
+        document.body.appendChild(div);
+        div.focus();
+
+        const event = dispatchKeydown("P", { shift: true });
+        expect(handle.setVisible).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+
+        div.remove();
+    });
+
+    it("Ctrl+P passes through (VS Code Quick Open)", () => {
+        isCanvasFocused.mockReturnValue(true);
+        const event = dispatchKeydown("p", { ctrl: true });
+        expect(handle.setVisible).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("Cmd+P passes through (macOS Quick Open)", () => {
+        isCanvasFocused.mockReturnValue(true);
+        const event = dispatchKeydown("p", { meta: true });
+        expect(handle.setVisible).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("Alt+P passes through", () => {
+        isCanvasFocused.mockReturnValue(true);
+        const event = dispatchKeydown("p", { alt: true });
+        expect(handle.setVisible).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("defaultPrevented events are ignored", () => {
+        isCanvasFocused.mockReturnValue(true);
+        const event = dispatchKeydown("p", { defaultPrevented: true });
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("all shortcuts are disabled when isEnabled returns false", () => {
+        isEnabled.mockReturnValue(false);
+        isCanvasFocused.mockReturnValue(true);
+
+        dispatchKeydown("p");
+        dispatchKeydown("P", { shift: true });
+
+        expect(handle.setVisible).not.toHaveBeenCalled();
+    });
+});
+
+describe("installPanelShortcuts (escapeToCanvas)", () => {
+    const focusCanvas = vi.fn();
+    const isCanvasFocused = vi.fn<() => boolean>();
+
+    let handle: ReturnType<typeof createHandle>;
+
+    beforeAll(() => {
+        handle = createHandle(true);
+
+        installPanelShortcuts(
+            { handle, focusCanvas, isCanvasFocused, escapeToCanvas: true },
+            { getPanelRoot: () => null, schedule: (cb) => cb() },
+        );
+    });
+
+    beforeEach(() => {
+        focusCanvas.mockReset();
+        isCanvasFocused.mockReset();
+    });
+
+    function dispatchKeydown(
+        key: string,
+        modifiers: { defaultPrevented?: boolean } = {},
+    ): void {
+        const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+        if (modifiers.defaultPrevented) event.preventDefault();
+        document.dispatchEvent(event);
+    }
+
+    it("Escape calls focusCanvas", () => {
+        dispatchKeydown("Escape");
+        expect(focusCanvas).toHaveBeenCalledTimes(1);
+    });
+
+    it("Escape is passive (does not call preventDefault)", () => {
+        const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+        document.dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("Escape is ignored when defaultPrevented", () => {
+        dispatchKeydown("Escape", { defaultPrevented: true });
+        // focusCanvas was called by the beforeAll listener plus the non-
+        // defaultPrevented tests; checking it was NOT called in *this* dispatch
+        // is checked by the count across the describe block.
+        expect(focusCanvas).not.toHaveBeenCalled();
+    });
+});
+
+// Import afterEach/afterAll for cleanup
+import { afterAll, afterEach } from "vitest";

--- a/libs/shared/src/lib/propertiesPanelFocus.ts
+++ b/libs/shared/src/lib/propertiesPanelFocus.ts
@@ -1,0 +1,146 @@
+import type { PropertiesPanelHandle } from "./propertiesPanelResizer";
+
+/**
+ * True when the element is a text-editing surface where single-character
+ * keystrokes must type rather than trigger shortcuts.
+ */
+export function isTextEditingSurface(el: Element | null): boolean {
+    if (el instanceof HTMLInputElement) return true;
+    if (el instanceof HTMLTextAreaElement) return true;
+    if (el instanceof HTMLElement && el.contentEditable === "true") return true;
+    return false;
+}
+
+export interface PanelFocusOptions {
+    /** Override the panel root lookup (default: `getElementById("js-properties-panel")`). */
+    getPanelRoot?: () => HTMLElement | null;
+    /**
+     * Scheduling primitive injected for testability.
+     * Default: `requestAnimationFrame`. Pass a synchronous thunk runner in specs.
+     */
+    schedule?: (cb: () => void) => void;
+}
+
+/**
+ * CSS selector matching focusable fields inside the properties panel.
+ * Buttons are included so an all-groups-collapsed panel can focus the
+ * first group-header toggle.
+ */
+const FOCUSABLE =
+    'input:not([disabled]):not([type="hidden"]), select:not([disabled]), ' +
+    'textarea:not([disabled]), [contenteditable="true"], button:not([disabled])';
+
+function getPanelRoot(opts?: PanelFocusOptions): HTMLElement | null {
+    return opts?.getPanelRoot
+        ? opts.getPanelRoot()
+        : document.getElementById("js-properties-panel");
+}
+
+function schedule(cb: () => void, opts?: PanelFocusOptions): void {
+    (opts?.schedule ?? requestAnimationFrame)(cb);
+}
+
+/**
+ * Focuses the first interactive field inside the properties panel,
+ * expanding it first when collapsed. One scheduling frame is inserted
+ * before focusing so the Preact commit that renders the panel contents
+ * after expand has settled — the same timing trick
+ * `WebviewStateManager.restorePanelUiState` uses.
+ */
+export function focusPropertiesPanel(
+    handle: PropertiesPanelHandle,
+    opts?: PanelFocusOptions,
+): void {
+    const panel = getPanelRoot(opts);
+    if (!panel || panel.childElementCount === 0) return;
+
+    if (!handle.isVisible()) {
+        handle.setVisible(true);
+    }
+
+    schedule(() => {
+        const scrollContainer =
+            panel.querySelector<HTMLElement>(".bio-properties-panel-scroll-container") ?? panel;
+        const candidates = scrollContainer.querySelectorAll<HTMLElement>(FOCUSABLE);
+
+        // Prefer the first *visible* candidate; fall back to the first one
+        // regardless (jsdom always reports offsetParent === null, so the
+        // fallback keeps specs deterministic).
+        const visible = Array.from(candidates).find((el) => el.offsetParent !== null);
+        const target = visible ?? candidates[0];
+
+        if (target) {
+            target.focus();
+        } else {
+            scrollContainer.tabIndex = -1;
+            scrollContainer.focus();
+        }
+    }, opts);
+}
+
+/**
+ * Toggles panel visibility. When collapsing with focus inside the panel,
+ * moves focus back to the canvas so it is not stranded in a zero-width
+ * container. Expanding does not move focus — `p` is the focus verb.
+ */
+export function togglePropertiesPanel(
+    handle: PropertiesPanelHandle,
+    focusCanvas: () => void,
+    opts?: PanelFocusOptions,
+): void {
+    if (handle.isVisible()) {
+        const panel = getPanelRoot(opts);
+        const hadFocusInside = panel?.contains(document.activeElement) ?? false;
+        handle.setVisible(false);
+        if (hadFocusInside) focusCanvas();
+    } else {
+        handle.setVisible(true);
+    }
+}
+
+export interface PanelShortcutDeps {
+    handle: PropertiesPanelHandle;
+    focusCanvas: () => void;
+    isCanvasFocused: () => boolean;
+    /** DMN: false outside DRD view — disables all three shortcuts. */
+    isEnabled?: () => boolean;
+    /** When true, Escape inside the panel moves focus to the canvas (DMN only). */
+    escapeToCanvas?: boolean;
+}
+
+/**
+ * Installs a document-level bubble-phase `keydown` listener that wires
+ * `p` (focus panel), `Shift+P` (toggle panel), and optionally Escape
+ * (return to canvas). The same handler serves both BPMN and DMN; host-
+ * specific gating is injected via {@link PanelShortcutDeps}.
+ */
+export function installPanelShortcuts(
+    deps: PanelShortcutDeps,
+    opts?: PanelFocusOptions,
+): void {
+    document.addEventListener("keydown", (e: KeyboardEvent) => {
+        if (deps.isEnabled && !deps.isEnabled()) return;
+
+        if (e.key === "Escape" && deps.escapeToCanvas) {
+            if (e.defaultPrevented) return;
+            deps.focusCanvas();
+            return;
+        }
+
+        if (e.defaultPrevented) return;
+        if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+        if (e.shiftKey && e.key === "P") {
+            if (isTextEditingSurface(document.activeElement)) return;
+            togglePropertiesPanel(deps.handle, deps.focusCanvas, opts);
+            e.preventDefault();
+            return;
+        }
+
+        if (!e.shiftKey && e.key === "p") {
+            if (!deps.isCanvasFocused()) return;
+            focusPropertiesPanel(deps.handle, opts);
+            e.preventDefault();
+        }
+    });
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,9 @@
             "@miragon/bpmn-modeler-append-menu": ["./libs/append-menu/src/index.ts"],
             "@miragon/bpmn-model-navigation": ["./libs/model-navigation/src/index.ts"],
             "@miragon/bpmn-modeler-code-link": ["./libs/code-link/src/index.ts"],
+            "@miragon/bpmn-modeler-flow-navigation": [
+                "./libs/flow-navigation/src/index.ts"
+            ],
             "@miragon/bpmn-modeler-webview": ["./apps/bpmn-webview/src/index.ts"],
             "@miragon/dmn-modeler-webview": ["./apps/dmn-webview/src/index.ts"]
         }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
             "libs/element-template-chooser",
             "libs/modeler-core",
             "libs/shared",
+            "libs/flow-navigation",
+            "libs/model-navigation",
         ],
         coverage: {
             provider: "v8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3718,6 +3718,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@miragon/bpmn-modeler-flow-navigation@workspace:*, @miragon/bpmn-modeler-flow-navigation@workspace:libs/flow-navigation":
+  version: 0.0.0-use.local
+  resolution: "@miragon/bpmn-modeler-flow-navigation@workspace:libs/flow-navigation"
+  dependencies:
+    typescript: "npm:6.0.3"
+    vitest: "npm:4.1.9"
+  peerDependencies:
+    bpmn-js: 18.19.0
+  languageName: unknown
+  linkType: soft
+
 "@miragon/bpmn-modeler-i18n-extras@workspace:*, @miragon/bpmn-modeler-i18n-extras@workspace:libs/bpmn-i18n-extras":
   version: 0.0.0-use.local
   resolution: "@miragon/bpmn-modeler-i18n-extras@workspace:libs/bpmn-i18n-extras"
@@ -3819,6 +3830,7 @@ __metadata:
     "@miragon/bpmn-modeler-clipboard": "workspace:*"
     "@miragon/bpmn-modeler-code-link": "workspace:*"
     "@miragon/bpmn-modeler-element-template-chooser": "workspace:*"
+    "@miragon/bpmn-modeler-flow-navigation": "workspace:*"
     "@miragon/bpmn-modeler-i18n": "npm:0.2.0"
     "@miragon/bpmn-modeler-i18n-extras": "workspace:*"
     "@miragon/bpmn-modeler-shared": "workspace:*"


### PR DESCRIPTION
**Issue**

Keyboard-first modeling with the append menu (`a`) has no way to move the selection back to a gateway to append another branch.

**Description**

Adds a new `libs/flow-navigation` bpmn-js module (registered for both C7 and C8 modelers) that moves the selection along sequence flows: Tab / Shift+Tab step shape-to-shape, at a fan-out Tab cycles the outgoing sequence flows (ordered top-to-bottom, wrapping), and Enter / Shift+Enter follow the selected flow to its target / source. The traversal logic is a pure, DOM-free module with 38 Vitest specs covering fan cycling, labels, boundary events, and message-flow filtering; the keyboard binding lives on the canvas SVG only, so Tab in the properties panel and Ctrl/Cmd+Tab keep their native behavior. Wiring touches `tsconfig.base.json`, `apps/bpmn-webview`, and the root `vitest.config.ts` — where the previously missing `libs/model-navigation` project is also added as a drive-by fix so its specs run under root `yarn test`. A new feature doc (`docs/vscode/features/flow-navigation.md`) is linked from the features index and cross-linked from the append-menu doc.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
