### PR TITLE
refactor(bpmn-webview): replace vsCodeBridge with per-feature capability ports

### DIFF
--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LintConfigService } from "./LintConfigService";
 
+/** The narrow host port; these render tests never reach its off/enable clicks. */
+const lintingHost = { setLintingEnabled: vi.fn() };
+
 /** Minimal stand-in for the bpmn-js-bpmnlint `linting` DI service. */
 function fakeLinting() {
     return {
@@ -25,7 +28,7 @@ beforeEach(() => {
 describe("LintConfigService.render", () => {
     it("overrides linting.lint to return the host-provided results", async () => {
         const linting = fakeLinting();
-        const svc = new LintConfigService(linting);
+        const svc = new LintConfigService(linting, lintingHost, (s) => s);
 
         const results = { "label-required": [{ id: "Task_1", message: "x", category: "warn" }] };
         svc.render(results);
@@ -37,7 +40,7 @@ describe("LintConfigService.render", () => {
     it("activates linting and reveals the button when results arrive", () => {
         const linting = fakeLinting();
 
-        new LintConfigService(linting).render({});
+        new LintConfigService(linting, lintingHost, (s) => s).render({});
 
         expect(linting.isActive()).toBe(true);
         expect(document.body.classList.contains("bpmnlint-active")).toBe(true);
@@ -46,7 +49,7 @@ describe("LintConfigService.render", () => {
     it("re-renders via update() when already active", () => {
         const linting = fakeLinting();
         linting.active = true;
-        const svc = new LintConfigService(linting);
+        const svc = new LintConfigService(linting, lintingHost, (s) => s);
 
         svc.render({});
 
@@ -59,7 +62,7 @@ describe("LintConfigService.render", () => {
         linting.active = true;
         document.body.classList.add("bpmnlint-active");
 
-        new LintConfigService(linting).render(null);
+        new LintConfigService(linting, lintingHost, (s) => s).render(null);
 
         expect(linting.toggle).toHaveBeenCalledWith(false);
         expect(document.body.classList.contains("bpmnlint-active")).toBe(false);
@@ -68,7 +71,7 @@ describe("LintConfigService.render", () => {
     it("does not toggle when already inactive and results are null", () => {
         const linting = fakeLinting();
 
-        new LintConfigService(linting).render(null);
+        new LintConfigService(linting, lintingHost, (s) => s).render(null);
 
         expect(linting.toggle).not.toHaveBeenCalled();
     });

--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
@@ -1,4 +1,4 @@
-import { LintResults, SetLintingEnabledCommand } from "@miragon/bpmn-modeler-shared";
+import { LintResults } from "@miragon/bpmn-modeler-shared";
 
 /**
  * The subset of `bpmn-js-bpmnlint`'s `linting` module this service drives. The
@@ -13,9 +13,13 @@ interface Linting {
     toggle(active: boolean): void;
 }
 
-/** The webview→host channel registered as the `vsCodeBridge` DI value in bootstrap. */
-interface VsCodeBridge {
-    postMessage(message: unknown): void;
+/**
+ * The single host capability this service needs, registered as the `lintingHost`
+ * DI value in bootstrap. Narrow on purpose so the service never touches the
+ * postMessage protocol — bootstrap translates the call into the host command.
+ */
+interface LintingHost {
+    setLintingEnabled(enabled: boolean): void;
 }
 
 type Translate = (template: string) => string;
@@ -45,7 +49,7 @@ const OFF_ICON = `<svg viewBox="0 0 16 16" width="13" height="13" fill="none" st
  * its own overlays optimistically.
  */
 export class LintConfigService {
-    static $inject = ["linting", "vsCodeBridge", "translate"];
+    static $inject = ["linting", "lintingHost", "translate"];
 
     private results: LintResults = {};
 
@@ -57,7 +61,7 @@ export class LintConfigService {
 
     constructor(
         private readonly linting: Linting,
-        private readonly bridge: VsCodeBridge,
+        private readonly lintingHost: LintingHost,
         private readonly translate: Translate,
     ) {
         // Replace the browser-side lint run with the host's precomputed results.
@@ -155,7 +159,7 @@ export class LintConfigService {
             button.title = label;
             button.setAttribute("aria-label", label);
             button.addEventListener("click", () => {
-                this.bridge.postMessage(new SetLintingEnabledCommand(false));
+                this.lintingHost.setLintingEnabled(false);
             });
             this.offButton = button;
         }
@@ -193,7 +197,7 @@ export class LintConfigService {
             enable.className = "lint-enable-button";
             enable.textContent = this.translate("Enable");
             enable.addEventListener("click", () => {
-                this.bridge.postMessage(new SetLintingEnabledCommand(true));
+                this.lintingHost.setLintingEnabled(true);
             });
 
             chip.appendChild(text);

--- a/apps/bpmn-webview/src/app/capabilities.ts
+++ b/apps/bpmn-webview/src/app/capabilities.ts
@@ -1,0 +1,19 @@
+import type { ModelNavigationPort } from "@miragon/bpmn-model-navigation";
+import type { CodeLinkPort } from "@miragon/bpmn-modeler-code-link";
+import type { InlineScriptingPort } from "@miragon/bpmn-modeler-inline-scripting";
+
+/**
+ * The optional per-feature host capabilities a consumer wires into the modeler.
+ * Each port is the browser-side mirror of a host-capability port: present ⇒ the
+ * feature's DI module is registered and its UI appears; absent ⇒ the feature is
+ * off and its context-pad entries / lock UI never render (so a host-less
+ * consumer no longer gets dead buttons).
+ *
+ * The bpmn-webview supplies a full protocol adapter by default, so every real
+ * host (VS Code, IntelliJ, Theia) keeps all three features unchanged.
+ */
+export interface ModelerCapabilities {
+    modelNavigation?: ModelNavigationPort;
+    codeLink?: CodeLinkPort;
+    scripting?: InlineScriptingPort;
+}

--- a/apps/bpmn-webview/src/app/capabilityModules.spec.ts
+++ b/apps/bpmn-webview/src/app/capabilityModules.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { capabilityModules } from "./capabilityModules";
+
+/** A didi bundle: string keys → either `["type", Ctor]` or `["value", obj]`. */
+type Bundle = Record<string, unknown>;
+
+/** Names of the `["value", …]` entries in a bundle — i.e. its DI value tokens. */
+function valueTokens(bundle: Bundle): string[] {
+    return Object.entries(bundle)
+        .filter(([, spec]) => Array.isArray(spec) && spec[0] === "value")
+        .map(([token]) => token);
+}
+
+/** The bundle in `modules` that registers `token` as a value, if any. */
+function bundleWithValue(modules: Bundle[], token: string): Bundle | undefined {
+    return modules.find((bundle) => valueTokens(bundle).includes(token));
+}
+
+const navPort = { openReference: () => {} };
+const codeLinkPort = { navigateToImplementation: () => {}, syncActivities: () => {} };
+const scriptingPort = { openScriptEditor: () => {}, scriptSourceChanged: () => {} };
+
+describe("capabilityModules", () => {
+    it("registers nothing when no capabilities are given", () => {
+        expect(capabilityModules("c7")).toEqual([]);
+        expect(capabilityModules("c7", {})).toEqual([]);
+        expect(capabilityModules("c8", {})).toEqual([]);
+    });
+
+    it("registers only model navigation, carrying the port under modelNavigationPort", () => {
+        const modules = capabilityModules("c7", { modelNavigation: navPort }) as Bundle[];
+
+        expect(modules).toHaveLength(1);
+        // The provider injects "modelNavigationPort" (verified in the lib's own
+        // spec); the factory must embed the port under that exact token or DI
+        // would fail at runtime, so pin the stringly-typed name here.
+        expect(modules[0].modelNavigationPort).toEqual(["value", navPort]);
+        expect(modules[0].navigateContextPadProvider).toBeDefined();
+    });
+
+    it("registers only code link, carrying the port under codeLinkPort", () => {
+        const modules = capabilityModules("c8", { codeLink: codeLinkPort }) as Bundle[];
+
+        expect(modules).toHaveLength(1);
+        expect(modules[0].codeLinkPort).toEqual(["value", codeLinkPort]);
+        // Client-first init order (the client subscribes before the provider reads it).
+        expect(modules[0].__init__).toEqual(["codeLinkMapClient", "codeLinkContextPadProvider"]);
+    });
+
+    it("registers scripting on c7, carrying the port under inlineScriptingPort", () => {
+        const modules = capabilityModules("c7", { scripting: scriptingPort }) as Bundle[];
+
+        const portBundle = bundleWithValue(modules, "inlineScriptingPort");
+        expect(portBundle).toBeDefined();
+        expect(portBundle!.inlineScriptingPort).toEqual(["value", scriptingPort]);
+        expect(portBundle!.inlineScriptingPortForwarder).toBeDefined();
+    });
+
+    it("does NOT register scripting on c8 even when the port is present", () => {
+        const modules = capabilityModules("c8", { scripting: scriptingPort }) as Bundle[];
+
+        expect(bundleWithValue(modules, "inlineScriptingPort")).toBeUndefined();
+        expect(modules).toEqual([]);
+    });
+
+    it("registers every present capability together", () => {
+        const modules = capabilityModules("c7", {
+            modelNavigation: navPort,
+            codeLink: codeLinkPort,
+            scripting: scriptingPort,
+        }) as Bundle[];
+
+        expect(bundleWithValue(modules, "modelNavigationPort")).toBeDefined();
+        expect(bundleWithValue(modules, "codeLinkPort")).toBeDefined();
+        expect(bundleWithValue(modules, "inlineScriptingPort")).toBeDefined();
+    });
+});

--- a/apps/bpmn-webview/src/app/capabilityModules.ts
+++ b/apps/bpmn-webview/src/app/capabilityModules.ts
@@ -1,0 +1,29 @@
+import { createModelNavigationModule } from "@miragon/bpmn-model-navigation";
+import { createCodeLinkModule } from "@miragon/bpmn-modeler-code-link";
+import { createInlineScriptingModules } from "@miragon/bpmn-modeler-inline-scripting";
+import type { Engine } from "@miragon/bpmn-modeler-shared";
+import type { ModelerCapabilities } from "./capabilities";
+
+/**
+ * Builds the DI modules for the capability-gated features. A capability that is
+ * absent contributes no module, so its providers are never registered and its
+ * UI cannot appear — the browser-side mirror of the host-capability-port
+ * pattern. Scripting is additionally C7-only (the C8 modeler leaves it
+ * unregistered), so its port alone is not enough on C8.
+ *
+ * Split out of {@link BpmnModeler} so the gating is unit-testable without
+ * dragging in camunda-bpmn-js.
+ */
+export function capabilityModules(engine: Engine, capabilities?: ModelerCapabilities): any[] {
+    const modules: any[] = [];
+    if (capabilities?.modelNavigation) {
+        modules.push(createModelNavigationModule(capabilities.modelNavigation));
+    }
+    if (capabilities?.codeLink) {
+        modules.push(createCodeLinkModule(capabilities.codeLink));
+    }
+    if (engine === "c7" && capabilities?.scripting) {
+        modules.push(...createInlineScriptingModules(capabilities.scripting));
+    }
+    return modules;
+}

--- a/apps/bpmn-webview/src/app/host.ts
+++ b/apps/bpmn-webview/src/app/host.ts
@@ -240,6 +240,34 @@ class MockHost extends MockHostApi<StateType, MessageType> {
                 console.debug("[DEBUG] SetLintingEnabledCommand", message);
                 break;
             }
+            // Capability-port commands. Dev keeps all capabilities so every
+            // feature's UI stays testable; there is no real host to act on them,
+            // so log-only cases replace the default throw that used to crash the
+            // first SyncActivitiesCommand on load.
+            case message.type === "NavigateToReferencedModelCommand": {
+                console.debug("[DEBUG] NavigateToReferencedModelCommand", message);
+                break;
+            }
+            case message.type === "NavigateToImplementationCommand": {
+                console.debug("[DEBUG] NavigateToImplementationCommand", message);
+                break;
+            }
+            case message.type === "SyncActivitiesCommand": {
+                console.debug("[DEBUG] SyncActivitiesCommand", message);
+                break;
+            }
+            case message.type === "OpenScriptEditorCommand": {
+                console.debug("[DEBUG] OpenScriptEditorCommand", message);
+                break;
+            }
+            case message.type === "UpdateScriptSourceCommand": {
+                console.debug("[DEBUG] UpdateScriptSourceCommand", message);
+                break;
+            }
+            case message.type === "UpdateScriptVariablesCommand": {
+                console.debug("[DEBUG] UpdateScriptVariablesCommand", message);
+                break;
+            }
             default: {
                 throw new Error(`Unknown message type: ${(message as MessageType).type}`);
             }

--- a/apps/bpmn-webview/src/app/index.ts
+++ b/apps/bpmn-webview/src/app/index.ts
@@ -1,4 +1,5 @@
 export * from "./modeler";
+export * from "./capabilities";
 export * from "./viewport";
 export * from "./selection";
 export * from "./rootElement";

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -7,8 +7,7 @@ import { ElementTemplateChooserModule } from "@miragon/bpmn-modeler-element-temp
 import TransactionBoundariesModule from "camunda-transaction-boundaries";
 import { CreateAppendElementTemplatesModule } from "bpmn-js-create-append-anything";
 import { AppendMenuModule } from "@miragon/bpmn-modeler-append-menu";
-import { NavigateToReferencedModelModule } from "@miragon/bpmn-model-navigation";
-import { CodeLinkModule, type CodeLinkMapClient } from "@miragon/bpmn-modeler-code-link";
+import { type CodeLinkMapClient } from "@miragon/bpmn-modeler-code-link";
 import { FlowNavigationModule } from "@miragon/bpmn-modeler-flow-navigation";
 import { CreateAppendC7ElementTemplatesModule } from "@miragon/create-append-c7";
 import {
@@ -22,14 +21,11 @@ import {
 import {
     collectInlineScriptTasks,
     findListenerAt,
-    InlineScriptingModules,
-    OPEN_SCRIPT_EDITOR_EVENT,
-    type OpenScriptEditorEvent,
     OpenScriptEditorsStore,
-    SCRIPT_SOURCE_CHANGED_EVENT,
-    type ScriptSourceChangedEvent,
     ScriptSourceWatcher,
 } from "@miragon/bpmn-modeler-inline-scripting";
+import type { ModelerCapabilities } from "./capabilities";
+import { capabilityModules } from "./capabilityModules";
 import { ViewportManager } from "./viewport";
 import { SelectionManager } from "./selection";
 import { RootElementManager } from "./rootElement";
@@ -127,18 +123,19 @@ export class BpmnModeler {
      * @param engine Camunda engine version — `"c7"` for Camunda Platform 7,
      *   `"c8"` for Camunda Cloud 8.
      * @param extraModules Optional bpmn-js DI modules (e.g. clipboard bridges).
+     * @param capabilities Optional per-feature host ports; each present port
+     *   registers its feature's DI module (see {@link capabilityModules}).
      * @throws {UnsupportedEngineError} If the engine string is not recognised.
      */
-    create(engine: Engine, extraModules?: any[]): void {
+    create(engine: Engine, extraModules?: any[], capabilities?: ModelerCapabilities): void {
         const commonModules = [
             TokenSimulationModule,
             LintModule,
             ElementTemplateChooserModule,
             AppendMenuModule,
-            NavigateToReferencedModelModule,
-            CodeLinkModule,
             FlowNavigationModule,
         ];
+        const capModules = capabilityModules(engine, capabilities);
         const extra = extraModules ?? [];
 
         this.engine = engine;
@@ -152,7 +149,7 @@ export class BpmnModeler {
                         CreateAppendElementTemplatesModule,
                         CreateAppendC7ElementTemplatesModule,
                         TransactionBoundariesModule,
-                        ...InlineScriptingModules,
+                        ...capModules,
                         ...extra,
                     ],
                 });
@@ -161,7 +158,7 @@ export class BpmnModeler {
             case "c8": {
                 this.modeler = new BpmnModeler8({
                     ...MODELER_OPTIONS,
-                    additionalModules: [...commonModules, ...extra],
+                    additionalModules: [...commonModules, ...capModules, ...extra],
                 });
                 break;
             }
@@ -497,39 +494,6 @@ export class BpmnModeler {
     }
 
     /**
-     * Registers a callback for the unified `scriptEditor.open` event.
-     *
-     * Four sources fire it: the canvas context pad on script tasks
-     * ({@link ScriptTaskContextPadModule}), the Script-group header icon
-     * on the properties panel for script tasks, the per-listener icon
-     * on each script-typed listener row (both via
-     * {@link ScriptEditorButtonsModule}), and the `o` keyboard shortcut
-     * ({@link ScriptEditorKeyboardModule}).
-     */
-    onOpenScriptEditor(callback: (data: OpenScriptEditorEvent) => void): void {
-        this.getModeler()
-            .get<any>("eventBus")
-            .on(OPEN_SCRIPT_EDITOR_EVENT, (event: OpenScriptEditorEvent) => {
-                callback(event);
-            });
-    }
-
-    /**
-     * Registers a callback for the {@link ScriptSourceWatcher}'s divergence
-     * event, fired when an open script's model content changed underneath its
-     * editor tab (canvas undo/redo, document reload, element deletion). The
-     * entry point forwards it to the host, which overwrites — or, for a
-     * deleted element, closes — the tab.
-     */
-    onScriptSourceChanged(callback: (data: ScriptSourceChangedEvent) => void): void {
-        this.getModeler()
-            .get<any>("eventBus")
-            .on(SCRIPT_SOURCE_CHANGED_EVENT, (event: ScriptSourceChangedEvent) => {
-                callback(event);
-            });
-    }
-
-    /**
      * Registers a sink for non-fatal warnings so the host can forward them to the
      * output channel. Without it these only reached the webview console, invisible
      * in a bug report.
@@ -544,10 +508,14 @@ export class BpmnModeler {
      * "Go to implementation" entry hides for tasks whose implementation does not
      * exist in the workspace.
      *
+     * The service is resolved defensively (`get(..., false)`): a consumer that
+     * omits the codeLink capability registers no `codeLinkMapClient`, and a
+     * stray status push must then be a no-op rather than throw.
+     *
      * @throws {NoModelerError} If the modeler has not been created yet.
      */
     applyImplementationStatus(resolved: Record<string, boolean>): void {
-        this.getService<CodeLinkMapClient>("codeLinkMapClient").applyStatus(resolved);
+        this.getModeler().get<CodeLinkMapClient>("codeLinkMapClient", false)?.applyStatus(resolved);
     }
 
     /**

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -27,14 +27,18 @@ import {
     LanguageQuery,
     LogErrorCommand,
     LogWarningCommand,
+    NavigateToImplementationCommand,
+    NavigateToReferencedModelCommand,
     NoModelerError,
     OpenScriptEditorCommand,
     OpenScriptEditorsCommand,
     PropertiesPanelStateQuery,
     Query,
     SetClipboardCommand,
+    SetLintingEnabledCommand,
     SetPropertiesPanelStateCommand,
     SetTextClipboardCommand,
+    SyncActivitiesCommand,
     SyncDocumentCommand,
     TextClipboardQuery,
     UpdateOpenScriptEditorsQuery,
@@ -63,6 +67,7 @@ import {
     UnsupportedEngineError,
 } from "./app";
 import type { HostApi, ResizableCanvas } from "@miragon/bpmn-modeler-shared";
+import type { ModelerCapabilities } from "./app/capabilities";
 import type { WebviewState } from "./app/webviewState";
 import { DiffMode } from "./app/diff/DiffMode";
 import type { LintConfigService } from "./app/bpmnlint";
@@ -72,6 +77,9 @@ import { WebviewStateManager } from "./app/state";
 // Injected by bootstrap(); the app/demo entry chooses the concrete host.
 let host: HostApi<WebviewState, Command | Query>;
 let injectedModules: unknown[] | undefined;
+// Injected capabilities, or undefined ⇒ the full protocol adapter is used, so
+// every real host (VS Code, IntelliJ, Theia) keeps all features unchanged.
+let injectedCapabilities: ModelerCapabilities | undefined;
 
 // Global safety net for throws the per-message try/catch in onReceiveMessage
 // can't reach — bpmn-js event-bus callbacks (e.g. onCommandStackChanged) run
@@ -190,6 +198,54 @@ const panelStateResolver = createResolver<PropertiesPanelStateQuery>();
 let stateManager: WebviewStateManager;
 
 /**
+ * The default capability adapter: each port posts the existing protocol command
+ * to the host. Used whenever `bootstrap()` is called without explicit
+ * capabilities, so VS Code / IntelliJ / Theia are unaffected by the port
+ * indirection. Closes over the module-level {@link host} and {@link bpmnModeler}.
+ *
+ * `scripting` is always populated here even though its DI cluster is C7-only;
+ * `capabilityModules` gates the registration, so the surplus port on C8 is inert.
+ */
+function createProtocolCapabilities(): ModelerCapabilities {
+    return {
+        modelNavigation: {
+            openReference: ({ id, kind }) =>
+                host.postMessage(new NavigateToReferencedModelCommand(id, kind)),
+        },
+        codeLink: {
+            navigateToImplementation: (reference, kind) =>
+                host.postMessage(new NavigateToImplementationCommand(reference, kind)),
+            syncActivities: (entries) => host.postMessage(new SyncActivitiesCommand(entries)),
+        },
+        scripting: {
+            // The process-variable model is re-extracted per open so completion
+            // reflects the diagram at the moment the tab opens.
+            openScriptEditor: (event) =>
+                host.postMessage(
+                    new OpenScriptEditorCommand(
+                        event.elementId,
+                        event.kind,
+                        event.listenerIndex,
+                        event.eventName,
+                        event.scriptFormat,
+                        event.content,
+                        extractProcessVariables(bpmnModeler.getDefinitions()),
+                    ),
+                ),
+            scriptSourceChanged: (event) =>
+                host.postMessage(
+                    new UpdateScriptSourceCommand(
+                        event.elementId,
+                        event.kind,
+                        event.listenerIndex,
+                        event.content,
+                    ),
+                ),
+        },
+    };
+}
+
+/**
  * Entry point executed once the webview DOM is fully loaded.
  *
  * Registers the message listener first so no backend messages are missed,
@@ -304,16 +360,32 @@ async function run(): Promise<void> {
             ) + " (Shift+P)",
         onLabelChange: (apply) => i18n.onChange(apply),
     });
-    const vsCodeBridgeModule = {
-        vsCodeBridge: ["value", { postMessage: (m: unknown) => host.postMessage(m as never) }],
+    // The linting toggle is a webview-internal service (always registered via
+    // LintModule), so its host port is wired unconditionally — never gated on a
+    // capability. A missing `lintingHost` value would break LintConfigService's
+    // DI at construction.
+    const lintingHostModule = {
+        lintingHost: [
+            "value",
+            {
+                setLintingEnabled: (enabled: boolean) =>
+                    host.postMessage(new SetLintingEnabledCommand(enabled)),
+            },
+        ],
     };
+    const capabilities = injectedCapabilities ?? createProtocolCapabilities();
     const extraModules = [
         TranslateModule,
-        vsCodeBridgeModule,
+        lintingHostModule,
         ...(clipboardModules ?? []),
         ...((injectedModules as any[]) ?? []),
     ];
-    await initializeModeler(bpmnFileQuery?.content, bpmnFileQuery?.engine, extraModules);
+    await initializeModeler(
+        bpmnFileQuery?.content,
+        bpmnFileQuery?.engine,
+        extraModules,
+        capabilities,
+    );
     modelerIsInitialized = true;
 
     if (pendingFocusId !== undefined) {
@@ -321,41 +393,13 @@ async function run(): Promise<void> {
         pendingFocusId = undefined;
     }
 
-    /**
-     * Bridge "Edit Script" / "Open in Editor" triggers (script-task context
-     * pad + listener properties-panel buttons) into a host command so the
-     * extension can open the inline script in a virtual VS Code editor.
-     * Listeners are wired only on C7; C8 is intentionally out of scope.
-     */
-    if (bpmnFileQuery?.engine === "c7") {
-        bpmnModeler.onOpenScriptEditor((data) => {
-            host.postMessage(
-                new OpenScriptEditorCommand(
-                    data.elementId,
-                    data.kind,
-                    data.listenerIndex,
-                    data.eventName,
-                    data.scriptFormat,
-                    data.content,
-                    extractProcessVariables(bpmnModeler.getDefinitions()),
-                ),
-            );
-        });
-
-        // Model-side script changes (canvas undo/redo, document reload,
-        // element deletion) must reach the host so it can overwrite — or
-        // close — the owning editor tab; see ScriptSourceWatcher.
-        bpmnModeler.onScriptSourceChanged((data) => {
-            host.postMessage(
-                new UpdateScriptSourceCommand(
-                    data.elementId,
-                    data.kind,
-                    data.listenerIndex,
-                    data.content,
-                ),
-            );
-        });
-
+    // The "Edit Script" / divergence bridge now lives entirely in the scripting
+    // capability port (InlineScriptingPortForwarder → createProtocolCapabilities),
+    // registered by capabilityModules on C7. Only the process-variable publisher
+    // stays here because it drives the host from a commandStack subscription
+    // rather than a lib-owned event. It belongs to the scripting capability, so
+    // gate it on both the engine and the port being present.
+    if (bpmnFileQuery?.engine === "c7" && capabilities.scripting) {
         // Publish the process-variable model to the host so open script editors
         // get live variable completion. The chain is a feedback loop, not an echo
         // loop — a keystroke in a script edits the moddle, which fires
@@ -450,11 +494,13 @@ async function run(): Promise<void> {
  * @param bpmn Initial BPMN XML, or `undefined` to create a blank diagram.
  * @param engine Execution platform identifier (`"c7"` or `"c8"`).
  * @param extraModules Optional bpmn-js DI modules (e.g. clipboard bridges).
+ * @param capabilities Per-feature host ports gating the capability modules.
  */
 async function initializeModeler(
     bpmn: string | undefined,
     engine: Engine | undefined,
     extraModules?: any[],
+    capabilities?: ModelerCapabilities,
 ): Promise<void> {
     if (!engine) {
         host.postMessage(new LogErrorCommand("ExecutionPlatformVersion undefined!"));
@@ -462,7 +508,7 @@ async function initializeModeler(
     }
 
     try {
-        bpmnModeler.create(engine, extraModules);
+        bpmnModeler.create(engine, extraModules, capabilities);
         // Lets the IntelliJ JCEF host drive undo/redo: it swallows Ctrl+Z/Ctrl+Y
         // at the IDE level before bpmn-js sees them (works fine in VS Code/Theia).
         installHostEditorActions((action) =>
@@ -786,14 +832,18 @@ async function refreshDiagram(): Promise<void> {
 
 /**
  * Starts the BPMN webview against the given host. The entry (real or demo)
- * chooses the host and any host-specific bpmn-js modules.
+ * chooses the host, any host-specific bpmn-js modules, and — optionally — the
+ * per-feature {@link ModelerCapabilities}. Omitting `capabilities` selects the
+ * full protocol adapter, so every real host keeps all features; passing a
+ * partial object turns off the features whose ports it omits.
  */
 export function bootstrap(
     injectedHost: HostApi<WebviewState, Command | Query>,
-    opts: { extraModules?: unknown[] } = {},
+    opts: { extraModules?: unknown[]; capabilities?: ModelerCapabilities } = {},
 ): void {
     host = injectedHost;
     injectedModules = opts.extraModules;
+    injectedCapabilities = opts.capabilities;
     registerGlobalErrorHandlers();
     if (document.readyState === "complete") {
         void run();

--- a/apps/bpmn-webview/src/index.ts
+++ b/apps/bpmn-webview/src/index.ts
@@ -1,2 +1,3 @@
 export { bootstrap } from "./bootstrap";
 export type { WebviewState, ViewportData } from "./app/webviewState";
+export type { ModelerCapabilities } from "./app/capabilities";

--- a/apps/bpmn-webview/vitest.config.ts
+++ b/apps/bpmn-webview/vitest.config.ts
@@ -8,6 +8,21 @@ export default defineConfig({
         include: ["src/**/*.{spec,test}.ts"],
         alias: {
             "@miragon/bpmn-modeler-shared": resolve(__dirname, "../../libs/shared/src/index.ts"),
+            // These workspace libs have no package entry point, so specs that
+            // import them by name (e.g. capabilityModules.spec) need the path
+            // mapped explicitly — the build/dev use vite-tsconfig-paths instead.
+            "@miragon/bpmn-model-navigation": resolve(
+                __dirname,
+                "../../libs/model-navigation/src/index.ts",
+            ),
+            "@miragon/bpmn-modeler-code-link": resolve(
+                __dirname,
+                "../../libs/code-link/src/index.ts",
+            ),
+            "@miragon/bpmn-modeler-inline-scripting": resolve(
+                __dirname,
+                "../../libs/inline-scripting/src/index.ts",
+            ),
         },
         coverage: {
             provider: "v8",

--- a/apps/demo-webapp/bpmn/demoHost.ts
+++ b/apps/demo-webapp/bpmn/demoHost.ts
@@ -6,11 +6,10 @@ import {
     Command,
     ElementTemplatesQuery,
     MockHostApi,
-    NavigateToReferencedModelCommand,
     PropertiesPanelStateQuery,
     Query,
 } from "@miragon/bpmn-modeler-shared";
-import { getActiveModel, modelHref, resolveReference } from "../src";
+import { getActiveModel } from "../src";
 import type { WebviewState } from "@miragon/bpmn-modeler-webview";
 
 type MessageType = Command | Query;
@@ -20,11 +19,11 @@ function dispatch(event: MessageType): void {
 }
 
 /**
- * Client-side host for the static BPMN demo: serves the active bundled model,
- * and resolves Call-Activity / Business-Rule navigation against the model
- * registry (a real host would open another file). Everything a real host does
- * over the extension boundary — deployment, code-link, script editor,
- * clipboard, persistence — is a no-op here.
+ * Client-side host for the static BPMN demo: serves the active bundled model.
+ * Model navigation is wired through the `modelNavigation` capability in
+ * `main.ts` (which resolves against the model registry and swaps the page), so
+ * it no longer crosses this message boundary. Everything else a real host does —
+ * deployment, code-link, script editor, clipboard, persistence — is a no-op here.
  */
 export class BpmnDemoHost extends MockHostApi<WebviewState, MessageType> {
     override updateState(state: Partial<WebviewState>): void {
@@ -63,14 +62,6 @@ export class BpmnDemoHost extends MockHostApi<WebviewState, MessageType> {
             case "GetBpmnlintConfigCommand":
                 dispatch(new BpmnlintResultsQuery(null));
                 break;
-            case "NavigateToReferencedModelCommand": {
-                const cmd = message as NavigateToReferencedModelCommand;
-                const target = resolveReference(cmd.referenceId, cmd.referenceKind);
-                if (target) {
-                    window.location.href = modelHref(target);
-                }
-                break;
-            }
         }
     }
 }

--- a/apps/demo-webapp/bpmn/main.ts
+++ b/apps/demo-webapp/bpmn/main.ts
@@ -1,6 +1,21 @@
 import { bootstrap } from "@miragon/bpmn-modeler-webview";
-import { mountDemoHeader, DemoGrayoutModule } from "../src";
+import { mountDemoHeader, DemoGrayoutModule, modelHref, resolveReference } from "../src";
 import { BpmnDemoHost } from "./demoHost";
 
 mountDemoHeader("bpmn");
-bootstrap(new BpmnDemoHost(), { extraModules: [DemoGrayoutModule] });
+// The demo supplies only the model-navigation capability; codeLink and scripting
+// are omitted, so their context-pad entries / lock UI genuinely never render
+// (AC3 — a host-less consumer no longer gets dead buttons).
+bootstrap(new BpmnDemoHost(), {
+    extraModules: [DemoGrayoutModule],
+    capabilities: {
+        modelNavigation: {
+            openReference: ({ id, kind }) => {
+                const target = resolveReference(id, kind);
+                if (target) {
+                    window.location.href = modelHref(target);
+                }
+            },
+        },
+    },
+});

--- a/apps/vscode-plugin/src/main.ts
+++ b/apps/vscode-plugin/src/main.ts
@@ -95,7 +95,7 @@ function notifyIfNewRelease(context: ExtensionContext, logger: LoggerPort): void
         )
         .then((selection) => {
             if (selection === "View Release Notes") {
-                return env.openExternal(Uri.parse(`${RELEASES_BASE}/v${current}`));
+                return env.openExternal(Uri.parse(`${RELEASES_BASE}/vscode-v${current}`));
             }
             return undefined;
         })

--- a/libs/code-link/README.md
+++ b/libs/code-link/README.md
@@ -7,19 +7,19 @@ implementation does not exist in the workspace.
 
 ## The always-on activity→code map
 
-`CodeLinkMapClient` (a bpmn-js DI service registered by `CodeLinkModule`) keeps
+`CodeLinkMapClient` (a bpmn-js DI service registered by `createCodeLinkModule`) keeps
 the host's activity→code map in sync with the live diagram so the context-pad
 entry's visibility is correct without the user clicking:
 
 - On `import.done` and after edits (`commandStack.changed`, debounced and
   skip-if-unchanged) it ships the diagram's `(activityId, kind, reference)` list
-  to the host via `SyncActivitiesCommand`. **The host never parses the BPMN
-  XML** — bpmn-js already parsed it, so the webview reads the model and sends
-  cheap strings.
-- The host resolves only the delta and pushes back a
-  `key → resolved` lookup (`ImplementationStatusQuery`), which the modeler hands
-  to `applyStatus`. The provider then asks `isResolved(element)` per element:
-  unknown ⇒ shown optimistically (flash-free), cached `false` ⇒ hidden.
+  to the host via `CodeLinkPort.syncActivities`. **The host never parses the
+  BPMN XML** — bpmn-js already parsed it, so the webview reads the model and
+  sends cheap strings.
+- The host resolves only the delta and pushes back a `key → resolved` lookup,
+  which the modeler hands to `applyStatus`. The provider then asks
+  `isResolved(element)` per element: unknown ⇒ shown optimistically
+  (flash-free), cached `false` ⇒ hidden.
 
 The client never mutates bpmn-js model state (forcing a context-pad re-render
 does not run the command stack), so a status push cannot loop back into a
@@ -36,9 +36,9 @@ does not run the command stack), so a status push cannot loop back into a
 - **Resolution is workspace-driven and host-side.** Mapping a reference to a
   source file (`workspace.findFiles`, content search, `vscode.open`) only makes
   sense on the extension host. Keeping the click target in a small webview-side
-  library lets the modeler stay agnostic of VS Code APIs — it just posts a
-  `NavigateToImplementationCommand` carrying the reference string and its kind.
-  Workspace paths never leave the host.
+  library lets the modeler stay agnostic of VS Code APIs — it just calls
+  `CodeLinkPort.navigateToImplementation` with the reference string and its
+  kind. Workspace paths never leave the host.
 - **Context-pad placement is opinionated.** The bpmn-js context pad wraps
   entries 3-per-row within each `data-group` div. The icon sits under the
   existing `connect` group to avoid an orphan row; that choice is documented
@@ -49,11 +49,28 @@ does not run the command stack), so a status push cannot loop back into a
 ## Usage
 
 ```ts
-import { CodeLinkModule } from "@miragon/bpmn-modeler-code-link";
+import { createCodeLinkModule } from "@miragon/bpmn-modeler-code-link";
 
-new BpmnModeler({ additionalModules: [CodeLinkModule] });
+new BpmnModeler({
+    additionalModules: [
+        createCodeLinkModule({
+            navigateToImplementation: (reference, kind) => {
+                /* open the source file */
+            },
+            syncActivities: (entries) => {
+                /* ship entries for status resolution */
+            },
+        }),
+    ],
+});
 ```
 
-The module expects a `vsCodeBridge` DI value with a `postMessage` method so it
-never has to call `acquireVsCodeApi()` directly (which can only be invoked once
-per webview).
+`createCodeLinkModule(port)` embeds the `CodeLinkPort` as the `codeLinkPort` DI
+value, so the module can only be registered together with its host capability. A
+consumer that has no host omits the module entirely and neither the entry nor
+the sync runs.
+
+The library keeps a runtime import of `implementationStatusKey` from
+`@miragon/bpmn-modeler-shared` (the composite status-map key both sides must
+agree on byte-for-byte) until the public/protocol split (#1371); everything else
+it takes from shared is `import type`.

--- a/libs/code-link/src/CodeLinkContextPadProvider.spec.ts
+++ b/libs/code-link/src/CodeLinkContextPadProvider.spec.ts
@@ -7,8 +7,6 @@ vi.mock("bpmn-js/lib/util/ModelUtil", () => ({
     is: (_element: unknown, type: string) => isMatchers.has(type),
 }));
 
-import { NavigateToImplementationCommand } from "@miragon/bpmn-modeler-shared";
-
 import { CodeLinkContextPadProvider } from "./CodeLinkContextPadProvider";
 
 interface MutableElement {
@@ -37,7 +35,7 @@ function build(
 
     const contextPad = { registerProvider: vi.fn() };
     const translate = vi.fn((template: string) => `t(${template})`);
-    const vsCodeBridge = { postMessage: vi.fn() };
+    const port = { navigateToImplementation: vi.fn(), syncActivities: vi.fn() };
     // The map client gates visibility; default to "resolved" so the existing
     // (pre-map) cases behave exactly as before.
     const client = { isResolved: vi.fn().mockReturnValue(opts.resolved ?? true) };
@@ -45,11 +43,11 @@ function build(
     const provider = new CodeLinkContextPadProvider(
         contextPad as never,
         translate as never,
-        vsCodeBridge as never,
+        port as never,
         client as never,
     );
 
-    return { provider, contextPad, translate, vsCodeBridge, client, element, attrs };
+    return { provider, contextPad, translate, port, client, element, attrs };
 }
 
 beforeEach(() => {
@@ -176,7 +174,7 @@ describe("CodeLinkContextPadProvider", () => {
     });
 
     it("re-extracts the reference on click — not the value captured at render time", () => {
-        const { provider, vsCodeBridge, element, attrs } = build({
+        const { provider, port, element, attrs } = build({
             types: ["bpmn:ServiceTask"],
             initialAttrs: { "camunda:class": "com.example.Original" },
         });
@@ -185,15 +183,15 @@ describe("CodeLinkContextPadProvider", () => {
         attrs["camunda:class"] = "com.example.Updated";
         entry.action.click({} as never, element as never);
 
-        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(1);
-        const posted = vsCodeBridge.postMessage.mock.calls[0][0];
-        expect(posted).toBeInstanceOf(NavigateToImplementationCommand);
-        expect((posted as NavigateToImplementationCommand).reference).toBe("com.example.Updated");
-        expect((posted as NavigateToImplementationCommand).kind).toBe("javaClass");
+        expect(port.navigateToImplementation).toHaveBeenCalledTimes(1);
+        expect(port.navigateToImplementation).toHaveBeenCalledWith(
+            "com.example.Updated",
+            "javaClass",
+        );
     });
 
     it("does nothing when the binding was cleared between render and click", () => {
-        const { provider, vsCodeBridge, element, attrs } = build({
+        const { provider, port, element, attrs } = build({
             types: ["bpmn:ServiceTask"],
             initialAttrs: { "camunda:class": "com.example.Original" },
         });
@@ -202,10 +200,10 @@ describe("CodeLinkContextPadProvider", () => {
         attrs["camunda:class"] = "";
         entry.action.click({} as never, element as never);
 
-        expect(vsCodeBridge.postMessage).not.toHaveBeenCalled();
+        expect(port.navigateToImplementation).not.toHaveBeenCalled();
     });
 
-    it("posts a jobType command for a C8 task definition", () => {
+    it("navigates with a jobType kind for a C8 task definition", () => {
         isMatchers.clear();
         isMatchers.add("bpmn:ServiceTask");
         const element = {
@@ -217,20 +215,18 @@ describe("CodeLinkContextPadProvider", () => {
             },
         };
         const contextPad = { registerProvider: vi.fn() };
-        const vsCodeBridge = { postMessage: vi.fn() };
+        const port = { navigateToImplementation: vi.fn(), syncActivities: vi.fn() };
         const client = { isResolved: vi.fn().mockReturnValue(true) };
         const provider = new CodeLinkContextPadProvider(
             contextPad as never,
             ((s: string) => s) as never,
-            vsCodeBridge as never,
+            port as never,
             client as never,
         );
 
         const entry = provider.getContextPadEntries(element as never)["go-to-implementation"];
         entry.action.click({} as never, element as never);
 
-        const posted = vsCodeBridge.postMessage.mock.calls[0][0] as NavigateToImplementationCommand;
-        expect(posted.kind).toBe("jobType");
-        expect(posted.reference).toBe("payment-service");
+        expect(port.navigateToImplementation).toHaveBeenCalledWith("payment-service", "jobType");
     });
 });

--- a/libs/code-link/src/CodeLinkContextPadProvider.ts
+++ b/libs/code-link/src/CodeLinkContextPadProvider.ts
@@ -6,9 +6,9 @@
  * `camunda:expression` / external `camunda:topic` (C7) or a
  * `zeebe:taskDefinition type` (C8).
  *
- * Clicking the entry sends a {@link NavigateToImplementationCommand} to the
- * extension host, which resolves the reference to a workspace source file and
- * opens it (or shows a QuickPick / info notification on N / 0 matches).
+ * Clicking the entry calls {@link CodeLinkPort.navigateToImplementation}; the
+ * consumer resolves the reference to a workspace source file and opens it (or
+ * shows a QuickPick / info notification on N / 0 matches).
  *
  * The entry mirrors `NavigateContextPadProvider`: an inline `html` fragment
  * with an embedded SVG, placed in the `connect` group so it shares a row with
@@ -18,11 +18,10 @@
  */
 import { is } from "bpmn-js/lib/util/ModelUtil";
 
-import { NavigateToImplementationCommand } from "@miragon/bpmn-modeler-shared";
-
 import { BusinessObjectLike, extractImplementation } from "./extractImplementation";
 import { IMPLEMENTABLE_TYPES } from "./collectImplementations";
 import type { CodeLinkMapClient } from "./CodeLinkMapClient";
+import type { CodeLinkPort } from "./CodeLinkPort";
 
 interface ContextPad {
     registerProvider(provider: CodeLinkContextPadProvider): void;
@@ -40,10 +39,6 @@ export interface Element {
     id?: string;
     type?: string;
     businessObject?: BusinessObjectLike;
-}
-
-interface VsCodeBridge {
-    postMessage(message: unknown): void;
 }
 
 interface ContextPadEntry {
@@ -69,27 +64,27 @@ const CODE_ICON_SVG = `<svg width="22" height="22" viewBox="0 0 24 24" fill="non
  * contributes only when the selected element is an implementable task with a
  * resolvable implementation reference.
  *
- * The `vsCodeBridge` DI value is supplied by the bpmn-webview during modeler
- * construction so this library never calls `acquireVsCodeApi` itself (it may
- * only be invoked once per webview).
+ * The `codeLinkPort` DI value is supplied by the consumer during modeler
+ * construction; the module cannot be registered without it (see
+ * {@link createCodeLinkModule}), so the library stays free of the host protocol.
  */
 export class CodeLinkContextPadProvider {
-    static $inject = ["contextPad", "translate", "vsCodeBridge", "codeLinkMapClient"];
+    static $inject = ["contextPad", "translate", "codeLinkPort", "codeLinkMapClient"];
 
     private readonly translate: Translate;
 
-    private readonly vsCodeBridge: VsCodeBridge;
+    private readonly port: CodeLinkPort;
 
     private readonly client: CodeLinkMapClient;
 
     constructor(
         contextPad: ContextPad,
         translate: Translate,
-        vsCodeBridge: VsCodeBridge,
+        codeLinkPort: CodeLinkPort,
         codeLinkMapClient: CodeLinkMapClient,
     ) {
         this.translate = translate;
-        this.vsCodeBridge = vsCodeBridge;
+        this.port = codeLinkPort;
         this.client = codeLinkMapClient;
         contextPad.registerProvider(this);
     }
@@ -127,12 +122,7 @@ export class CodeLinkContextPadProvider {
                     click: (_event, clickedElement) => {
                         const current = extractImplementation(clickedElement.businessObject);
                         if (current) {
-                            this.vsCodeBridge.postMessage(
-                                new NavigateToImplementationCommand(
-                                    current.reference,
-                                    current.kind,
-                                ),
-                            );
+                            this.port.navigateToImplementation(current.reference, current.kind);
                         }
                     },
                 },

--- a/libs/code-link/src/CodeLinkMapClient.spec.ts
+++ b/libs/code-link/src/CodeLinkMapClient.spec.ts
@@ -4,7 +4,7 @@ vi.mock("bpmn-js/lib/util/ModelUtil", () => ({
     is: (element: { type?: string } | undefined, type: string) => element?.type === type,
 }));
 
-import { implementationStatusKey, SyncActivitiesCommand } from "@miragon/bpmn-modeler-shared";
+import { implementationStatusKey } from "@miragon/bpmn-modeler-shared";
 
 import { CodeLinkMapClient } from "./CodeLinkMapClient";
 
@@ -35,22 +35,21 @@ function setup(elements: FakeElement[] = []) {
     const registryElements = [...elements];
     const elementRegistry = { getAll: () => registryElements as never };
     const contextPad = { isOpen: vi.fn().mockReturnValue(false), open: vi.fn() };
-    const vsCodeBridge = { postMessage: vi.fn() };
+    const port = { navigateToImplementation: vi.fn(), syncActivities: vi.fn() };
 
     const client = new CodeLinkMapClient(
         eventBus as never,
         elementRegistry,
         contextPad as never,
-        vsCodeBridge as never,
+        port as never,
     );
 
     const lastSentEntries = () => {
-        const calls = vsCodeBridge.postMessage.mock.calls;
-        const command = calls[calls.length - 1][0] as SyncActivitiesCommand;
-        return command.entries;
+        const calls = port.syncActivities.mock.calls;
+        return calls[calls.length - 1][0];
     };
 
-    return { client, fire, contextPad, vsCodeBridge, registryElements, lastSentEntries };
+    return { client, fire, contextPad, port, registryElements, lastSentEntries };
 }
 
 afterEach(() => {
@@ -58,50 +57,47 @@ afterEach(() => {
 });
 
 describe("CodeLinkMapClient — syncing", () => {
-    it("posts a SyncActivitiesCommand immediately on import.done", () => {
-        const { fire, vsCodeBridge, lastSentEntries } = setup([
-            serviceTask("Activity_1", "com.example.A"),
-        ]);
+    it("syncs the activities immediately on import.done", () => {
+        const { fire, port, lastSentEntries } = setup([serviceTask("Activity_1", "com.example.A")]);
 
         fire("import.done");
 
-        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(1);
-        expect(vsCodeBridge.postMessage.mock.calls[0][0]).toBeInstanceOf(SyncActivitiesCommand);
+        expect(port.syncActivities).toHaveBeenCalledTimes(1);
         expect(lastSentEntries()).toEqual([
             { activityId: "Activity_1", kind: "javaClass", reference: "com.example.A" },
         ]);
     });
 
-    it("debounces a burst of commandStack.changed into a single post", () => {
+    it("debounces a burst of commandStack.changed into a single sync", () => {
         vi.useFakeTimers();
-        const { fire, vsCodeBridge } = setup([serviceTask("Activity_1", "com.example.A")]);
+        const { fire, port } = setup([serviceTask("Activity_1", "com.example.A")]);
 
         fire("commandStack.changed");
         fire("commandStack.changed");
         fire("commandStack.changed");
-        expect(vsCodeBridge.postMessage).not.toHaveBeenCalled();
+        expect(port.syncActivities).not.toHaveBeenCalled();
 
         vi.advanceTimersByTime(400);
-        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(1);
+        expect(port.syncActivities).toHaveBeenCalledTimes(1);
     });
 
-    it("skips the post when the implementation list is unchanged", () => {
+    it("skips the sync when the implementation list is unchanged", () => {
         vi.useFakeTimers();
-        const { fire, vsCodeBridge } = setup([serviceTask("Activity_1", "com.example.A")]);
+        const { fire, port } = setup([serviceTask("Activity_1", "com.example.A")]);
 
         fire("import.done");
-        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(1);
+        expect(port.syncActivities).toHaveBeenCalledTimes(1);
 
         // An edit that did not touch any implementation binding.
         fire("commandStack.changed");
         vi.advanceTimersByTime(400);
-        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(1);
+        expect(port.syncActivities).toHaveBeenCalledTimes(1);
     });
 
-    it("posts again once a binding actually changes", () => {
+    it("syncs again once a binding actually changes", () => {
         vi.useFakeTimers();
         const element = serviceTask("Activity_1", "com.example.A");
-        const { fire, vsCodeBridge, registryElements, lastSentEntries } = setup([element]);
+        const { fire, port, registryElements, lastSentEntries } = setup([element]);
 
         fire("import.done");
         registryElements[0] = serviceTask("Activity_1", "com.example.B");
@@ -109,7 +105,7 @@ describe("CodeLinkMapClient — syncing", () => {
         fire("commandStack.changed");
         vi.advanceTimersByTime(400);
 
-        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(2);
+        expect(port.syncActivities).toHaveBeenCalledTimes(2);
         expect(lastSentEntries()).toEqual([
             { activityId: "Activity_1", kind: "javaClass", reference: "com.example.B" },
         ]);

--- a/libs/code-link/src/CodeLinkMapClient.ts
+++ b/libs/code-link/src/CodeLinkMapClient.ts
@@ -5,23 +5,21 @@
  *
  * It is the webview half of the always-on map: on import and after edits it
  * ships the diagram's implementation references to the host
- * ({@link SyncActivitiesCommand}); the host resolves the delta and pushes back a
- * `key → resolved` lookup ({@link ImplementationStatusQuery}) consumed by
- * {@link applyStatus}. The provider then calls {@link isResolved} per element.
+ * ({@link CodeLinkPort.syncActivities}); the host resolves the delta and pushes
+ * back a `key → resolved` lookup consumed by {@link applyStatus}. The provider
+ * then calls {@link isResolved} per element.
  *
  * It never mutates bpmn-js model state — forcing the context pad to re-render
  * does not run the command stack — so a status push can't loop back into a
  * `commandStack.changed` event and re-trigger a sync.
  */
-import {
-    ImplementationEntry,
-    implementationStatusKey,
-    SyncActivitiesCommand,
-} from "@miragon/bpmn-modeler-shared";
+import { implementationStatusKey } from "@miragon/bpmn-modeler-shared";
+import type { ImplementationEntry } from "@miragon/bpmn-modeler-shared";
 
 import { collectImplementations, ElementRegistryLike } from "./collectImplementations";
 import { extractImplementation } from "./extractImplementation";
 import type { Element } from "./CodeLinkContextPadProvider";
+import type { CodeLinkPort } from "./CodeLinkPort";
 
 interface EventBus {
     on(event: string, callback: (event?: unknown) => void): void;
@@ -30,10 +28,6 @@ interface EventBus {
 interface ContextPad {
     isOpen(): boolean;
     open(target: unknown, force?: boolean): void;
-}
-
-interface VsCodeBridge {
-    postMessage(message: unknown): void;
 }
 
 // Coalesce the bursts of `commandStack.changed` a single gesture fires (drag,
@@ -55,13 +49,13 @@ function singleTarget(current: unknown): Element | undefined {
 }
 
 export class CodeLinkMapClient {
-    static $inject = ["eventBus", "elementRegistry", "contextPad", "vsCodeBridge"];
+    static $inject = ["eventBus", "elementRegistry", "contextPad", "codeLinkPort"];
 
     private readonly elementRegistry: ElementRegistryLike;
 
     private readonly contextPad: ContextPad;
 
-    private readonly vsCodeBridge: VsCodeBridge;
+    private readonly port: CodeLinkPort;
 
     // Resolution status keyed by `${activityId}::${reference}`. Absent key ⇒
     // unknown ⇒ shown optimistically; explicit `false` ⇒ hidden.
@@ -81,11 +75,11 @@ export class CodeLinkMapClient {
         eventBus: EventBus,
         elementRegistry: ElementRegistryLike,
         contextPad: ContextPad,
-        vsCodeBridge: VsCodeBridge,
+        codeLinkPort: CodeLinkPort,
     ) {
         this.elementRegistry = elementRegistry;
         this.contextPad = contextPad;
-        this.vsCodeBridge = vsCodeBridge;
+        this.port = codeLinkPort;
 
         eventBus.on("import.done", () => this.sendNow());
         eventBus.on("commandStack.changed", () => this.sendDebounced());
@@ -151,6 +145,6 @@ export class CodeLinkMapClient {
             return;
         }
         this.lastSentSignature = signature;
-        this.vsCodeBridge.postMessage(new SyncActivitiesCommand(entries));
+        this.port.syncActivities(entries);
     }
 }

--- a/libs/code-link/src/CodeLinkPort.ts
+++ b/libs/code-link/src/CodeLinkPort.ts
@@ -1,0 +1,20 @@
+import type { ImplementationKind } from "./extractImplementation";
+import type { ImplementationEntry } from "@miragon/bpmn-modeler-shared";
+
+/**
+ * The host capabilities this library needs. The consumer supplies an
+ * implementation (in the VS Code webview both calls post protocol commands),
+ * so the library never imports the postMessage protocol and registering its
+ * providers without a host is unrepresentable — no port, no module (see
+ * {@link createCodeLinkModule}).
+ *
+ * `ImplementationEntry` is a type-only import from the shared package until the
+ * public/protocol split (#1371) gives it a protocol-free home.
+ */
+export interface CodeLinkPort {
+    /** Open the workspace source file the reference resolves to. */
+    navigateToImplementation(reference: string, kind: ImplementationKind): void;
+
+    /** Ship the diagram's current implementation references for status resolution. */
+    syncActivities(entries: ImplementationEntry[]): void;
+}

--- a/libs/code-link/src/index.ts
+++ b/libs/code-link/src/index.ts
@@ -4,35 +4,43 @@
  * implementation reference (C7 `camunda:class` / delegate / expression /
  * external topic, or C8 `zeebe:taskDefinition` job type).
  *
- * Register as an `additionalModule` when creating the bpmn-js modeler:
+ * The module is built by {@link createCodeLinkModule}, which takes the
+ * {@link CodeLinkPort} and embeds it as the `codeLinkPort` DI value.
+ * Registering the providers without their port is therefore unrepresentable —
+ * a host-less consumer that omits the port gets no UI.
  *
  * ```ts
- * import { CodeLinkModule } from "@miragon/bpmn-modeler-code-link";
+ * import { createCodeLinkModule } from "@miragon/bpmn-modeler-code-link";
  *
- * new BpmnModeler({ additionalModules: [CodeLinkModule] });
+ * new BpmnModeler({ additionalModules: [createCodeLinkModule(port)] });
  * ```
- *
- * Requires a `vsCodeBridge` DI value with a `postMessage` method (the
- * bpmn-webview provides this so the existing single VS Code API instance is
- * reused).
  *
  * The module also registers a {@link CodeLinkMapClient}: it keeps the host's
  * activity→code map in sync (so the context-pad entry can hide when a task's
  * implementation does not exist) and is the service the bpmn-webview hands the
- * host's {@link ImplementationStatusQuery} pushes via `applyStatus`.
+ * host's status pushes via `applyStatus`.
  */
 import { CodeLinkContextPadProvider } from "./CodeLinkContextPadProvider";
 import { CodeLinkMapClient } from "./CodeLinkMapClient";
+import type { CodeLinkPort } from "./CodeLinkPort";
 
 export { extractImplementation } from "./extractImplementation";
 export type { ImplementationKind, ImplementationReference } from "./extractImplementation";
 export { collectImplementations, IMPLEMENTABLE_TYPES } from "./collectImplementations";
 export { CodeLinkMapClient } from "./CodeLinkMapClient";
+export type { CodeLinkPort } from "./CodeLinkPort";
 
-export const CodeLinkModule = {
-    // `codeLinkMapClient` is listed first so it is constructed (and subscribed
-    // to import/edit events) before the provider that depends on it.
-    __init__: ["codeLinkMapClient", "codeLinkContextPadProvider"],
-    codeLinkMapClient: ["type", CodeLinkMapClient],
-    codeLinkContextPadProvider: ["type", CodeLinkContextPadProvider],
-};
+/**
+ * Builds the DI bundle for the given host port. `codeLinkMapClient` is listed
+ * first in `__init__` so it is constructed (and subscribed to import/edit
+ * events) before the provider that depends on it; the port rides along as a
+ * `value` so both `codeLinkPort` injections resolve.
+ */
+export function createCodeLinkModule(port: CodeLinkPort) {
+    return {
+        __init__: ["codeLinkMapClient", "codeLinkContextPadProvider"],
+        codeLinkMapClient: ["type", CodeLinkMapClient],
+        codeLinkContextPadProvider: ["type", CodeLinkContextPadProvider],
+        codeLinkPort: ["value", port],
+    };
+}

--- a/libs/inline-scripting/README.md
+++ b/libs/inline-scripting/README.md
@@ -32,8 +32,10 @@ The modules never import host code; they communicate over the bpmn-js event bus.
 | `scriptEditor.sourceChanged` | out | An open script's model content diverged. |
 | `openScriptEditors.changed` | internal | The open-editors set changed (lock refresh). |
 
-The webview facade (`apps/bpmn-webview/src/app/modeler.ts`) subscribes to the
-first two and forwards them to whichever host is running.
+`InlineScriptingPortForwarder` (registered by `createInlineScriptingModules`)
+subscribes to the first two and calls the `InlineScriptingPort` the consumer
+supplies. The library never imports the host protocol; in the VS Code webview
+the port's implementation posts the corresponding protocol commands.
 
 ## Usage
 
@@ -41,10 +43,14 @@ Camunda-7 only — register the aggregate on the C7 modeler's `additionalModules
 (the C8 modeler leaves it unregistered):
 
 ```ts
-import { InlineScriptingModules } from "@miragon/bpmn-modeler-inline-scripting";
+import { createInlineScriptingModules } from "@miragon/bpmn-modeler-inline-scripting";
 
-new BpmnModeler7({ additionalModules: [...InlineScriptingModules] });
+new BpmnModeler7({ additionalModules: [...createInlineScriptingModules(port)] });
 ```
+
+`createInlineScriptingModules(port)` embeds the `InlineScriptingPort` as the
+`inlineScriptingPort` DI value, so the cluster can only be registered together
+with its host capability.
 
 ## Known coupling
 

--- a/libs/inline-scripting/src/InlineScriptingPort.ts
+++ b/libs/inline-scripting/src/InlineScriptingPort.ts
@@ -1,0 +1,19 @@
+import type { OpenScriptEditorEvent } from "./scriptTaskContextPad";
+import type { ScriptSourceChangedEvent } from "./scriptSourceWatcher";
+
+/**
+ * The host capabilities this library needs. The consumer supplies an
+ * implementation (in the VS Code webview both calls post protocol commands),
+ * so the library never imports the postMessage protocol. The modules keep
+ * speaking over lib-owned event-bus events; {@link InlineScriptingPortForwarder}
+ * bridges those two events onto this port at DI construction, so registering
+ * the cluster without a host is unrepresentable — no port, no module (see
+ * `createInlineScriptingModules`).
+ */
+export interface InlineScriptingPort {
+    /** A surface requested its editor tab be opened. */
+    openScriptEditor(event: OpenScriptEditorEvent): void;
+
+    /** An open script's model content diverged from its editor tab. */
+    scriptSourceChanged(event: ScriptSourceChangedEvent): void;
+}

--- a/libs/inline-scripting/src/index.ts
+++ b/libs/inline-scripting/src/index.ts
@@ -7,16 +7,17 @@
  * event-bus events — `scriptEditor.open` (a surface requested its tab),
  * `scriptEditor.sourceChanged` (an open script diverged in the model), and the
  * internal `openScriptEditors.changed` (the owned-surface set changed, so the
- * lock provider refreshes). The webview facade forwards the first two to
- * whichever host is running.
+ * lock provider refreshes). {@link InlineScriptingPortForwarder} bridges the
+ * first two onto the {@link InlineScriptingPort} the consumer supplies.
  *
  * Register the whole cluster on the Camunda-7 modeler (the C8 modeler leaves it
- * unregistered):
+ * unregistered). Because the port is embedded in the returned bundle,
+ * registering the cluster without a host is unrepresentable:
  *
  * ```ts
- * import { InlineScriptingModules } from "@miragon/bpmn-modeler-inline-scripting";
+ * import { createInlineScriptingModules } from "@miragon/bpmn-modeler-inline-scripting";
  *
- * new BpmnModeler7({ additionalModules: [...InlineScriptingModules] });
+ * new BpmnModeler7({ additionalModules: [...createInlineScriptingModules(port)] });
  * ```
  */
 import "./inlineScripting.css";
@@ -34,6 +35,8 @@ import {
     ScriptSourceWatcherModule,
 } from "./scriptSourceWatcher";
 import type { ScriptSourceChangedEvent } from "./scriptSourceWatcher";
+import { InlineScriptingPortForwarder } from "./inlineScriptingPortForwarder";
+import type { InlineScriptingPort } from "./InlineScriptingPort";
 import { collectInlineScriptTasks, findListenerAt } from "./scriptModel";
 
 export {
@@ -48,18 +51,31 @@ export {
     SCRIPT_SOURCE_CHANGED_EVENT,
     ScriptSourceWatcher,
     ScriptSourceWatcherModule,
+    InlineScriptingPortForwarder,
     collectInlineScriptTasks,
     findListenerAt,
 };
-export type { OpenScriptEditorEvent, ScriptSourceChangedEvent };
+export type { OpenScriptEditorEvent, ScriptSourceChangedEvent, InlineScriptingPort };
 
-/** All C7 inline-scripting DI modules, in registration order — spread into additionalModules. */
-export const InlineScriptingModules = [
-    ScriptTaskContextPadModule,
-    ScriptEditorOpenerModule,
-    ScriptEditorButtonsModule,
-    ScriptEditorKeyboardModule,
-    OpenScriptEditorsStoreModule,
-    ScriptLockPropertiesProviderModule,
-    ScriptSourceWatcherModule,
-];
+/**
+ * All C7 inline-scripting DI modules for the given host port, in registration
+ * order — spread into `additionalModules`. The eighth bundle carries the
+ * {@link InlineScriptingPortForwarder} together with the `inlineScriptingPort`
+ * DI value, so the cluster and its host capability are registered as a unit.
+ */
+export function createInlineScriptingModules(port: InlineScriptingPort) {
+    return [
+        ScriptTaskContextPadModule,
+        ScriptEditorOpenerModule,
+        ScriptEditorButtonsModule,
+        ScriptEditorKeyboardModule,
+        OpenScriptEditorsStoreModule,
+        ScriptLockPropertiesProviderModule,
+        ScriptSourceWatcherModule,
+        {
+            __init__: ["inlineScriptingPortForwarder"],
+            inlineScriptingPortForwarder: ["type", InlineScriptingPortForwarder],
+            inlineScriptingPort: ["value", port],
+        },
+    ];
+}

--- a/libs/inline-scripting/src/inlineScriptingPortForwarder.spec.ts
+++ b/libs/inline-scripting/src/inlineScriptingPortForwarder.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { OPEN_SCRIPT_EDITOR_EVENT } from "./scriptTaskContextPad";
+import { SCRIPT_SOURCE_CHANGED_EVENT } from "./scriptSourceWatcher";
+import { InlineScriptingPortForwarder } from "./inlineScriptingPortForwarder";
+
+/** Records event-bus subscriptions so the test can fire them by name. */
+function fakeEventBus() {
+    const handlers: Record<string, ((event: unknown) => void)[]> = {};
+    return {
+        on: (event: string, callback: (event: unknown) => void) => {
+            (handlers[event] ??= []).push(callback);
+        },
+        fire: (event: string, payload: unknown) =>
+            (handlers[event] ?? []).forEach((callback) => callback(payload)),
+    };
+}
+
+describe("InlineScriptingPortForwarder", () => {
+    it("forwards scriptEditor.open to the port", () => {
+        const bus = fakeEventBus();
+        const port = { openScriptEditor: vi.fn(), scriptSourceChanged: vi.fn() };
+        new InlineScriptingPortForwarder(bus as never, port);
+
+        const event = {
+            elementId: "Task_1",
+            kind: "script-task",
+            listenerIndex: undefined,
+            eventName: undefined,
+            scriptFormat: "groovy",
+            content: "x = 1",
+        };
+        bus.fire(OPEN_SCRIPT_EDITOR_EVENT, event);
+
+        expect(port.openScriptEditor).toHaveBeenCalledWith(event);
+        expect(port.scriptSourceChanged).not.toHaveBeenCalled();
+    });
+
+    it("forwards scriptEditor.sourceChanged to the port", () => {
+        const bus = fakeEventBus();
+        const port = { openScriptEditor: vi.fn(), scriptSourceChanged: vi.fn() };
+        new InlineScriptingPortForwarder(bus as never, port);
+
+        const event = {
+            elementId: "Task_1",
+            kind: "script-task",
+            listenerIndex: undefined,
+            content: "x = 2",
+        };
+        bus.fire(SCRIPT_SOURCE_CHANGED_EVENT, event);
+
+        expect(port.scriptSourceChanged).toHaveBeenCalledWith(event);
+        expect(port.openScriptEditor).not.toHaveBeenCalled();
+    });
+});

--- a/libs/inline-scripting/src/inlineScriptingPortForwarder.ts
+++ b/libs/inline-scripting/src/inlineScriptingPortForwarder.ts
@@ -1,0 +1,31 @@
+import { OPEN_SCRIPT_EDITOR_EVENT } from "./scriptTaskContextPad";
+import type { OpenScriptEditorEvent } from "./scriptTaskContextPad";
+import { SCRIPT_SOURCE_CHANGED_EVENT } from "./scriptSourceWatcher";
+import type { ScriptSourceChangedEvent } from "./scriptSourceWatcher";
+import type { InlineScriptingPort } from "./InlineScriptingPort";
+
+interface EventBus {
+    on(event: string, callback: (event: unknown) => void): void;
+}
+
+/**
+ * Bridges the two outbound lib-owned events onto the {@link InlineScriptingPort}
+ * so the cluster stays protocol-free while the consumer decides what "open a
+ * tab" / "overwrite the tab" means.
+ *
+ * It subscribes at DI construction — earlier than the previous post-init facade
+ * wiring — which is safe because both events are only ever fired by a user
+ * action or an edit, never during modeler bring-up.
+ */
+export class InlineScriptingPortForwarder {
+    static $inject = ["eventBus", "inlineScriptingPort"];
+
+    constructor(eventBus: EventBus, port: InlineScriptingPort) {
+        eventBus.on(OPEN_SCRIPT_EDITOR_EVENT, (event) =>
+            port.openScriptEditor(event as OpenScriptEditorEvent),
+        );
+        eventBus.on(SCRIPT_SOURCE_CHANGED_EVENT, (event) =>
+            port.scriptSourceChanged(event as ScriptSourceChangedEvent),
+        );
+    }
+}

--- a/libs/model-navigation/README.md
+++ b/libs/model-navigation/README.md
@@ -15,8 +15,8 @@ or from a Business Rule Task to the referenced DMN decision.
 - **Resolution is workspace-driven.** The actual file lookup
   (`workspace.findFiles`, opening via `vscode.open`) only makes sense on
   the extension host.  Keeping the click target in a small webview-side
-  library lets the modeler stay agnostic of VS Code APIs — it just posts
-  a `NavigateToReferencedModelCommand`.
+  library lets the modeler stay agnostic of VS Code APIs — it just calls
+  the injected `ModelNavigationPort`.
 - **Context-pad placement is opinionated.** The bpmn-js context pad
   wraps entries 3-per-row within each `data-group` div.  Putting the
   icon under the existing `connect` group avoids an orphan row; that
@@ -25,12 +25,21 @@ or from a Business Rule Task to the referenced DMN decision.
 ## Usage
 
 ```ts
-import { NavigateToReferencedModelModule } from "@miragon/bpmn-model-navigation";
+import { createModelNavigationModule } from "@miragon/bpmn-model-navigation";
 
-new BpmnModeler({ additionalModules: [NavigateToReferencedModelModule] });
+new BpmnModeler({
+    additionalModules: [
+        createModelNavigationModule({
+            openReference: ({ id, kind }) => {
+                /* resolve id/kind to a file and open it */
+            },
+        }),
+    ],
+});
 ```
 
-The module expects a `vsCodeBridge` DI value with a `postMessage` method
-so it never has to call `acquireVsCodeApi()` directly (which can only be
-invoked once per webview).
+`createModelNavigationModule(port)` embeds the `ModelNavigationPort` as the
+`modelNavigationPort` DI value, so the module can only be registered together
+with its host capability. A consumer that has no host omits the module entirely
+and the context-pad entry never appears.
 

--- a/libs/model-navigation/package.json
+++ b/libs/model-navigation/package.json
@@ -6,9 +6,6 @@
         "build": "tsc --noEmit",
         "test": "vitest run"
     },
-    "dependencies": {
-        "@miragon/bpmn-modeler-shared": "workspace:*"
-    },
     "peerDependencies": {
         "bpmn-js": "18.19.0"
     },

--- a/libs/model-navigation/src/ModelNavigationPort.ts
+++ b/libs/model-navigation/src/ModelNavigationPort.ts
@@ -1,0 +1,22 @@
+import type { ReferenceKind } from "./extractReference";
+
+/**
+ * A resolvable model reference the context-pad entry navigates to: the
+ * process / decision id plus the {@link ReferenceKind} that tells the host
+ * which file type to look for.
+ */
+export interface ModelReference {
+    id: string;
+    kind: ReferenceKind;
+}
+
+/**
+ * The single host capability this library needs. The consumer supplies an
+ * implementation (in the VS Code webview it posts a protocol command; a
+ * host-less consumer resolves the reference itself), so the library never
+ * imports the postMessage protocol and registering the provider without a
+ * host is unrepresentable — no port, no module (see {@link createModelNavigationModule}).
+ */
+export interface ModelNavigationPort {
+    openReference(reference: ModelReference): void;
+}

--- a/libs/model-navigation/src/NavigateContextPadProvider.spec.ts
+++ b/libs/model-navigation/src/NavigateContextPadProvider.spec.ts
@@ -7,8 +7,6 @@ vi.mock("bpmn-js/lib/util/ModelUtil", () => ({
     is: (_element: unknown, type: string) => isMatchers.has(type),
 }));
 
-import { NavigateToReferencedModelCommand } from "@miragon/bpmn-modeler-shared";
-
 import { NavigateContextPadProvider } from "./NavigateContextPadProvider";
 
 interface MutableElement {
@@ -36,15 +34,15 @@ function build(
 
     const contextPad = { registerProvider: vi.fn() };
     const translate = vi.fn((template: string) => `t(${template})`);
-    const vsCodeBridge = { postMessage: vi.fn() };
+    const port = { openReference: vi.fn() };
 
     const provider = new NavigateContextPadProvider(
         contextPad as never,
         translate as never,
-        vsCodeBridge as never,
+        port as never,
     );
 
-    return { provider, contextPad, translate, vsCodeBridge, element, attrs };
+    return { provider, contextPad, translate, port, element, attrs };
 }
 
 beforeEach(() => {
@@ -116,8 +114,8 @@ describe("NavigateContextPadProvider", () => {
 
     it("re-extracts the reference id on click — not the value captured at render time", () => {
         // Build the pad while the id is "Original".  Mutate to "Updated"
-        // before invoking click — the posted command must carry "Updated".
-        const { provider, vsCodeBridge, element, attrs } = build({
+        // before invoking click — the port must be called with "Updated".
+        const { provider, port, element, attrs } = build({
             types: ["bpmn:CallActivity"],
             initialAttrs: { calledElement: "Original" },
         });
@@ -128,15 +126,12 @@ describe("NavigateContextPadProvider", () => {
         attrs.calledElement = "Updated";
         entry.action.click({} as never, element as never);
 
-        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(1);
-        const posted = vsCodeBridge.postMessage.mock.calls[0][0];
-        expect(posted).toBeInstanceOf(NavigateToReferencedModelCommand);
-        expect((posted as NavigateToReferencedModelCommand).referenceId).toBe("Updated");
-        expect((posted as NavigateToReferencedModelCommand).referenceKind).toBe("process");
+        expect(port.openReference).toHaveBeenCalledTimes(1);
+        expect(port.openReference).toHaveBeenCalledWith({ id: "Updated", kind: "process" });
     });
 
     it("does nothing when the reference id was cleared between render and click", () => {
-        const { provider, vsCodeBridge, element, attrs } = build({
+        const { provider, port, element, attrs } = build({
             types: ["bpmn:CallActivity"],
             initialAttrs: { calledElement: "Original" },
         });
@@ -147,11 +142,11 @@ describe("NavigateContextPadProvider", () => {
         attrs.calledElement = "";
         entry.action.click({} as never, element as never);
 
-        expect(vsCodeBridge.postMessage).not.toHaveBeenCalled();
+        expect(port.openReference).not.toHaveBeenCalled();
     });
 
-    it("posts a decision-kind command for Business Rule Tasks", () => {
-        const { provider, vsCodeBridge, element } = build({
+    it("opens a decision-kind reference for Business Rule Tasks", () => {
+        const { provider, port, element } = build({
             types: ["bpmn:BusinessRuleTask"],
             initialAttrs: { "camunda:decisionRef": "Decision_1" },
         });
@@ -161,9 +156,6 @@ describe("NavigateContextPadProvider", () => {
 
         entry.action.click({} as never, element as never);
 
-        const posted = vsCodeBridge.postMessage.mock
-            .calls[0][0] as NavigateToReferencedModelCommand;
-        expect(posted.referenceKind).toBe("decision");
-        expect(posted.referenceId).toBe("Decision_1");
+        expect(port.openReference).toHaveBeenCalledWith({ id: "Decision_1", kind: "decision" });
     });
 });

--- a/libs/model-navigation/src/NavigateContextPadProvider.ts
+++ b/libs/model-navigation/src/NavigateContextPadProvider.ts
@@ -5,9 +5,9 @@
  * `calledElement` / `zeebe:calledElement processId`) and Business Rule
  * Tasks (with `camunda:decisionRef` / `zeebe:calledDecision decisionId`).
  *
- * Clicking the entry sends a {@link NavigateToReferencedModelCommand} to
- * the extension host, which performs the workspace lookup and opens the
- * referenced `.bpmn` or `.dmn` file.
+ * Clicking the entry calls {@link ModelNavigationPort.openReference}; the
+ * consumer performs the workspace lookup and opens the referenced `.bpmn` or
+ * `.dmn` file (the VS Code webview does this by posting a protocol command).
  *
  * The entry is rendered as an inline `html` fragment with an embedded SVG
  * (same approach as the `append` entry from `bpmn-js-create-append-anything`)
@@ -22,9 +22,8 @@
  */
 import { is } from "bpmn-js/lib/util/ModelUtil";
 
-import { NavigateToReferencedModelCommand } from "@miragon/bpmn-modeler-shared";
-
 import { BusinessObjectLike, extractReference, ReferenceKind } from "./extractReference";
+import type { ModelNavigationPort } from "./ModelNavigationPort";
 
 interface ContextPad {
     registerProvider(provider: NavigateContextPadProvider): void;
@@ -37,10 +36,6 @@ interface Translate {
 interface Element {
     type?: string;
     businessObject?: BusinessObjectLike;
-}
-
-interface VsCodeBridge {
-    postMessage(message: unknown): void;
 }
 
 interface ContextPadEntry {
@@ -64,20 +59,25 @@ const NAVIGATE_ICON_SVG = `<svg width="22" height="22" viewBox="0 0 24 24" fill=
  * by calling {@link getContextPadEntries} on every registered provider; we
  * only contribute when the selected element actually references a model.
  *
- * The `vsCodeBridge` DI value is supplied by the bpmn-webview during
- * modeler construction so this library does not call `acquireVsCodeApi`
- * itself (it may only be invoked once per webview).
+ * The `modelNavigationPort` DI value is supplied by the consumer during
+ * modeler construction; the module cannot be registered without it (see
+ * {@link createModelNavigationModule}), so the library stays free of the
+ * host protocol.
  */
 export class NavigateContextPadProvider {
-    static $inject = ["contextPad", "translate", "vsCodeBridge"];
+    static $inject = ["contextPad", "translate", "modelNavigationPort"];
 
     private readonly translate: Translate;
 
-    private readonly vsCodeBridge: VsCodeBridge;
+    private readonly port: ModelNavigationPort;
 
-    constructor(contextPad: ContextPad, translate: Translate, vsCodeBridge: VsCodeBridge) {
+    constructor(
+        contextPad: ContextPad,
+        translate: Translate,
+        modelNavigationPort: ModelNavigationPort,
+    ) {
         this.translate = translate;
-        this.vsCodeBridge = vsCodeBridge;
+        this.port = modelNavigationPort;
         contextPad.registerProvider(this);
     }
 
@@ -97,12 +97,6 @@ export class NavigateContextPadProvider {
             return {};
         }
 
-        const postMessage = (latestReferenceId: string) => {
-            this.vsCodeBridge.postMessage(
-                new NavigateToReferencedModelCommand(latestReferenceId, kind),
-            );
-        };
-
         return {
             "navigate-to-referenced-model": {
                 group: "connect",
@@ -115,7 +109,7 @@ export class NavigateContextPadProvider {
                     click: (_event, clickedElement) => {
                         const current = extractReference(clickedElement.businessObject, kind);
                         if (current) {
-                            postMessage(current);
+                            this.port.openReference({ id: current, kind });
                         }
                     },
                 },

--- a/libs/model-navigation/src/index.ts
+++ b/libs/model-navigation/src/index.ts
@@ -3,24 +3,35 @@
  * context pad around Call Activities (BPMN→BPMN) and Business Rule Tasks
  * (BPMN→DMN).
  *
- * Register as an `additionalModule` when creating the bpmn-js modeler:
+ * The module is built by {@link createModelNavigationModule}, which takes the
+ * {@link ModelNavigationPort} and embeds it as the `modelNavigationPort` DI
+ * value. Registering the provider without its port is therefore
+ * unrepresentable — a host-less consumer that omits the port gets no UI.
  *
  * ```ts
- * import { NavigateToReferencedModelModule } from "@miragon/bpmn-model-navigation";
+ * import { createModelNavigationModule } from "@miragon/bpmn-model-navigation";
  *
- * new BpmnModeler({ additionalModules: [NavigateToReferencedModelModule] });
+ * new BpmnModeler({
+ *     additionalModules: [createModelNavigationModule({ openReference })],
+ * });
  * ```
- *
- * Requires a `vsCodeBridge` DI value with a `postMessage` method (the
- * bpmn-webview provides this so the existing single VS Code API instance
- * is reused).
  */
 import { NavigateContextPadProvider } from "./NavigateContextPadProvider";
+import type { ModelNavigationPort } from "./ModelNavigationPort";
 
 export { extractReference } from "./extractReference";
 export type { ReferenceKind } from "./extractReference";
+export type { ModelNavigationPort, ModelReference } from "./ModelNavigationPort";
 
-export const NavigateToReferencedModelModule = {
-    __init__: ["navigateContextPadProvider"],
-    navigateContextPadProvider: ["type", NavigateContextPadProvider],
-};
+/**
+ * Builds the DI bundle for the given host port. The port rides along as a
+ * `value` so the provider's `["contextPad", "translate", "modelNavigationPort"]`
+ * injection resolves.
+ */
+export function createModelNavigationModule(port: ModelNavigationPort) {
+    return {
+        __init__: ["navigateContextPadProvider"],
+        navigateContextPadProvider: ["type", NavigateContextPadProvider],
+        modelNavigationPort: ["value", port],
+    };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3584,7 +3584,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@miragon/bpmn-model-navigation@workspace:libs/model-navigation"
   dependencies:
-    "@miragon/bpmn-modeler-shared": "workspace:*"
     bpmn-js: "npm:18.19.0"
     typescript: "npm:6.0.3"
     vitest: "npm:4.1.9"


### PR DESCRIPTION
## Issue

Closes #1370

## Description

Prerequisite for inlining the webview libs into the publishable `@miragon/bpmn-modeler` package (#1293): `libs/model-navigation`, `libs/code-link`, and `libs/inline-scripting` no longer import Query/Command protocol classes or the generic `vsCodeBridge` DI token — each defines a narrow port interface (`ModelNavigationPort`, `CodeLinkPort`, `InlineScriptingPort`) and is registered via a `createXxxModule(port)` factory that embeds the port as a DI value, so registering a feature without its host capability is unrepresentable. `bootstrap.ts` becomes the adapter implementing every port by posting the existing protocol commands (and `LintConfigService` moves to a narrow `lintingHost` port), so VS Code / IntelliJ / Theia behave unchanged, while a consumer that omits a capability gets no UI at all — demonstrated by demo-webapp, which now declares only `modelNavigation` (dead code-link/script buttons are gone), and by the dev `MockHost`, which no longer throws on `SyncActivitiesCommand` under `vite serve`.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [ ] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)