### PR TITLE
refactor(bpmn-webview): de-singleton the modeler facade via createModeler

### DIFF
--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
@@ -20,15 +20,37 @@ function fakeLinting() {
     };
 }
 
+/**
+ * A fake diagram-js `Canvas` over a fresh `.djs-container` in the document, so
+ * the service's state classes and pill lookups are asserted per-container
+ * instead of on `document.body` (the multi-instance scoping this test guards).
+ */
+function fakeCanvas(): { getContainer(): HTMLElement } {
+    const container = document.createElement("div");
+    container.className = "djs-container";
+    document.body.appendChild(container);
+    return { getContainer: () => container };
+}
+
+/** Appends a vendor summary pill (wrapped, as bpmn-js-bpmnlint mounts it) to a container. */
+function addPill(container: HTMLElement): HTMLButtonElement {
+    const pill = document.createElement("button");
+    pill.className = "bjsl-button";
+    const wrap = document.createElement("div");
+    wrap.appendChild(pill);
+    container.appendChild(wrap);
+    return pill;
+}
+
 beforeEach(() => {
-    document.body.className = "";
+    document.body.innerHTML = "";
     vi.clearAllMocks();
 });
 
 describe("LintConfigService.render", () => {
     it("overrides linting.lint to return the host-provided results", async () => {
         const linting = fakeLinting();
-        const svc = new LintConfigService(linting, lintingHost, (s) => s);
+        const svc = new LintConfigService(linting, lintingHost, (s) => s, fakeCanvas());
 
         const results = { "label-required": [{ id: "Task_1", message: "x", category: "warn" }] };
         svc.render(results);
@@ -37,19 +59,23 @@ describe("LintConfigService.render", () => {
         await expect(linting.lint!()).resolves.toEqual(results);
     });
 
-    it("activates linting and reveals the button when results arrive", () => {
+    it("activates linting and marks the container active when results arrive", () => {
         const linting = fakeLinting();
+        const canvas = fakeCanvas();
 
-        new LintConfigService(linting, lintingHost, (s) => s).render({});
+        new LintConfigService(linting, lintingHost, (s) => s, canvas).render({});
 
         expect(linting.isActive()).toBe(true);
-        expect(document.body.classList.contains("bpmnlint-active")).toBe(true);
+        expect(canvas.getContainer().classList.contains("bpmnlint-active")).toBe(true);
+        // Never leaks onto the page-global body — that is what let two modelers
+        // clobber each other before scoping.
+        expect(document.body.classList.contains("bpmnlint-active")).toBe(false);
     });
 
     it("re-renders via update() when already active", () => {
         const linting = fakeLinting();
         linting.active = true;
-        const svc = new LintConfigService(linting, lintingHost, (s) => s);
+        const svc = new LintConfigService(linting, lintingHost, (s) => s, fakeCanvas());
 
         svc.render({});
 
@@ -57,22 +83,42 @@ describe("LintConfigService.render", () => {
         expect(linting.toggle).not.toHaveBeenCalled();
     });
 
-    it("deactivates linting and hides the button when results are null", () => {
+    it("deactivates linting and clears the container class when results are null", () => {
         const linting = fakeLinting();
         linting.active = true;
-        document.body.classList.add("bpmnlint-active");
+        const canvas = fakeCanvas();
+        canvas.getContainer().classList.add("bpmnlint-active");
 
-        new LintConfigService(linting, lintingHost, (s) => s).render(null);
+        new LintConfigService(linting, lintingHost, (s) => s, canvas).render(null);
 
         expect(linting.toggle).toHaveBeenCalledWith(false);
-        expect(document.body.classList.contains("bpmnlint-active")).toBe(false);
+        expect(canvas.getContainer().classList.contains("bpmnlint-active")).toBe(false);
     });
 
     it("does not toggle when already inactive and results are null", () => {
         const linting = fakeLinting();
 
-        new LintConfigService(linting, lintingHost, (s) => s).render(null);
+        new LintConfigService(linting, lintingHost, (s) => s, fakeCanvas()).render(null);
 
         expect(linting.toggle).not.toHaveBeenCalled();
+    });
+});
+
+describe("LintConfigService: per-container scoping", () => {
+    it("wraps only its own container's pill and marks only its own container", () => {
+        const canvasA = fakeCanvas();
+        const canvasB = fakeCanvas();
+        const containerA = canvasA.getContainer();
+        const containerB = canvasB.getContainer();
+        addPill(containerA);
+        addPill(containerB);
+
+        new LintConfigService(fakeLinting(), lintingHost, (s) => s, canvasA).render({});
+
+        // The off-button toolbar is built around A's pill, inside A's container.
+        expect(containerA.querySelector(".lint-toolbar")).not.toBeNull();
+        expect(containerB.querySelector(".lint-toolbar")).toBeNull();
+        expect(containerA.classList.contains("bpmnlint-active")).toBe(true);
+        expect(containerB.classList.contains("bpmnlint-active")).toBe(false);
     });
 });

--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
@@ -22,6 +22,16 @@ interface LintingHost {
     setLintingEnabled(enabled: boolean): void;
 }
 
+/**
+ * The slice of diagram-js's `Canvas` this service needs. The state classes and
+ * the vendor pill are scoped to this container (`.djs-container`) rather than
+ * `document.body`, so two modelers on one page never toggle each other's lint
+ * chrome.
+ */
+interface Canvas {
+    getContainer(): HTMLElement;
+}
+
 type Translate = (template: string) => string;
 
 // A slashed circle, painted in `currentColor` so it inherits the chip's text
@@ -49,7 +59,7 @@ const OFF_ICON = `<svg viewBox="0 0 16 16" width="13" height="13" fill="none" st
  * its own overlays optimistically.
  */
 export class LintConfigService {
-    static $inject = ["linting", "lintingHost", "translate"];
+    static $inject = ["linting", "lintingHost", "translate", "canvas"];
 
     private results: LintResults = {};
 
@@ -63,6 +73,7 @@ export class LintConfigService {
         private readonly linting: Linting,
         private readonly lintingHost: LintingHost,
         private readonly translate: Translate,
+        private readonly canvas: Canvas,
     ) {
         // Replace the browser-side lint run with the host's precomputed results.
         // `update()` calls `this.lint()`; returning the stored results makes every
@@ -84,13 +95,13 @@ export class LintConfigService {
                 // Fires `linting.toggle`, which clears the overlays via `update()`.
                 this.linting.toggle(false);
             }
-            document.body.classList.remove("bpmnlint-active");
+            this.canvas.getContainer().classList.remove("bpmnlint-active");
             this.hideOffButton();
             return;
         }
 
         this.results = results;
-        document.body.classList.add("bpmnlint-active");
+        this.canvas.getContainer().classList.add("bpmnlint-active");
         if (this.linting.isActive()) {
             this.linting.update();
         } else {
@@ -111,17 +122,18 @@ export class LintConfigService {
         if (this.linting.isActive()) {
             this.linting.toggle(false);
         }
-        document.body.classList.remove("bpmnlint-active");
+        this.canvas.getContainer().classList.remove("bpmnlint-active");
         this.hideOffButton();
         this.showDisabledChip();
     }
 
     /**
-     * The bpmn-js canvas container, located via the vendor summary pill (created
-     * on module init, so it is present from the first render even while hidden).
+     * The vendor summary pill (created on module init, so it is present from the
+     * first render even while hidden). Scoped to this modeler's canvas container
+     * so a sibling modeler's pill is never picked up.
      */
     private pill(): HTMLElement | null {
-        return document.querySelector<HTMLElement>(".bjsl-button");
+        return this.canvas.getContainer().querySelector<HTMLElement>(".bjsl-button");
     }
 
     /**
@@ -208,11 +220,11 @@ export class LintConfigService {
             container.appendChild(this.disabledChip);
         }
         this.disabledChip.hidden = false;
-        document.body.classList.add("bpmnlint-disabled");
+        this.canvas.getContainer().classList.add("bpmnlint-disabled");
     }
 
     private hideDisabledChip(): void {
-        document.body.classList.remove("bpmnlint-disabled");
+        this.canvas.getContainer().classList.remove("bpmnlint-disabled");
         if (this.disabledChip) {
             this.disabledChip.hidden = true;
         }

--- a/apps/bpmn-webview/src/app/bpmnlint/bpmnlint.css
+++ b/apps/bpmn-webview/src/app/bpmnlint/bpmnlint.css
@@ -1,8 +1,10 @@
 /**
  * Hide-until-configured: the bpmn-js-bpmnlint status button is hidden until a
  * `.bpmnlintrc` is applied, so a workspace with no lint config looks exactly as
- * it did before this feature. LintConfigService.apply() toggles
- * `.bpmnlint-active` on <body> (add on config, remove on null).
+ * it did before this feature. LintConfigService toggles `.bpmnlint-active` on
+ * this modeler's canvas container `.djs-container` (add on config, remove on
+ * null) — container-scoped, not on <body>, so two modelers on one page keep
+ * independent lint chrome.
  */
 .bjsl-button {
     display: none;
@@ -20,7 +22,7 @@
  * in every VS Code theme, so the palette is tuned for a light background and
  * needs no dark-mode variant.
  */
-body.bpmnlint-active .bjsl-button {
+.djs-container.bpmnlint-active .bjsl-button {
     display: inline-flex;
     align-items: center;
     gap: 6px;
@@ -39,43 +41,43 @@ body.bpmnlint-active .bjsl-button {
         color 0.12s ease;
 }
 
-body.bpmnlint-active .bjsl-button .icon {
+.djs-container.bpmnlint-active .bjsl-button .icon {
     margin: 0;
     width: 13px;
     height: 13px;
 }
 
-body.bpmnlint-active .bjsl-button-success {
+.djs-container.bpmnlint-active .bjsl-button-success {
     background-color: #eaf6ea;
     border-color: #cbe7c4;
     color: #2e7d22;
 }
 
-body.bpmnlint-active .bjsl-button-warning {
+.djs-container.bpmnlint-active .bjsl-button-warning {
     background-color: #fbf1d3;
     border-color: #f0dfa3;
     color: #7a5d10;
 }
 
-body.bpmnlint-active .bjsl-button-error {
+.djs-container.bpmnlint-active .bjsl-button-error {
     background-color: #fbe6e6;
     border-color: #f1c2c0;
     color: #c0392b;
 }
 
-body.bpmnlint-active .bjsl-button-success:hover {
+.djs-container.bpmnlint-active .bjsl-button-success:hover {
     background-color: #e0f0df;
 }
 
-body.bpmnlint-active .bjsl-button-warning:hover {
+.djs-container.bpmnlint-active .bjsl-button-warning:hover {
     background-color: #f7e9bf;
 }
 
-body.bpmnlint-active .bjsl-button-error:hover {
+.djs-container.bpmnlint-active .bjsl-button-error:hover {
     background-color: #f7d9d7;
 }
 
-body.bpmnlint-active .bjsl-button:focus-visible {
+.djs-container.bpmnlint-active .bjsl-button:focus-visible {
     outline: 2px solid rgba(0, 120, 212, 0.7);
     outline-offset: 1px;
 }
@@ -84,14 +86,14 @@ body.bpmnlint-active .bjsl-button:focus-visible {
  * Match the issues dropdown to the chip: flat panel, soft hairline border, and a
  * gentle lift so it stays legible floating over the diagram.
  */
-body.bpmnlint-active .bjsl-issues {
+.djs-container.bpmnlint-active .bjsl-issues {
     padding: 10px 12px;
     border: 1px solid #e4e4e4;
     border-radius: 6px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
-body.bpmnlint-active .bjsl-id-hint {
+.djs-container.bpmnlint-active .bjsl-id-hint {
     padding: 1px 6px;
     background-color: #ededed;
     color: #555;
@@ -113,7 +115,7 @@ body.bpmnlint-active .bjsl-id-hint {
     display: none;
 }
 
-body.bpmnlint-active .lint-toolbar {
+.djs-container.bpmnlint-active .lint-toolbar {
     position: absolute;
     bottom: 16px;
     left: 50%;
@@ -124,14 +126,14 @@ body.bpmnlint-active .lint-toolbar {
     z-index: 100;
 }
 
-body.bpmnlint-active .lint-toolbar .bjsl-button {
+.djs-container.bpmnlint-active .lint-toolbar .bjsl-button {
     position: static;
     bottom: auto;
     left: auto;
     transform: none;
 }
 
-body.bpmnlint-active .lint-off-button {
+.djs-container.bpmnlint-active .lint-off-button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -149,13 +151,13 @@ body.bpmnlint-active .lint-off-button {
         color 0.12s ease;
 }
 
-body.bpmnlint-active .lint-off-button:hover {
+.djs-container.bpmnlint-active .lint-off-button:hover {
     background-color: #f7d9d7;
     border-color: #f1c2c0;
     color: #c0392b;
 }
 
-body.bpmnlint-active .lint-off-button:focus-visible {
+.djs-container.bpmnlint-active .lint-off-button:focus-visible {
     outline: 2px solid rgba(0, 120, 212, 0.7);
     outline-offset: 1px;
 }
@@ -168,7 +170,7 @@ body.bpmnlint-active .lint-off-button:focus-visible {
     display: none;
 }
 
-body.bpmnlint-disabled .lint-disabled-chip {
+.djs-container.bpmnlint-disabled .lint-disabled-chip {
     position: absolute;
     bottom: 16px;
     left: 50%;
@@ -190,7 +192,7 @@ body.bpmnlint-disabled .lint-disabled-chip {
     display: none;
 }
 
-body.bpmnlint-disabled .lint-enable-button {
+.djs-container.bpmnlint-disabled .lint-enable-button {
     border: none;
     background: transparent;
     padding: 2px 4px;
@@ -200,6 +202,6 @@ body.bpmnlint-disabled .lint-enable-button {
     cursor: pointer;
 }
 
-body.bpmnlint-disabled .lint-enable-button:hover {
+.djs-container.bpmnlint-disabled .lint-enable-button:hover {
     text-decoration: underline;
 }

--- a/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
+++ b/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
@@ -60,12 +60,14 @@ const FOCUS_STRONG_SVG = `<svg class="canvas-focus-indicator__on" viewBox="0 -96
  *
  * Purely decorative: `aria-hidden` + `pointer-events: none`. The focus move
  * itself already conveys the state to assistive tech, and a clickable glyph
- * would need a tab stop and would steal canvas clicks. There is no dispose
- * API — the indicator lives as long as the webview document.
+ * would need a tab stop and would steal canvas clicks.
  *
  * @param deps Injected parent/focus closures (see {@link CanvasFocusIndicatorDeps}).
+ * @returns A disposer that removes the reticle from the DOM, so a destroyed
+ *   modeler instance leaves no orphaned overlay in its (shared-page) container.
+ *   The event subscriptions die with the modeler's own event bus on destroy.
  */
-export function installCanvasFocusIndicator(deps: CanvasFocusIndicatorDeps): void {
+export function installCanvasFocusIndicator(deps: CanvasFocusIndicatorDeps): () => void {
     const root = document.createElement("div");
     root.className = "canvas-focus-indicator";
     root.setAttribute("aria-hidden", "true");
@@ -91,4 +93,6 @@ export function installCanvasFocusIndicator(deps: CanvasFocusIndicatorDeps): voi
     });
 
     deps.parent.append(root);
+
+    return () => root.remove();
 }

--- a/apps/bpmn-webview/src/app/createModeler.ts
+++ b/apps/bpmn-webview/src/app/createModeler.ts
@@ -1,0 +1,47 @@
+import type { BpmnModelerSetting } from "@miragon/bpmn-modeler-types";
+import type { ModelerCapabilities } from "./capabilities";
+import { BpmnModeler } from "./modeler";
+
+/**
+ * Per-instance configuration for a {@link BpmnModeler}. Everything a modeler
+ * needs to stand up independently of any other instance on the page lives here
+ * — the panel host, the DI extras, and the small set of page-level side effects
+ * a host-less consumer can opt out of. Deliberately minimal: the polished
+ * public API surface is #1375's job (epic #1293).
+ */
+export interface CreateModelerOptions {
+    /** Each instance needs its own panel host; required. */
+    propertiesPanelParent: HTMLElement;
+    /** Extra bpmn-js DI modules (clipboard bridges, translation, demo modules). */
+    extraModules?: unknown[];
+    /** Per-feature host ports; each present port registers its feature's module. */
+    capabilities?: ModelerCapabilities;
+    /**
+     * Lint on/off chip port. Defaults to a no-op so a host-less consumer works
+     * — `LintConfigService.$inject` requires the `lintingHost` DI value.
+     */
+    lintingHost?: { setLintingEnabled(enabled: boolean): void };
+    /**
+     * Page-level colour theme stays outside the facade (it is shared with the
+     * dmn-webview and owns a single `#theme-link`). bootstrap passes
+     * `setColorThemeMode`; a host-less consumer omits it and the setting is inert.
+     */
+    applyColorThemeMode?: (mode: BpmnModelerSetting["colorTheme"]) => void;
+    /**
+     * When `true`, an Escape with nothing focused (`<body>`) re-homes this
+     * canvas. Default off; the single-instance bootstrap passes `true` to keep
+     * today's page-wide behaviour, while a multi-instance consumer leaves it off
+     * so each modeler only reacts to Escapes inside its own subtrees.
+     */
+    handleGlobalEscape?: boolean;
+}
+
+/**
+ * Thin factory over the {@link BpmnModeler} constructor: builds one independent
+ * modeler bound to `container` and its own `propertiesPanelParent`. Engine
+ * selection is a deliberate second step — call {@link BpmnModeler.create} once
+ * the engine is known (the host learns it only after the file arrives).
+ */
+export function createModeler(container: HTMLElement, options: CreateModelerOptions): BpmnModeler {
+    return new BpmnModeler(container, options);
+}

--- a/apps/bpmn-webview/src/app/hostEditorActions.spec.ts
+++ b/apps/bpmn-webview/src/app/hostEditorActions.spec.ts
@@ -4,8 +4,13 @@ import { installHostEditorActions } from "./hostEditorActions";
 
 const trigger = vi.fn<(action: "undo" | "redo") => void>();
 
+// jsdom ships no execCommand; stub it so the native-text-undo fallback is observable.
+const execCommand = vi.fn<(commandId: string) => boolean>().mockReturnValue(true);
+
 beforeEach(() => {
     trigger.mockReset();
+    execCommand.mockClear();
+    document.execCommand = execCommand as unknown as typeof document.execCommand;
     document.body.innerHTML = "";
     installHostEditorActions((action) => trigger(action));
 });
@@ -25,7 +30,7 @@ describe("installHostEditorActions", () => {
         expect(trigger).toHaveBeenCalledWith("redo");
     });
 
-    it("skips while an input owns the caret so the diagram isn't clobbered", () => {
+    it("runs native text undo instead while an input owns the caret", () => {
         const input = document.createElement("input");
         document.body.appendChild(input);
         input.focus();
@@ -33,17 +38,19 @@ describe("installHostEditorActions", () => {
         window.__modelerTriggerEditorAction!("undo");
 
         expect(trigger).not.toHaveBeenCalled();
+        expect(execCommand).toHaveBeenCalledWith("undo");
     });
 
-    it("skips while a contenteditable surface owns the caret", () => {
+    it("runs native text redo instead while a contenteditable surface owns the caret", () => {
         const editable = document.createElement("div");
         editable.contentEditable = "true";
         editable.tabIndex = 0;
         document.body.appendChild(editable);
         editable.focus();
 
-        window.__modelerTriggerEditorAction!("undo");
+        window.__modelerTriggerEditorAction!("redo");
 
         expect(trigger).not.toHaveBeenCalled();
+        expect(execCommand).toHaveBeenCalledWith("redo");
     });
 });

--- a/apps/bpmn-webview/src/app/hostEditorActions.ts
+++ b/apps/bpmn-webview/src/app/hostEditorActions.ts
@@ -17,16 +17,22 @@ declare global {
 /**
  * Installs {@link Window.__modelerTriggerEditorAction}.
  *
- * Skips text-editing surfaces so a host-issued undo never clobbers the diagram's
- * command stack while the caret sits in a property field — mirroring how a real
- * Ctrl+Z would be owned by the focused input rather than the canvas.
+ * Text-editing surfaces never reach the diagram's command stack: while the
+ * caret sits in a property field, a host-issued undo runs the browser's native
+ * text undo instead — mirroring how a real Ctrl+Z would be owned by the focused
+ * input rather than the canvas. Since the host swallowed the real keystroke,
+ * skipping outright would leave the chord doing nothing at all until the field
+ * is blurred. The action names double as `execCommand` ids.
  *
  * @param trigger Runs the bpmn-js editor action (typically
  *   `editorActions.trigger(action)`).
  */
 export function installHostEditorActions(trigger: (action: HostEditorAction) => void): void {
     window.__modelerTriggerEditorAction = (action) => {
-        if (isTextEditingSurface(document.activeElement)) return;
+        if (isTextEditingSurface(document.activeElement)) {
+            document.execCommand?.(action);
+            return;
+        }
         trigger(action);
     };
 }

--- a/apps/bpmn-webview/src/app/index.ts
+++ b/apps/bpmn-webview/src/app/index.ts
@@ -1,4 +1,5 @@
 export * from "./modeler";
+export * from "./createModeler";
 export * from "./capabilities";
 export * from "./viewport";
 export * from "./selection";

--- a/apps/bpmn-webview/src/app/keyboardFocus.spec.ts
+++ b/apps/bpmn-webview/src/app/keyboardFocus.spec.ts
@@ -1,98 +1,189 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { installKeyboardFocus } from "./keyboardFocus";
+import { installKeyboardFocus, type KeyboardFocusDeps } from "./keyboardFocus";
 
-const focusCanvas = vi.fn();
-const isCanvasFocused = vi.fn<() => boolean>();
-const hasSelection = vi.fn<() => boolean>();
-const clearSelection = vi.fn();
-const isSearchPadOpen = vi.fn<() => boolean>();
-const closeSearchPad = vi.fn();
-
-/** Dispatches a bubble-phase keydown on `document`, honouring preventDefault. */
-function dispatchKeydown(key: string, defaultPrevented = false): void {
-    const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
-    if (defaultPrevented) {
-        // Mark as already-handled the way an earlier listener would.
-        event.preventDefault();
-    }
-    document.dispatchEvent(event);
+/**
+ * A fresh set of spy deps over a single-element root appended to the document,
+ * so a keydown fired inside `root` reaches the document listener through bubbling
+ * and passes the root-scoping gate.
+ */
+function makeDeps(
+    root: HTMLElement,
+    overrides: Partial<KeyboardFocusDeps> = {},
+): KeyboardFocusDeps {
+    return {
+        roots: [root],
+        focusCanvas: vi.fn(),
+        isCanvasFocused: vi.fn<() => boolean>().mockReturnValue(false),
+        hasSelection: vi.fn<() => boolean>().mockReturnValue(false),
+        clearSelection: vi.fn(),
+        isSearchPadOpen: vi.fn<() => boolean>().mockReturnValue(false),
+        closeSearchPad: vi.fn(),
+        ...overrides,
+    };
 }
 
-// Install exactly once: installKeyboardFocus adds a document listener with no
-// removal API, so reinstalling per-test would stack duplicate listeners that
-// all fire on the same keydown and inflate the mock call counts.
-beforeAll(() => {
-    installKeyboardFocus({
-        focusCanvas: () => focusCanvas(),
-        isCanvasFocused: () => isCanvasFocused(),
-        hasSelection: () => hasSelection(),
-        clearSelection: () => clearSelection(),
-        isSearchPadOpen: () => isSearchPadOpen(),
-        closeSearchPad: () => closeSearchPad(),
-    });
-});
+/** Dispatches a bubble-phase keydown on `target`, honouring preventDefault. */
+function fireKeydown(target: EventTarget, key: string, defaultPrevented = false): void {
+    const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+    if (defaultPrevented) {
+        event.preventDefault();
+    }
+    target.dispatchEvent(event);
+}
+
+let root: HTMLElement;
+let child: HTMLElement;
+let disposers: Array<() => void>;
 
 beforeEach(() => {
-    focusCanvas.mockReset();
-    isCanvasFocused.mockReset();
-    hasSelection.mockReset();
-    clearSelection.mockReset();
-    isSearchPadOpen.mockReset();
-    closeSearchPad.mockReset();
-    isCanvasFocused.mockReturnValue(false);
-    hasSelection.mockReturnValue(false);
-    isSearchPadOpen.mockReturnValue(false);
+    document.body.innerHTML = "";
+    root = document.createElement("div");
+    child = document.createElement("div");
+    root.appendChild(child);
+    document.body.appendChild(root);
+    disposers = [];
 });
 
+afterEach(() => {
+    disposers.forEach((dispose) => dispose());
+});
+
+/** Installs and records the disposer so no listener leaks into the next test. */
+function install(deps: KeyboardFocusDeps): void {
+    disposers.push(installKeyboardFocus(deps));
+}
+
 describe("installKeyboardFocus", () => {
-    it("focuses the canvas on Escape", () => {
-        dispatchKeydown("Escape");
-        expect(focusCanvas).toHaveBeenCalledTimes(1);
-        expect(closeSearchPad).not.toHaveBeenCalled();
+    it("focuses the canvas on Escape inside a root", () => {
+        const deps = makeDeps(root);
+        install(deps);
+
+        fireKeydown(child, "Escape");
+
+        expect(deps.focusCanvas).toHaveBeenCalledTimes(1);
+        expect(deps.closeSearchPad).not.toHaveBeenCalled();
     });
 
     it("ignores keys other than Escape", () => {
-        dispatchKeydown("a");
-        expect(focusCanvas).not.toHaveBeenCalled();
+        const deps = makeDeps(root);
+        install(deps);
+
+        fireKeydown(child, "a");
+
+        expect(deps.focusCanvas).not.toHaveBeenCalled();
     });
 
     it("does nothing when the Escape was already handled (defaultPrevented)", () => {
-        dispatchKeydown("Escape", true);
-        expect(focusCanvas).not.toHaveBeenCalled();
-        expect(closeSearchPad).not.toHaveBeenCalled();
+        const deps = makeDeps(root);
+        install(deps);
+
+        fireKeydown(child, "Escape", true);
+
+        expect(deps.focusCanvas).not.toHaveBeenCalled();
+        expect(deps.closeSearchPad).not.toHaveBeenCalled();
     });
 
     it("closes the search pad then focuses the canvas when the pad is open", () => {
-        isSearchPadOpen.mockReturnValue(true);
-        dispatchKeydown("Escape");
-        expect(closeSearchPad).toHaveBeenCalledTimes(1);
-        expect(focusCanvas).toHaveBeenCalledTimes(1);
+        const deps = makeDeps(root, {
+            isSearchPadOpen: vi.fn<() => boolean>().mockReturnValue(true),
+        });
+        install(deps);
+
+        fireKeydown(child, "Escape");
+
+        expect(deps.closeSearchPad).toHaveBeenCalledTimes(1);
+        expect(deps.focusCanvas).toHaveBeenCalledTimes(1);
     });
 
     it("keeps the selection when Escape only re-homes focus onto the canvas", () => {
         // Focus sits e.g. in the properties panel of the selected element —
         // clearing the selection here would blank that panel mid-edit.
-        isCanvasFocused.mockReturnValue(false);
-        hasSelection.mockReturnValue(true);
-        dispatchKeydown("Escape");
-        expect(focusCanvas).toHaveBeenCalledTimes(1);
-        expect(clearSelection).not.toHaveBeenCalled();
+        const deps = makeDeps(root, {
+            isCanvasFocused: vi.fn<() => boolean>().mockReturnValue(false),
+            hasSelection: vi.fn<() => boolean>().mockReturnValue(true),
+        });
+        install(deps);
+
+        fireKeydown(child, "Escape");
+
+        expect(deps.focusCanvas).toHaveBeenCalledTimes(1);
+        expect(deps.clearSelection).not.toHaveBeenCalled();
     });
 
     it("clears the selection when Escape hits the already-focused canvas", () => {
-        isCanvasFocused.mockReturnValue(true);
-        hasSelection.mockReturnValue(true);
-        dispatchKeydown("Escape");
-        expect(clearSelection).toHaveBeenCalledTimes(1);
-        expect(focusCanvas).not.toHaveBeenCalled();
+        const deps = makeDeps(root, {
+            isCanvasFocused: vi.fn<() => boolean>().mockReturnValue(true),
+            hasSelection: vi.fn<() => boolean>().mockReturnValue(true),
+        });
+        install(deps);
+
+        fireKeydown(child, "Escape");
+
+        expect(deps.clearSelection).toHaveBeenCalledTimes(1);
+        expect(deps.focusCanvas).not.toHaveBeenCalled();
     });
 
     it("leaves an empty selection alone on the focused canvas", () => {
-        isCanvasFocused.mockReturnValue(true);
-        hasSelection.mockReturnValue(false);
-        dispatchKeydown("Escape");
-        expect(clearSelection).not.toHaveBeenCalled();
-        expect(focusCanvas).toHaveBeenCalledTimes(1);
+        const deps = makeDeps(root, {
+            isCanvasFocused: vi.fn<() => boolean>().mockReturnValue(true),
+            hasSelection: vi.fn<() => boolean>().mockReturnValue(false),
+        });
+        install(deps);
+
+        fireKeydown(child, "Escape");
+
+        expect(deps.clearSelection).not.toHaveBeenCalled();
+        expect(deps.focusCanvas).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("installKeyboardFocus: root scoping", () => {
+    it("ignores an Escape targeting a node outside all roots", () => {
+        const deps = makeDeps(root);
+        install(deps);
+
+        // document.body is not contained by root; handleGlobalEscape defaults off.
+        fireKeydown(document.body, "Escape");
+
+        expect(deps.focusCanvas).not.toHaveBeenCalled();
+    });
+
+    it("handles a body-targeted Escape only when handleGlobalEscape is set", () => {
+        const deps = makeDeps(root, { handleGlobalEscape: true });
+        install(deps);
+
+        fireKeydown(document.body, "Escape");
+
+        expect(deps.focusCanvas).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not cross-fire between two independent instances", () => {
+        const rootB = document.createElement("div");
+        const childB = document.createElement("div");
+        rootB.appendChild(childB);
+        document.body.appendChild(rootB);
+
+        const depsA = makeDeps(root);
+        const depsB = makeDeps(rootB);
+        install(depsA);
+        install(depsB);
+
+        fireKeydown(child, "Escape");
+
+        expect(depsA.focusCanvas).toHaveBeenCalledTimes(1);
+        expect(depsB.focusCanvas).not.toHaveBeenCalled();
+    });
+});
+
+describe("installKeyboardFocus: disposer", () => {
+    it("removes the document listener so later Escapes are ignored", () => {
+        const deps = makeDeps(root);
+        const dispose = installKeyboardFocus(deps);
+
+        dispose();
+        fireKeydown(child, "Escape");
+
+        expect(deps.focusCanvas).not.toHaveBeenCalled();
     });
 });

--- a/apps/bpmn-webview/src/app/keyboardFocus.ts
+++ b/apps/bpmn-webview/src/app/keyboardFocus.ts
@@ -6,6 +6,16 @@
  * exist until the modeler is created).
  */
 export interface KeyboardFocusDeps {
+    /**
+     * The DOM subtrees this instance owns — the canvas container and its
+     * properties-panel parent. An Escape is only handled when it originates
+     * inside one of these, so multiple modelers on one page never cross-fire:
+     * an Escape in panel A re-homes canvas A, not canvas B. Escape must be
+     * caught in the properties panel (a *sibling* of the canvas, not a
+     * descendant), which is why this is a document listener scoped by roots
+     * rather than a container listener.
+     */
+    roots: HTMLElement[];
     /** Moves DOM focus onto the canvas SVG (`canvas.focus()`). */
     focusCanvas: () => void;
     /** Whether the canvas SVG currently holds DOM focus (`canvas.isFocused()`). */
@@ -18,6 +28,13 @@ export interface KeyboardFocusDeps {
     isSearchPadOpen: () => boolean;
     /** Closes the SearchPad (restores the cached selection). */
     closeSearchPad: () => void;
+    /**
+     * When `true`, an Escape fired with focus on `<body>` (nothing focused) is
+     * also handled — the single-instance host wants a stray Escape anywhere on
+     * the page to re-home the canvas. Defaults to `false` so a library consumer
+     * hosting several modelers only reacts to Escapes inside its own roots.
+     */
+    handleGlobalEscape?: boolean;
 }
 
 /**
@@ -40,11 +57,22 @@ export interface KeyboardFocusDeps {
  * The listener runs in the **bubble** phase and stays deliberately passive
  * (no preventDefault/stopPropagation) so host Escape behaviour is untouched.
  *
- * @param deps Injected focus/selection/search-pad closures (see {@link KeyboardFocusDeps}).
+ * @param deps Injected roots + focus/selection/search-pad closures (see {@link KeyboardFocusDeps}).
+ * @returns A disposer that removes the document listener, so a destroyed
+ *   modeler instance stops reacting to Escapes.
  */
-export function installKeyboardFocus(deps: KeyboardFocusDeps): void {
-    document.addEventListener("keydown", (e: KeyboardEvent) => {
+export function installKeyboardFocus(deps: KeyboardFocusDeps): () => void {
+    const handler = (e: KeyboardEvent): void => {
         if (e.key !== "Escape") return;
+
+        // Scope to this instance's own subtrees: an Escape targeting another
+        // modeler (or unrelated page chrome) must not re-home our canvas. The
+        // single-instance host opts into also handling body-targeted Escapes so
+        // a keystroke with nothing focused still returns to the canvas.
+        const target = e.target;
+        const inRoots = target instanceof Node && deps.roots.some((root) => root.contains(target));
+        const isGlobalBody = deps.handleGlobalEscape === true && target === document.body;
+        if (!inRoots && !isGlobalBody) return;
 
         // Something already handled this Escape. Covers CodeMirror 6 (FEEL
         // editor), whose Escape binding preventDefault-s only while its
@@ -83,5 +111,7 @@ export function installKeyboardFocus(deps: KeyboardFocusDeps): void {
         }
 
         deps.focusCanvas();
-    });
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
 }

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -24,14 +24,15 @@ import {
     OpenScriptEditorsStore,
     ScriptSourceWatcher,
 } from "@miragon/bpmn-modeler-inline-scripting";
-import type { ModelerCapabilities } from "./capabilities";
 import { capabilityModules } from "./capabilityModules";
 import { ViewportManager } from "./viewport";
 import { SelectionManager } from "./selection";
 import { RootElementManager } from "./rootElement";
 import { deriveEngines } from "./engines";
 import LintModule from "./bpmnlint";
-import { setColorThemeMode } from "@miragon/bpmn-modeler-types";
+import { installKeyboardFocus } from "./keyboardFocus";
+import { installCanvasFocusIndicator } from "./canvasFocusIndicator";
+import type { CreateModelerOptions } from "./createModeler";
 
 const DEFAULT_SETTINGS: BpmnModelerSetting = {
     alignToOrigin: false,
@@ -39,24 +40,22 @@ const DEFAULT_SETTINGS: BpmnModelerSetting = {
     colorTheme: "automatic",
 };
 
-const MODELER_OPTIONS = {
-    container: "#js-canvas",
-    propertiesPanel: {
-        parent: "#js-properties-panel",
-    },
-    alignToOrigin: {
-        alignOnSave: false,
-        offset: 150,
-        tolerance: 50,
-    },
+// Align-to-origin plugin config; the container / panel parent are per-instance
+// HTMLElements resolved from the constructor options in {@link BpmnModeler.create}.
+const ALIGN_TO_ORIGIN_OPTIONS = {
+    alignOnSave: false,
+    offset: 150,
+    tolerance: 50,
 };
 
 /**
- * Encapsulates the bpmn-js modeler instance and all operations on it.
+ * Encapsulates one bpmn-js modeler instance and all operations on it.
  *
- * A single instance is created at application startup and shared via the
- * module-level export in {@link index.ts}.  All methods throw
- * {@link NoModelerError} if called before {@link create}.
+ * Per-instance by construction: it is bound to its own `container` and
+ * `propertiesPanelParent` (see {@link CreateModelerOptions}), so several
+ * modelers can coexist on a page — the future in-page diff view wants two. Use
+ * {@link createModeler} as the factory. All methods throw {@link NoModelerError}
+ * if called before {@link create}, and {@link destroy} tears the instance down.
  *
  * Viewport and selection concerns are delegated to {@link ViewportManager}
  * and {@link SelectionManager}, accessible via the corresponding getters
@@ -80,6 +79,19 @@ export class BpmnModeler {
     // inline script). Kept as an injected callback rather than a host import so
     // the modeler stays constructible in tests and the standalone dev browser.
     private onWarningSink?: (message: string) => void;
+
+    // Teardown for the container-scoped focus features installed in create();
+    // run on re-create (to avoid stacking) and on destroy().
+    private focusDisposers: Array<() => void> = [];
+
+    /**
+     * @param container The canvas host element (bpmn-js `container`).
+     * @param options Per-instance config — see {@link CreateModelerOptions}.
+     */
+    constructor(
+        private readonly container: HTMLElement,
+        private readonly options: CreateModelerOptions,
+    ) {}
 
     /**
      * Access the viewport manager after {@link create}.
@@ -118,32 +130,58 @@ export class BpmnModeler {
     }
 
     /**
-     * Creates and mounts a new bpmn-js modeler for the given execution engine.
+     * Creates and mounts the bpmn-js modeler for the given execution engine.
+     *
+     * Engine selection is a second step (not a constructor arg) because the host
+     * detects the engine only after the file arrives, while closures that need
+     * the facade (flush responder, protocol capabilities) are wired before that.
+     * The per-instance DI extras and capabilities come from the constructor
+     * options. Re-`create()` disposes the prior instance's focus installs first.
      *
      * @param engine Camunda engine version — `"c7"` for Camunda Platform 7,
      *   `"c8"` for Camunda Cloud 8.
-     * @param extraModules Optional bpmn-js DI modules (e.g. clipboard bridges).
-     * @param capabilities Optional per-feature host ports; each present port
-     *   registers its feature's DI module (see {@link capabilityModules}).
      * @throws {UnsupportedEngineError} If the engine string is not recognised.
      */
-    create(engine: Engine, extraModules?: any[], capabilities?: ModelerCapabilities): void {
+    create(engine: Engine): void {
+        this.disposeFocusFeatures();
+
+        // The linting toggle is always registered (LintModule) but its host port
+        // is optional; a no-op keeps LintConfigService's DI resolvable host-less.
+        const lintingHostModule = {
+            lintingHost: [
+                "value",
+                this.options.lintingHost ?? { setLintingEnabled: () => undefined },
+            ],
+        };
+        // Per-instance panel host, so id-coupled DI services (scriptEditorButtons)
+        // observe this modeler's own panel instead of the first `#js-properties-panel`.
+        const propertiesPanelRootModule = {
+            propertiesPanelRoot: ["value", this.options.propertiesPanelParent],
+        };
         const commonModules = [
             TokenSimulationModule,
             LintModule,
             ElementTemplateChooserModule,
             AppendMenuModule,
             FlowNavigationModule,
+            lintingHostModule,
+            propertiesPanelRootModule,
         ];
-        const capModules = capabilityModules(engine, capabilities);
-        const extra = extraModules ?? [];
+        const capModules = capabilityModules(engine, this.options.capabilities);
+        const extra = (this.options.extraModules as any[]) ?? [];
+
+        const modelerOptions = {
+            container: this.container,
+            propertiesPanel: { parent: this.options.propertiesPanelParent },
+            alignToOrigin: ALIGN_TO_ORIGIN_OPTIONS,
+        };
 
         this.engine = engine;
 
         switch (engine) {
             case "c7": {
                 this.modeler = new BpmnModeler7({
-                    ...MODELER_OPTIONS,
+                    ...modelerOptions,
                     additionalModules: [
                         ...commonModules,
                         CreateAppendElementTemplatesModule,
@@ -157,7 +195,7 @@ export class BpmnModeler {
             }
             case "c8": {
                 this.modeler = new BpmnModeler8({
-                    ...MODELER_OPTIONS,
+                    ...modelerOptions,
                     additionalModules: [...commonModules, ...capModules, ...extra],
                 });
                 break;
@@ -172,6 +210,8 @@ export class BpmnModeler {
         this._selection = new SelectionManager(accessor);
         this._rootElement = new RootElementManager(accessor);
 
+        this.installFocusFeatures();
+
         /**
          * Apply default favourites immediately after creation.
          */
@@ -181,6 +221,85 @@ export class BpmnModeler {
                 appendMenuOverride.setFavourites(this.settings.favouriteBpmnElements);
             }
         }
+    }
+
+    /**
+     * Composes the container-scopable focus features onto the fresh modeler:
+     * the "Escape → focus canvas" guard and the canvas focus reticle. Both are
+     * scoped to this instance's canvas container and panel parent so several
+     * modelers on one page never cross-fire. Disposers are recorded so a
+     * re-`create()` or {@link destroy} tears them down.
+     */
+    private installFocusFeatures(): void {
+        const canvas = this.getModeler().get<{
+            getContainer(): HTMLElement;
+            focus(): void;
+            isFocused(): boolean;
+        }>("canvas");
+        const canvasContainer = canvas.getContainer();
+        const eventBus = () => this.getModeler().get<any>("eventBus");
+        const selection = () => this.getModeler().get<{ get(): unknown[] }>("selection");
+
+        // Escape re-homes focus onto the canvas so keyboard-driven modelling
+        // (A/N/arrows, owned by bpmn-js's canvas-scoped Keyboard service) works
+        // even from the panel or a search field; a further Escape on the focused
+        // canvas clears the selection. Roots scope the guard to this instance.
+        this.focusDisposers.push(
+            installKeyboardFocus({
+                roots: [canvasContainer, this.options.propertiesPanelParent],
+                handleGlobalEscape: this.options.handleGlobalEscape ?? false,
+                focusCanvas: () => canvas.focus(),
+                isCanvasFocused: () => canvas.isFocused(),
+                hasSelection: () => selection().get().length > 0,
+                clearSelection: () =>
+                    this.getModeler()
+                        .get<{ select(elements: null): void }>("selection")
+                        .select(null),
+                isSearchPadOpen: () =>
+                    this.getModeler().get<{ isOpen(): boolean }>("searchPad").isOpen(),
+                closeSearchPad: () => this.getModeler().get<{ close(): void }>("searchPad").close(),
+            }),
+        );
+
+        // The reticle beside the "Open minimap" control lights up green while the
+        // canvas holds keyboard focus with nothing selected. It subscribes to
+        // diagram-js's deduplicated `canvas.focus.changed` rather than a
+        // container-level focusin (which would false-positive on the lint chip).
+        this.focusDisposers.push(
+            installCanvasFocusIndicator({
+                parent: canvasContainer,
+                isFocused: () => canvas.isFocused(),
+                onFocusChanged: (listener) =>
+                    eventBus().on("canvas.focus.changed", (e: { focused: boolean }) =>
+                        listener(e.focused),
+                    ),
+                hasSelection: () => selection().get().length > 0,
+                onSelectionChanged: (listener) =>
+                    eventBus().on("selection.changed", (e: { newSelection: unknown[] }) =>
+                        listener(e.newSelection.length > 0),
+                    ),
+            }),
+        );
+    }
+
+    private disposeFocusFeatures(): void {
+        for (const dispose of this.focusDisposers.splice(0)) {
+            dispose();
+        }
+    }
+
+    /**
+     * Tears the instance down: disposes the focus features and destroys the
+     * underlying bpmn-js modeler (which frees its event bus, DI graph, and DOM).
+     * A destroyed facade throws {@link NoModelerError} from every accessor.
+     */
+    destroy(): void {
+        this.disposeFocusFeatures();
+        this.modeler?.destroy();
+        this.modeler = undefined;
+        this._viewport = undefined;
+        this._selection = undefined;
+        this._rootElement = undefined;
     }
 
     /**
@@ -330,10 +449,12 @@ export class BpmnModeler {
         this.settings = { ...this.settings, ...settings };
 
         /**
-         * Apply color theme mode change immediately.
+         * Apply color theme mode change immediately. Page-level theme state
+         * lives outside the facade (shared with the dmn-webview), so we call the
+         * host-provided sink rather than the module singleton directly.
          */
         if (settings.colorTheme !== undefined) {
-            setColorThemeMode(this.settings.colorTheme);
+            this.options.applyColorThemeMode?.(this.settings.colorTheme);
         }
 
         /**

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.spec.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.spec.ts
@@ -147,6 +147,25 @@ describe("copy and paste in the FEEL expression editor", () => {
     });
 });
 
+describe("idempotent install", () => {
+    it("a second install registers no additional handlers", () => {
+        // The polyfill acts on `document` and monkey-patches execCommand, so a
+        // repeat call must be a no-op rather than stack a second handler.
+        const secondRequest = vi.fn().mockResolvedValue("");
+        installContentEditableClipboardPolyfill(
+            () => secondRequest(),
+            () => undefined,
+        );
+
+        focusedEditor().dispatchEvent(ctrl("v"));
+
+        // Only the original install's handler fired; the second install's own
+        // request fn is never wired.
+        expect(secondRequest).not.toHaveBeenCalled();
+        expect(mocks.requestClipboard).toHaveBeenCalledTimes(1);
+    });
+});
+
 describe("paste triggered via the VS Code command palette", () => {
     it("writes clipboard text into the focused FEEL editor", () => {
         focusedEditor();

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
@@ -54,10 +54,22 @@ function handlePaste(el: HTMLElement, requestClipboard: () => Promise<string>): 
  * @param requestClipboard Async callback that reads clipboard text via the extension host.
  * @param writeClipboard Callback that writes text to the extension host clipboard.
  */
+let polyfillInstalled = false;
+
 export function installContentEditableClipboardPolyfill(
     requestClipboard: () => Promise<string>,
     writeClipboard: (text: string) => void,
 ): void {
+    // Page-global by nature: the two document listeners and the execCommand
+    // monkey-patch below act on `document`, so a second install would stack
+    // duplicate handlers and double-wrap execCommand. This stays owned by the
+    // single-instance bootstrap (not the per-instance facade); the guard makes
+    // a repeat call a no-op should a multi-instance consumer wire it twice.
+    if (polyfillInstalled) {
+        return;
+    }
+    polyfillInstalled = true;
+
     let handled = false;
 
     document.addEventListener(

--- a/apps/bpmn-webview/src/app/state.spec.ts
+++ b/apps/bpmn-webview/src/app/state.spec.ts
@@ -6,7 +6,11 @@ import { WebviewStateManager } from "./state";
  * Builds a `WebviewStateManager` wired to spies for the collaborators
  * that `restoreViewport`, `captureViewState`, and `applyViewState` touch.
  */
-function setup(savedState: unknown, applied = true) {
+function setup(
+    savedState: unknown,
+    applied = true,
+    panelRoot: HTMLElement = document.createElement("div"),
+) {
     const getState = vi.fn().mockReturnValue(savedState);
     const updateState = vi.fn();
     const setState = vi.fn();
@@ -18,16 +22,18 @@ function setup(savedState: unknown, applied = true) {
     const setRootElementById = vi.fn().mockReturnValue(true);
     const getRootElementId = vi.fn().mockReturnValue(undefined);
     const onRootChanged = vi.fn();
+    const onViewportChanged = vi.fn();
+    const onSelectionChanged = vi.fn();
     const getSelectedElementIds = vi.fn().mockReturnValue([]);
     const selectElementsByIds = vi.fn();
     const host = { getState, updateState, setState } as any;
     const modeler = {
-        viewport: { setViewport, fitViewport, getViewport },
+        viewport: { setViewport, fitViewport, getViewport, onViewportChanged },
         rootElement: { setRootElementById, getRootElementId, onRootChanged },
-        selection: { getSelectedElementIds, selectElementsByIds },
+        selection: { getSelectedElementIds, selectElementsByIds, onSelectionChanged },
     } as any;
     return {
-        manager: new WebviewStateManager(host, modeler),
+        manager: new WebviewStateManager(host, modeler, panelRoot),
         setViewport,
         fitViewport,
         setRootElementById,
@@ -181,6 +187,48 @@ describe("WebviewStateManager.captureViewState / applyViewState", () => {
         manager.applyViewState(snapshot);
         // setRootElementById(undefined) returns false — no plane switch
         expect(setRootElementById).toHaveBeenCalledWith(undefined);
+    });
+});
+
+describe("WebviewStateManager panel scoping", () => {
+    /** A panel host with a scroll container, plus a decoy panel elsewhere. */
+    function panels() {
+        const panelRoot = document.createElement("div");
+        const scroll = document.createElement("div");
+        scroll.className = "bio-properties-panel-scroll-container";
+        panelRoot.appendChild(scroll);
+        document.body.appendChild(panelRoot);
+
+        const otherPanel = document.createElement("div");
+        const otherScroll = document.createElement("div");
+        otherScroll.className = "bio-properties-panel-scroll-container";
+        otherPanel.appendChild(otherScroll);
+        document.body.appendChild(otherPanel);
+
+        return { panelRoot, scroll, otherScroll, otherPanel };
+    }
+
+    it("binds scroll persistence to the scroll container within the passed panelRoot", () => {
+        vi.useFakeTimers();
+        const { panelRoot, scroll, otherScroll } = panels();
+        const { manager, updateState } = setup(undefined, true, panelRoot);
+
+        manager.startPersisting();
+
+        Object.defineProperty(scroll, "scrollTop", { value: 42, configurable: true });
+        scroll.dispatchEvent(new Event("scroll"));
+        vi.advanceTimersByTime(100);
+        expect(updateState).toHaveBeenCalledWith({ panelScroll: 42 });
+
+        // A scroll in a foreign panel must not be persisted as ours.
+        updateState.mockClear();
+        Object.defineProperty(otherScroll, "scrollTop", { value: 99, configurable: true });
+        otherScroll.dispatchEvent(new Event("scroll"));
+        vi.advanceTimersByTime(100);
+        expect(updateState).not.toHaveBeenCalled();
+
+        vi.useRealTimers();
+        document.body.innerHTML = "";
     });
 });
 

--- a/apps/bpmn-webview/src/app/state.ts
+++ b/apps/bpmn-webview/src/app/state.ts
@@ -39,6 +39,10 @@ export class WebviewStateManager {
     constructor(
         private readonly host: HostApi<WebviewState, Command | Query>,
         private readonly modeler: BpmnModeler,
+        // The properties-panel host element. The scroll container is looked up
+        // within it rather than via `document` so a second modeler's panel on
+        // the same page is never mistaken for this one's.
+        private readonly panelRoot: HTMLElement,
     ) {}
 
     /**
@@ -110,7 +114,7 @@ export class WebviewStateManager {
             return;
         }
         requestAnimationFrame(() => {
-            const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
+            const container = this.panelRoot.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
             if (!container) {
                 return;
             }
@@ -218,7 +222,7 @@ export class WebviewStateManager {
      * `setState` synchronously writes to VS Code workspace storage.
      */
     private subscribePanelScroll(): void {
-        const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
+        const container = this.panelRoot.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
         if (!container) {
             return;
         }
@@ -238,7 +242,7 @@ export class WebviewStateManager {
      * discarded by filtering for `.bio-properties-panel-group-header`.
      */
     private subscribeGroupExpansion(): void {
-        const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
+        const container = this.panelRoot.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
         if (!container) {
             return;
         }

--- a/apps/bpmn-webview/src/app/viewport.spec.ts
+++ b/apps/bpmn-webview/src/app/viewport.spec.ts
@@ -8,9 +8,12 @@ import { ViewportManager } from "./viewport";
  * size (`outer`). The setter is a spy so the computed viewbox can be asserted.
  */
 function setup(inner: Rect, outer: { width: number; height: number }) {
+    // The palette lookup is scoped to this canvas's own container, so the fake
+    // canvas carries one; tests append their palette into it (or a decoy outside).
+    const container = document.createElement("div");
     const viewbox = vi.fn((box?: unknown) => (box ? undefined : { inner, outer }));
     const zoom = vi.fn();
-    const canvas = { viewbox, zoom };
+    const canvas = { viewbox, zoom, getContainer: () => container };
     const listeners: Record<string, (event: any) => void> = {};
     const eventBus = {
         on: (event: string, handler: (event: any) => void) => {
@@ -25,7 +28,7 @@ function setup(inner: Rect, outer: { width: number; height: number }) {
     /** Fires a `canvas.viewbox.changed` event at the manager's subscriber. */
     const emitViewboxChanged = (box: Partial<Rect>) =>
         listeners["canvas.viewbox.changed"]({ viewbox: box });
-    return { manager, viewbox, zoom, emitViewboxChanged };
+    return { manager, viewbox, zoom, emitViewboxChanged, container };
 }
 
 type Rect = { x: number; y: number; width: number; height: number; scale?: number };
@@ -94,14 +97,14 @@ describe("ViewportManager.fitViewport", () => {
 
     // An unstyled palette is a full-width block; reserving it collapsed the
     // fit to an invisible diagram on a perfectly sized canvas.
-    it("ignores an unstyled, full-width palette", () => {
+    it("ignores an unstyled, full-width palette inside its own container", () => {
+        const inner = { x: 0, y: 0, width: 1176, height: 537 };
+        const { manager, viewbox, container } = setup(inner, { width: 1000, height: 800 });
+
         const palette = document.createElement("div");
         palette.className = "djs-palette";
-        document.body.appendChild(palette);
+        container.appendChild(palette);
         vi.spyOn(palette, "getBoundingClientRect").mockReturnValue({ width: 1000 } as DOMRect);
-
-        const inner = { x: 0, y: 0, width: 1176, height: 537 };
-        const { manager, viewbox } = setup(inner, { width: 1000, height: 800 });
 
         manager.fitViewport();
 
@@ -109,7 +112,30 @@ describe("ViewportManager.fitViewport", () => {
         const scale = 1000 / box.width;
         // At least half the canvas stays available, so the diagram is visible.
         expect(inner.width * scale).toBeGreaterThan(400);
-        palette.remove();
+    });
+
+    // With two modelers on a page a bare document query would measure the
+    // first (foreign) palette; scoping to the container ignores it entirely.
+    it("ignores a palette that belongs to another modeler's container", () => {
+        const inner = { x: 5000, y: 4000, width: 400, height: 200 };
+        const { manager, viewbox } = setup(inner, { width: 1000, height: 800 });
+
+        // A full-width decoy palette elsewhere in the document (not in our
+        // container). If the query were unscoped it would collapse the fit.
+        const decoy = document.createElement("div");
+        decoy.className = "djs-palette";
+        document.body.appendChild(decoy);
+        vi.spyOn(decoy, "getBoundingClientRect").mockReturnValue({ width: 1000 } as DOMRect);
+
+        manager.fitViewport();
+
+        const box = viewbox.mock.calls.at(-1)?.[0] as Rect;
+        const scale = 1000 / box.width;
+        // The 50px fallback is used (our container has no palette), not the decoy.
+        expect(scale).toBe(1);
+        const leftPx = project(inner.x, box.x, scale);
+        expect(leftPx).toBeGreaterThanOrEqual(70);
+        decoy.remove();
     });
 
     it("zooms out a diagram larger than the inset area to fit", () => {

--- a/apps/bpmn-webview/src/app/viewport.ts
+++ b/apps/bpmn-webview/src/app/viewport.ts
@@ -115,8 +115,12 @@ export class ViewportManager {
         // inset keeps half the canvas available whatever the chrome reports.
         const maxInsetX = outer.width / 4;
         const maxInsetY = outer.height / 4;
+        // Scope the palette lookup to this modeler's own container: with two
+        // modelers on a page a bare `document.querySelector` would measure the
+        // first palette, insetting the wrong canvas.
         const paletteWidth =
-            document.querySelector(".djs-palette")?.getBoundingClientRect().width ?? 50;
+            canvas.getContainer().querySelector(".djs-palette")?.getBoundingClientRect().width ??
+            50;
         const inset = {
             top: Math.min(40, maxInsetY),
             right: Math.min(40, maxInsetX),

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -57,15 +57,15 @@ import {
     initTheme,
     installPanelShortcuts,
     observeCanvasSize,
+    setColorThemeMode,
 } from "@miragon/bpmn-modeler-types";
 import { VsCodeClipboardModule, LabelClipboardModule } from "@miragon/bpmn-modeler-clipboard";
 import { TranslateModule, i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
 import { extras as i18nExtras } from "@miragon/bpmn-modeler-i18n-extras";
 import {
     BpmnModeler,
-    installCanvasFocusIndicator,
+    createModeler,
     installContentEditableClipboardPolyfill,
-    installKeyboardFocus,
     UnsupportedEngineError,
 } from "./app";
 import type { HostApi } from "@miragon/bpmn-modeler-shared";
@@ -76,762 +76,6 @@ import { DiffMode } from "./app/diff/DiffMode";
 import type { LintConfigService } from "./app/bpmnlint";
 import { installHostEditorActions } from "./app/hostEditorActions";
 import { WebviewStateManager } from "./app/state";
-
-// Injected by bootstrap(); the app/demo entry chooses the concrete host.
-let host: HostApi<WebviewState, Command | Query>;
-let injectedModules: unknown[] | undefined;
-// Injected capabilities, or undefined ⇒ the full protocol adapter is used, so
-// every real host (VS Code, IntelliJ, Theia) keeps all features unchanged.
-let injectedCapabilities: ModelerCapabilities | undefined;
-
-// Global safety net for throws the per-message try/catch in onReceiveMessage
-// can't reach — bpmn-js event-bus callbacks (e.g. onCommandStackChanged) run
-// outside it, so an error there would otherwise vanish into the webview console
-// and never reach the output channel.
-function registerGlobalErrorHandlers(): void {
-    window.addEventListener("error", (event: ErrorEvent) => {
-        host.postMessage(
-            new LogErrorCommand(`Unhandled error: ${event.message}`, event.error?.stack),
-        );
-    });
-    window.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
-        const reason: unknown = event.reason;
-        host.postMessage(
-            new LogErrorCommand(
-                `Unhandled promise rejection: ${reason instanceof Error ? reason.message : String(reason)}`,
-                reason instanceof Error ? reason.stack : undefined,
-            ),
-        );
-    });
-}
-
-// Best-effort flush of the outbound sync debounce when the webview is hidden
-// (tab switch / close). Reliable in the persistent JCEF host; in VS Code the
-// webview context may be torn down mid-export, so this is a best-effort mitigation
-// of the ≤300ms hide-loss window — the save path is fully covered by the flush
-// protocol instead.
-document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "hidden") {
-        void debouncedSendXmlChanges.flush();
-        stateManager?.flushViewport();
-    }
-});
-
-/**
- * Singleton modeler instance shared across all message handlers.
- * Created during {@link initializeModeler}; `undefined` until then.
- */
-const bpmnModeler = new BpmnModeler();
-
-/**
- * Re-imports the XML while preserving the user's drill-down plane,
- * viewbox, and selection. The snapshot is taken from the live canvas
- * inside the debounced function so a burst of host pushes captures
- * once, not from a half-imported intermediate.
- */
-async function reloadXmlPreservingView(bpmn: string): Promise<void> {
-    const snapshot = stateManager?.captureViewState();
-    await openXml(bpmn);
-    if (snapshot) {
-        stateManager.applyViewState(snapshot);
-    }
-}
-
-/**
- * Debounce the update of the XML content to avoid too many updates.
- *
- * @param bpmn Latest BPMN XML string received from the backend.
- * @throws {NoModelerError} If the modeler is not available.
- */
-const debouncedUpdateXML = asyncDebounce(reloadXmlPreservingView, 100);
-
-/**
- * Debounces the outbound document sync so a burst of model changes (e.g.
- * properties-panel typing) collapses into one full export + host write instead
- * of one per keystroke. `maxWait` bounds starvation: sustained typing still
- * syncs at least once per second. 300ms/1000ms mirrors the script-streaming
- * debounce above. The host recovers the sub-300ms tail via the flush protocol
- * ({@link respondToFlush}) so a save never persists stale XML.
- */
-const debouncedSendXmlChanges = asyncDebounce(sendXmlChanges, 300, { maxWait: 1000 });
-
-/**
- * Answers a host {@link FlushDocumentQuery} on the save/close path: exports and
- * returns the pending XML (or reports nothing-pending). The `pending()` gate and
- * cancel-and-carry rationale live in {@link createFlushResponder}.
- */
-const respondToFlush = createFlushResponder(
-    {
-        isReady: () => modelerIsInitialized,
-        hasPendingSync: () => debouncedSendXmlChanges.pending(),
-        cancelPendingSync: () => debouncedSendXmlChanges.cancel(),
-        exportXml: () => bpmnModeler.exportDiagram(),
-    },
-    (reply) => host.postMessage(reply),
-);
-
-// Create resolver to wait for the response from the backend.
-const bpmnFileResolver = createResolver<BpmnFileQuery>();
-
-let modelerIsInitialized = false;
-
-// A FocusElementQuery can arrive before the import finishes (host opens the
-// editor and focuses in one tick); apply it once the modeler is ready.
-let pendingFocusId: string | undefined;
-
-// Separate resolvers for element clipboard and text (label) clipboard.
-let elementClipboardResolver = createResolver<ClipboardQuery>();
-let textClipboardResolver = createResolver<TextClipboardQuery>();
-
-// Resolvers that signal when element templates and settings have been applied.
-// Selection restore is deferred until both complete so that side-effects
-// (e.g. transaction-boundary rendering) do not clear the restored selection.
-const elementTemplatesResolver = createResolver<ElementTemplatesQuery>();
-const settingsResolver = createResolver<BpmnModelerSettingQuery>();
-
-// Resolves once the host has replied with the global properties-panel default.
-// The webview uses this value only when its own webview state has no
-// panelVisible entry — see WebviewStateManager.restorePanelVisibility.
-const panelStateResolver = createResolver<PropertiesPanelStateQuery>();
-
-/**
- * State manager for persisting and restoring viewport/selection across tab switches.
- * Initialised after the modeler is created.
- */
-let stateManager: WebviewStateManager;
-
-/**
- * The default capability adapter: each port posts the existing protocol command
- * to the host. Used whenever `bootstrap()` is called without explicit
- * capabilities, so VS Code / IntelliJ / Theia are unaffected by the port
- * indirection. Closes over the module-level {@link host} and {@link bpmnModeler}.
- *
- * `scripting` is always populated here even though its DI cluster is C7-only;
- * `capabilityModules` gates the registration, so the surplus port on C8 is inert.
- */
-function createProtocolCapabilities(): ModelerCapabilities {
-    return {
-        modelNavigation: {
-            openReference: ({ id, kind }) =>
-                host.postMessage(new NavigateToReferencedModelCommand(id, kind)),
-        },
-        codeLink: {
-            navigateToImplementation: (reference, kind) =>
-                host.postMessage(new NavigateToImplementationCommand(reference, kind)),
-            syncActivities: (entries) => host.postMessage(new SyncActivitiesCommand(entries)),
-        },
-        scripting: {
-            // The process-variable model is re-extracted per open so completion
-            // reflects the diagram at the moment the tab opens.
-            openScriptEditor: (event) =>
-                host.postMessage(
-                    new OpenScriptEditorCommand(
-                        event.elementId,
-                        event.kind,
-                        event.listenerIndex,
-                        event.eventName,
-                        event.scriptFormat,
-                        event.content,
-                        extractProcessVariables(bpmnModeler.getDefinitions()),
-                    ),
-                ),
-            scriptSourceChanged: (event) =>
-                host.postMessage(
-                    new UpdateScriptSourceCommand(
-                        event.elementId,
-                        event.kind,
-                        event.listenerIndex,
-                        event.content,
-                    ),
-                ),
-        },
-    };
-}
-
-/**
- * Entry point executed once the webview DOM is fully loaded.
- *
- * Registers the message listener first so no backend messages are missed,
- * then requests the BPMN file and waits for the reply before creating the
- * modeler.  After the modeler is ready, secondary resources (element
- * templates, settings) are requested.
- *
- * There are two reasons the webview is built:
- * 1. A new `.bpmn` file was opened.
- * 2. The user switched away and back to the tab.
- */
-async function run(): Promise<void> {
-    window.addEventListener("message", onReceiveMessage);
-
-    // Merge the modeler's Camunda-7 / dmn-js / internal strings onto the shared
-    // library's dictionaries before anything translates. The shared package is
-    // C8-seeded and lacks these keys; without this bridge they would render as
-    // English. extend() persists across setLanguage(), so this single call at
-    // startup covers every later language switch and both the modeler and the
-    // viewer-mode diff legend below.
-    i18n.extend(i18nExtras);
-
-    initTheme();
-
-    // Viewer mode (one side of a diff view) skips the resizer + properties
-    // panel + palette, so we don't call initResizer() here — the chrome is
-    // hidden by .viewer-mode CSS once we confirm the mode below.  For the
-    // modeler path, initResizer() is called after the branch check.
-
-    // Build clipboard DI modules conditionally.
-    // In development (plain browser) NativeCopyPaste handles clipboard natively.
-    let clipboardModules: any[] | undefined;
-
-    if (process.env.NODE_ENV !== "development") {
-        const requestElementClipboard = async (): Promise<string> => {
-            elementClipboardResolver = createResolver<ClipboardQuery>();
-            host.postMessage(new GetClipboardCommand());
-            const q = await elementClipboardResolver.wait();
-            return q?.text ?? "";
-        };
-        const writeElementClipboard = (text: string): void => {
-            host.postMessage(new SetClipboardCommand(text));
-        };
-
-        const requestTextClipboard = async (): Promise<string> => {
-            textClipboardResolver = createResolver<TextClipboardQuery>();
-            host.postMessage(new GetTextClipboardCommand());
-            const q = await textClipboardResolver.wait();
-            return q?.text ?? "";
-        };
-        const writeTextClipboard = (text: string): void => {
-            host.postMessage(new SetTextClipboardCommand(text));
-        };
-
-        clipboardModules = [
-            VsCodeClipboardModule,
-            LabelClipboardModule,
-            {
-                elementClipboardBridge: [
-                    "value",
-                    {
-                        requestClipboard: requestElementClipboard,
-                        writeClipboard: writeElementClipboard,
-                    },
-                ],
-                textClipboardBridge: [
-                    "value",
-                    {
-                        requestClipboard: requestTextClipboard,
-                        writeClipboard: writeTextClipboard,
-                    },
-                ],
-            },
-        ];
-
-        /**
-         * The FEEL editor (CodeMirror 6) in the C8 properties panel lives outside
-         * the bpmn-js DI context, so the DI clipboard modules above don't reach it.
-         * This polyfill intercepts Cmd/Ctrl+C/V on contenteditable elements and
-         * bridges them through the extension host clipboard, and guards Ctrl+A
-         * in text-editing surfaces from being stolen by bpmn-js's Keyboard
-         * service (canvas Ctrl+A is owned by bpmn-js's SelectionKeyBindings).
-         */
-        installContentEditableClipboardPolyfill(requestTextClipboard, writeTextClipboard);
-    }
-
-    host.postMessage(new GetBpmnFileCommand());
-
-    const bpmnFileQuery = await bpmnFileResolver.wait();
-
-    /**
-     * Diff view: host told us this pane is one half of a diff, so bootstrap
-     * the readonly DiffMode and skip the editable modeler entirely.
-     */
-    if (bpmnFileQuery?.viewerMode === "viewer") {
-        document.body.classList.add("viewer-mode");
-        const canvas = document.getElementById("js-canvas");
-        const dropZone = document.getElementById("js-drop-zone");
-        if (!canvas || !dropZone) {
-            console.error("Diff mode: missing #js-canvas or #js-drop-zone");
-            return;
-        }
-        const diffMode = new DiffMode("#js-canvas", dropZone, host);
-        await diffMode.startWith(bpmnFileQuery.content);
-        return;
-    }
-
-    const propertiesPanelHandle = initResizer({
-        getToggleLabel: (state) =>
-            i18n.translate(
-                state === "collapsed" ? "Open properties panel" : "Close properties panel",
-            ) + " (Shift+P)",
-        onLabelChange: (apply) => i18n.onChange(apply),
-    });
-    // The linting toggle is a webview-internal service (always registered via
-    // LintModule), so its host port is wired unconditionally — never gated on a
-    // capability. A missing `lintingHost` value would break LintConfigService's
-    // DI at construction.
-    const lintingHostModule = {
-        lintingHost: [
-            "value",
-            {
-                setLintingEnabled: (enabled: boolean) =>
-                    host.postMessage(new SetLintingEnabledCommand(enabled)),
-            },
-        ],
-    };
-    const capabilities = injectedCapabilities ?? createProtocolCapabilities();
-    const extraModules = [
-        TranslateModule,
-        lintingHostModule,
-        ...(clipboardModules ?? []),
-        ...((injectedModules as any[]) ?? []),
-    ];
-    await initializeModeler(
-        bpmnFileQuery?.content,
-        bpmnFileQuery?.engine,
-        extraModules,
-        capabilities,
-    );
-    modelerIsInitialized = true;
-
-    if (pendingFocusId !== undefined) {
-        bpmnModeler.viewport.centerOnElement(pendingFocusId);
-        pendingFocusId = undefined;
-    }
-
-    // The "Edit Script" / divergence bridge now lives entirely in the scripting
-    // capability port (InlineScriptingPortForwarder → createProtocolCapabilities),
-    // registered by capabilityModules on C7. Only the process-variable publisher
-    // stays here because it drives the host from a commandStack subscription
-    // rather than a lib-owned event. It belongs to the scripting capability, so
-    // gate it on both the engine and the port being present.
-    if (bpmnFileQuery?.engine === "c7" && capabilities.scripting) {
-        // Publish the process-variable model to the host so open script editors
-        // get live variable completion. The chain is a feedback loop, not an echo
-        // loop — a keystroke in a script edits the moddle, which fires
-        // commandStack.changed, which re-extracts — so it is gated twice: the
-        // 300ms debounce collapses per-keystroke bursts, and the JSON compare
-        // suppresses re-publishes when the extracted model is unchanged.
-        let lastVariablesJson = "";
-        const sendVariables = asyncDebounce(async () => {
-            const variables = extractProcessVariables(bpmnModeler.getDefinitions());
-            const json = JSON.stringify(variables);
-            if (json === lastVariablesJson) {
-                return;
-            }
-            lastVariablesJson = json;
-            host.postMessage(new UpdateScriptVariablesCommand(variables));
-        }, 300);
-        bpmnModeler.onCommandStackChanged(() => void sendVariables());
-        // commandStack.changed doesn't fire on import, and a webview reload starts
-        // with an empty host-side store, so seed it unconditionally on every load.
-        void sendVariables();
-    }
-
-    console.debug("[DEBUG] Modeler is initialized...");
-
-    stateManager = new WebviewStateManager(host, bpmnModeler);
-
-    // Phase 1: restore viewport (canvas exists after openXml). Retried from the
-    // observer because hosts mount the webview before laying it out, and the
-    // observer then keeps the cached viewbox in sync for the rest of the session.
-    stateManager.restoreViewport();
-    const canvas = bpmnModeler.getService<ResizableCanvas & { getContainer(): Element }>("canvas");
-    observeCanvasSize(canvas, canvas.getContainer(), {
-        applyInitialViewport: () => stateManager.restoreViewport(),
-    });
-
-    // Surface templates bpmn-js rejects (invalid schema, bad `appliesTo`, …).
-    // Subscribed *before* GetElementTemplatesCommand so the errors fired while
-    // the loader validates the reply are observed. It's a warning, not an error:
-    // bpmn-js skips an invalid template non-fatally, and its message already
-    // carries the offending template's id/name.
-    bpmnModeler.onElementTemplatesErrors((errors) => {
-        for (const error of errors ?? []) {
-            const message = error instanceof Error ? error.message : String(error);
-            host.postMessage(new LogWarningCommand(`Element template rejected: ${message}`));
-        }
-    });
-
-    // Request templates + settings + panel state, wait for all to apply
-    host.postMessage(new GetElementTemplatesCommand());
-    host.postMessage(new GetBpmnModelerSettingCommand());
-    host.postMessage(new GetPropertiesPanelStateCommand());
-    host.postMessage(new GetBpmnlintConfigCommand());
-
-    const [, , panelStateQuery] = await Promise.all([
-        elementTemplatesResolver.wait(),
-        settingsResolver.wait(),
-        panelStateResolver.wait(),
-    ]);
-
-    // Apply the host's global properties-panel default.  A missing query
-    // (unlikely but possible if the resolver was cancelled) falls back to a
-    // visible panel so the user is never stranded without properties editing.
-    propertiesPanelHandle.setVisible(panelStateQuery?.visible ?? true);
-
-    // Report user toggles back to the host so the global default tracks the
-    // latest preference across all BPMN editors.
-    propertiesPanelHandle.onVisibilityChanged((visible) => {
-        host.postMessage(new SetPropertiesPanelStateCommand(visible));
-    });
-
-    // `p` focuses the properties panel (expanding it first if collapsed);
-    // `Shift+P` toggles panel visibility from anywhere except text fields.
-    // Escape stays with keyboardFocus.ts in BPMN — no escapeToCanvas here.
-    installPanelShortcuts({
-        handle: propertiesPanelHandle,
-        focusCanvas: () => bpmnModeler.getService<{ focus(): void }>("canvas").focus(),
-        isCanvasFocused: () =>
-            bpmnModeler.getService<{ isFocused(): boolean }>("canvas").isFocused(),
-    });
-
-    // Phase 2: restore selection + panel-side UI state (safe now — side-effects done)
-    stateManager.restoreSelection();
-    stateManager.restorePanelUiState();
-
-    // Phase 3: begin persisting changes
-    stateManager.startPersisting();
-}
-
-/**
- * Creates the modeler for the given engine and loads the initial diagram.
- *
- * @param bpmn Initial BPMN XML, or `undefined` to create a blank diagram.
- * @param engine Execution platform identifier (`"c7"` or `"c8"`).
- * @param extraModules Optional bpmn-js DI modules (e.g. clipboard bridges).
- * @param capabilities Per-feature host ports gating the capability modules.
- */
-async function initializeModeler(
-    bpmn: string | undefined,
-    engine: Engine | undefined,
-    extraModules?: any[],
-    capabilities?: ModelerCapabilities,
-): Promise<void> {
-    if (!engine) {
-        host.postMessage(new LogErrorCommand("ExecutionPlatformVersion undefined!"));
-        return;
-    }
-
-    try {
-        bpmnModeler.create(engine, extraModules, capabilities);
-        // Lets the IntelliJ JCEF host drive undo/redo: it swallows Ctrl+Z/Ctrl+Y
-        // at the IDE level before bpmn-js sees them (works fine in VS Code/Theia).
-        installHostEditorActions((action) =>
-            bpmnModeler
-                .getService<{ trigger(action: string): void }>("editorActions")
-                .trigger(action),
-        );
-        // Escape re-homes focus on the canvas so keyboard-driven modelling
-        // (A/N/arrows, all owned by bpmn-js's canvas-scoped Keyboard service)
-        // works even when focus sits in the properties panel or a search field;
-        // a further Escape on the focused canvas clears the selection.
-        // Services are resolved lazily inside the closures because the modeler
-        // exists by the time an Escape can fire.
-        installKeyboardFocus({
-            focusCanvas: () => bpmnModeler.getService<{ focus(): void }>("canvas").focus(),
-            isCanvasFocused: () =>
-                bpmnModeler.getService<{ isFocused(): boolean }>("canvas").isFocused(),
-            hasSelection: () =>
-                bpmnModeler.getService<{ get(): unknown[] }>("selection").get().length > 0,
-            clearSelection: () =>
-                bpmnModeler.getService<{ select(elements: null): void }>("selection").select(null),
-            isSearchPadOpen: () =>
-                bpmnModeler.getService<{ isOpen(): boolean }>("searchPad").isOpen(),
-            closeSearchPad: () => bpmnModeler.getService<{ close(): void }>("searchPad").close(),
-        });
-        // Playful counterpart to installKeyboardFocus: a focus reticle in the
-        // canvas's top-right corner, beside the "Open minimap" control, that
-        // lights up green while the canvas holds keyboard focus
-        // with no element selected (a selection already marks itself).
-        // diagram-js already tracks the focus half (Canvas fires a deduplicated
-        // "canvas.focus.changed" from its own SVG focus listeners), so subscribe
-        // instead of re-observing DOM focus — a container-level focusin would
-        // false-positive on the lint chip inside the same .djs-container.
-        installCanvasFocusIndicator({
-            parent: bpmnModeler
-                .getService<{ getContainer(): HTMLElement }>("canvas")
-                .getContainer(),
-            isFocused: () => bpmnModeler.getService<{ isFocused(): boolean }>("canvas").isFocused(),
-            onFocusChanged: (listener) =>
-                bpmnModeler
-                    .getService<{
-                        on(event: string, cb: (e: { focused: boolean }) => void): void;
-                    }>("eventBus")
-                    .on("canvas.focus.changed", (e) => listener(e.focused)),
-            hasSelection: () =>
-                bpmnModeler.getService<{ get(): unknown[] }>("selection").get().length > 0,
-            onSelectionChanged: (listener) =>
-                bpmnModeler
-                    .getService<{
-                        on(event: string, cb: (e: { newSelection: unknown[] }) => void): void;
-                    }>("eventBus")
-                    .on("selection.changed", (e) => listener(e.newSelection.length > 0)),
-        });
-        // Forward the modeler's non-fatal warnings (element-not-found, missing
-        // inline script) to the output channel — they were console-only before.
-        bpmnModeler.onWarning((warning) => host.postMessage(new LogWarningCommand(warning)));
-        bpmnModeler.onCommandStackChanged(() => void debouncedSendXmlChanges());
-        await openXml(bpmn);
-    } catch (error: any) {
-        if (error instanceof NoModelerError) {
-            host.postMessage(new LogErrorCommand(error.message));
-        } else if (error instanceof UnsupportedEngineError) {
-            host.postMessage(new LogErrorCommand(error.message));
-        } else {
-            host.postMessage(new LogErrorCommand(`Unable to open XML\n${error.message}`));
-        }
-    }
-}
-
-/**
- * Loads or replaces the diagram in the modeler with the given BPMN XML.
- * Creates a blank diagram when `bpmn` is `undefined` or empty.
- *
- * @param bpmn BPMN XML string, or `undefined` for a new blank diagram.
- * @throws {NoModelerError} If the modeler is not available.
- */
-async function openXml(bpmn?: string): Promise<void> {
-    let result: ImportXMLResult;
-    if (!bpmn) {
-        result = await bpmnModeler.newDiagram();
-    } else {
-        result = await bpmnModeler.loadDiagram(bpmn);
-    }
-
-    if (result.warnings.length > 0) {
-        const warnings = `Diagram opened with following warnings: ${formatErrors(result.warnings)}`;
-        host.postMessage(new LogWarningCommand(warnings));
-    }
-}
-
-/**
- * Exports the current diagram XML and sends it to the backend to persist the
- * changes, then triggers an align-to-origin pass if the setting is enabled.
- *
- * Runs at debounce-fire time now, not per model change. Align-to-origin
- * therefore also runs debounced (and is skipped on the flush path, where we
- * only export); the next edit realigns. That align emits its own
- * `commandStack.changed`, which schedules one more debounced cycle — but a
- * no-op align executes no commands, so the cycle terminates rather than looping.
- */
-async function sendXmlChanges(): Promise<void> {
-    // A rejection here only reaches the global unhandledrejection hook (diagram-js
-    // discards the returned promise) as a context-free line — catch it so the
-    // failure is named and deterministic on the channel.
-    try {
-        const bpmn = await bpmnModeler.exportDiagram();
-        host.postMessage(new SyncDocumentCommand(bpmn));
-        bpmnModeler.alignElementsToOrigin();
-    } catch (error) {
-        const e = error instanceof Error ? error : new Error(String(error));
-        host.postMessage(
-            new LogErrorCommand(`Failed to sync diagram changes: ${e.message}`, e.stack),
-        );
-    }
-}
-
-/**
- * Routes incoming messages from the host application to the appropriate
- * handler.
- *
- * @param message The raw `MessageEvent` from `window.addEventListener("message", …)`.
- */
-async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise<void> {
-    const queryOrCommand = message.data;
-    const errorPrefix = "Error receiving message: " + queryOrCommand.type + " — ";
-
-    switch (true) {
-        case queryOrCommand.type === "BpmnFileQuery": {
-            try {
-                const bpmnFileQuery = message.data as BpmnFileQuery;
-                if (modelerIsInitialized) {
-                    // A host push (e.g. a raw-XML side-by-side edit) is
-                    // authoritative. Drop any pending outbound sync first so a
-                    // stale export firing after the re-import can't clobber it.
-                    debouncedSendXmlChanges.cancel();
-                    await debouncedUpdateXML(bpmnFileQuery.content);
-                } else {
-                    bpmnFileResolver.done(bpmnFileQuery);
-                }
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "ElementTemplatesQuery": {
-            try {
-                const elementTemplates = (message.data as ElementTemplatesQuery).elementTemplates;
-                console.debug("Received element templates: ", elementTemplates);
-                bpmnModeler.setElementTemplates(elementTemplates);
-                elementTemplatesResolver.done(message.data as ElementTemplatesQuery);
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "BpmnlintResultsQuery": {
-            try {
-                const query = message.data as BpmnlintResultsQuery;
-                bpmnModeler.getService<LintConfigService>("bpmnLintConfig").render(query.results);
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "BpmnLintDisabledQuery": {
-            try {
-                bpmnModeler.getService<LintConfigService>("bpmnLintConfig").renderDisabled();
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "BpmnModelerSettingQuery": {
-            try {
-                const setting = (message.data as BpmnModelerSettingQuery).setting;
-                bpmnModeler.setSettings(setting);
-                settingsResolver.done(message.data as BpmnModelerSettingQuery);
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "PropertiesPanelStateQuery": {
-            panelStateResolver.done(message.data as PropertiesPanelStateQuery);
-            break;
-        }
-        case queryOrCommand.type === "ClipboardQuery": {
-            elementClipboardResolver.done(message.data as ClipboardQuery);
-            break;
-        }
-        case queryOrCommand.type === "TextClipboardQuery": {
-            textClipboardResolver.done(message.data as TextClipboardQuery);
-            break;
-        }
-        case queryOrCommand.type === "LanguageQuery": {
-            try {
-                const query = message.data as LanguageQuery;
-                // Switch the shared translator; the DI-bound service and all
-                // onChange subscribers (resizer, diff legend, …) pick it up.
-                // bpmn-js itself still needs a diagram re-import to re-invoke
-                // translate() for already-rendered elements — skipped in
-                // viewer mode where there is no editable modeler.
-                i18n.setLanguage(query.locale as SupportedLocale);
-                if (modelerIsInitialized) {
-                    await refreshDiagram();
-                }
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "GetDiagramAsSVGCommand": {
-            try {
-                const command = message.data as GetDiagramAsSVGCommand;
-                // Populate the SVG field and echo the command back to the host.
-                command.svg = await bpmnModeler.getDiagramSvg();
-                host.postMessage(command);
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "OpenAllScriptTasksQuery": {
-            try {
-                // Reply as a single bulk command so the host opens the scripts
-                // sequentially; the variable model is identical for every script
-                // in the diagram, so it is extracted once and shared.
-                const scripts = bpmnModeler.collectInlineScriptTasks();
-                host.postMessage(
-                    new OpenScriptEditorsCommand(
-                        scripts,
-                        extractProcessVariables(bpmnModeler.getDefinitions()),
-                    ),
-                );
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "UpdateScriptContentQuery": {
-            try {
-                const query = message.data as UpdateScriptContentQuery;
-                bpmnModeler.updateScriptContent(
-                    query.elementId,
-                    query.kind,
-                    query.listenerIndex,
-                    query.content,
-                );
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "UpdateScriptFormatQuery": {
-            try {
-                const query = message.data as UpdateScriptFormatQuery;
-                bpmnModeler.updateScriptFormat(
-                    query.elementId,
-                    query.kind,
-                    query.listenerIndex,
-                    query.scriptFormat,
-                );
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "UpdateOpenScriptEditorsQuery": {
-            try {
-                const query = message.data as UpdateOpenScriptEditorsQuery;
-                bpmnModeler.applyOpenScriptEditors(query.openScripts);
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "ImplementationStatusQuery": {
-            try {
-                const query = message.data as ImplementationStatusQuery;
-                bpmnModeler.applyImplementationStatus(query.resolved);
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "FocusElementQuery": {
-            try {
-                const { elementId } = message.data as FocusElementQuery;
-                if (modelerIsInitialized) {
-                    bpmnModeler.viewport.centerOnElement(elementId);
-                } else {
-                    pendingFocusId = elementId;
-                }
-            } catch (error: any) {
-                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
-            }
-            break;
-        }
-        case queryOrCommand.type === "FlushDocumentQuery": {
-            // The responder owns its own error handling (replies `undefined` on
-            // export failure), so it never throws into this dispatch.
-            await respondToFlush(message.data as FlushDocumentQuery);
-            break;
-        }
-    }
-}
-
-/**
- * Re-renders the diagram by exporting and re-importing the XML.
- *
- * Preserves the current drill-down plane, viewport, and selection so the
- * user does not lose their place.  Used after a language switch to force
- * bpmn-js to re-invoke `translate()` for all UI elements.
- */
-async function refreshDiagram(): Promise<void> {
-    const xml = await bpmnModeler.exportDiagram();
-    const snapshot = stateManager.captureViewState();
-    await bpmnModeler.loadDiagram(xml);
-    stateManager.applyViewState(snapshot);
-}
 
 /**
  * Starts the BPMN webview against the given host. The entry (real or demo)
@@ -844,9 +88,744 @@ export function bootstrap(
     injectedHost: HostApi<WebviewState, Command | Query>,
     opts: { extraModules?: unknown[]; capabilities?: ModelerCapabilities } = {},
 ): void {
-    host = injectedHost;
-    injectedModules = opts.extraModules;
-    injectedCapabilities = opts.capabilities;
+    startSession(injectedHost, opts.extraModules, opts.capabilities);
+}
+
+/**
+ * One webview session. All state that used to live at module scope — the
+ * modeler, resolvers, debounced syncs, flush responder, the "is initialized"
+ * latch — is folded into this closure so a session owns its own lifetime rather
+ * than a page-wide singleton. The single-instance hosts (VS Code, IntelliJ,
+ * Theia) call {@link bootstrap} exactly once, so behaviour is unchanged; the
+ * closure is the prerequisite for the multi-instance facade (issue #1372).
+ *
+ * @param host The injected host adapter.
+ * @param injectedModules Host-specific extra bpmn-js DI modules.
+ * @param injectedCapabilities Explicit per-feature ports; `undefined` selects
+ *   the full protocol adapter so every real host keeps all features.
+ */
+function startSession(
+    host: HostApi<WebviewState, Command | Query>,
+    injectedModules: unknown[] | undefined,
+    injectedCapabilities: ModelerCapabilities | undefined,
+): void {
+    // Assigned in run() once the engine is known — flush/capability callbacks
+    // only fire post-init, so the definite-assignment assertion is safe.
+    let bpmnModeler!: BpmnModeler;
+
+    let modelerIsInitialized = false;
+
+    // A FocusElementQuery can arrive before the import finishes (host opens the
+    // editor and focuses in one tick); apply it once the modeler is ready.
+    let pendingFocusId: string | undefined;
+
+    // Separate resolvers for element clipboard and text (label) clipboard.
+    let elementClipboardResolver = createResolver<ClipboardQuery>();
+    let textClipboardResolver = createResolver<TextClipboardQuery>();
+
+    // Create resolver to wait for the response from the backend.
+    const bpmnFileResolver = createResolver<BpmnFileQuery>();
+
+    // Resolvers that signal when element templates and settings have been
+    // applied. Selection restore is deferred until both complete so that
+    // side-effects (e.g. transaction-boundary rendering) do not clear the
+    // restored selection.
+    const elementTemplatesResolver = createResolver<ElementTemplatesQuery>();
+    const settingsResolver = createResolver<BpmnModelerSettingQuery>();
+
+    // Resolves once the host has replied with the global properties-panel
+    // default. The webview uses this value only when its own webview state has
+    // no panelVisible entry — see WebviewStateManager.restorePanelVisibility.
+    const panelStateResolver = createResolver<PropertiesPanelStateQuery>();
+
+    /**
+     * State manager for persisting and restoring viewport/selection across tab
+     * switches. Initialised after the modeler is created.
+     */
+    let stateManager: WebviewStateManager;
+
+    /**
+     * Debounce the update of the XML content to avoid too many updates.
+     */
+    const debouncedUpdateXML = asyncDebounce(reloadXmlPreservingView, 100);
+
+    /**
+     * Debounces the outbound document sync so a burst of model changes (e.g.
+     * properties-panel typing) collapses into one full export + host write
+     * instead of one per keystroke. `maxWait` bounds starvation: sustained
+     * typing still syncs at least once per second. 300ms/1000ms mirrors the
+     * script-streaming debounce. The host recovers the sub-300ms tail via the
+     * flush protocol ({@link respondToFlush}) so a save never persists stale XML.
+     */
+    const debouncedSendXmlChanges = asyncDebounce(sendXmlChanges, 300, { maxWait: 1000 });
+
+    /**
+     * Answers a host {@link FlushDocumentQuery} on the save/close path: exports
+     * and returns the pending XML (or reports nothing-pending). The `pending()`
+     * gate and cancel-and-carry rationale live in {@link createFlushResponder}.
+     */
+    const respondToFlush = createFlushResponder(
+        {
+            isReady: () => modelerIsInitialized,
+            hasPendingSync: () => debouncedSendXmlChanges.pending(),
+            cancelPendingSync: () => debouncedSendXmlChanges.cancel(),
+            exportXml: () => bpmnModeler.exportDiagram(),
+        },
+        (reply) => host.postMessage(reply),
+    );
+
+    // Global safety net for throws the per-message try/catch in onReceiveMessage
+    // can't reach — bpmn-js event-bus callbacks (e.g. onCommandStackChanged) run
+    // outside it, so an error there would otherwise vanish into the webview
+    // console and never reach the output channel.
+    function registerGlobalErrorHandlers(): void {
+        window.addEventListener("error", (event: ErrorEvent) => {
+            host.postMessage(
+                new LogErrorCommand(`Unhandled error: ${event.message}`, event.error?.stack),
+            );
+        });
+        window.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
+            const reason: unknown = event.reason;
+            host.postMessage(
+                new LogErrorCommand(
+                    `Unhandled promise rejection: ${reason instanceof Error ? reason.message : String(reason)}`,
+                    reason instanceof Error ? reason.stack : undefined,
+                ),
+            );
+        });
+    }
+
+    /**
+     * Re-imports the XML while preserving the user's drill-down plane, viewbox,
+     * and selection. The snapshot is taken from the live canvas inside the
+     * debounced function so a burst of host pushes captures once, not from a
+     * half-imported intermediate.
+     */
+    async function reloadXmlPreservingView(bpmn: string): Promise<void> {
+        const snapshot = stateManager?.captureViewState();
+        await openXml(bpmn);
+        if (snapshot) {
+            stateManager.applyViewState(snapshot);
+        }
+    }
+
+    /**
+     * The default capability adapter: each port posts the existing protocol
+     * command to the host. Used whenever `bootstrap()` is called without
+     * explicit capabilities, so VS Code / IntelliJ / Theia are unaffected by the
+     * port indirection. Closes over the session {@link host} and {@link bpmnModeler}.
+     *
+     * `scripting` is always populated here even though its DI cluster is C7-only;
+     * `capabilityModules` gates the registration, so the surplus port on C8 is inert.
+     */
+    function createProtocolCapabilities(): ModelerCapabilities {
+        return {
+            modelNavigation: {
+                openReference: ({ id, kind }) =>
+                    host.postMessage(new NavigateToReferencedModelCommand(id, kind)),
+            },
+            codeLink: {
+                navigateToImplementation: (reference, kind) =>
+                    host.postMessage(new NavigateToImplementationCommand(reference, kind)),
+                syncActivities: (entries) => host.postMessage(new SyncActivitiesCommand(entries)),
+            },
+            scripting: {
+                // The process-variable model is re-extracted per open so
+                // completion reflects the diagram at the moment the tab opens.
+                openScriptEditor: (event) =>
+                    host.postMessage(
+                        new OpenScriptEditorCommand(
+                            event.elementId,
+                            event.kind,
+                            event.listenerIndex,
+                            event.eventName,
+                            event.scriptFormat,
+                            event.content,
+                            extractProcessVariables(bpmnModeler.getDefinitions()),
+                        ),
+                    ),
+                scriptSourceChanged: (event) =>
+                    host.postMessage(
+                        new UpdateScriptSourceCommand(
+                            event.elementId,
+                            event.kind,
+                            event.listenerIndex,
+                            event.content,
+                        ),
+                    ),
+            },
+        };
+    }
+
+    /**
+     * Entry point executed once the webview DOM is fully loaded.
+     *
+     * Registers the message listener first so no backend messages are missed,
+     * then requests the BPMN file and waits for the reply before creating the
+     * modeler. After the modeler is ready, secondary resources (element
+     * templates, settings) are requested.
+     *
+     * There are two reasons the webview is built:
+     * 1. A new `.bpmn` file was opened.
+     * 2. The user switched away and back to the tab.
+     */
+    async function run(): Promise<void> {
+        window.addEventListener("message", onReceiveMessage);
+
+        // Merge the modeler's Camunda-7 / dmn-js / internal strings onto the
+        // shared library's dictionaries before anything translates. The shared
+        // package is C8-seeded and lacks these keys; without this bridge they
+        // would render as English. extend() persists across setLanguage(), so
+        // this single call at startup covers every later language switch and
+        // both the modeler and the viewer-mode diff legend below.
+        i18n.extend(i18nExtras);
+
+        initTheme();
+
+        // Viewer mode (one side of a diff view) skips the resizer + properties
+        // panel + palette, so we don't call initResizer() here — the chrome is
+        // hidden by .viewer-mode CSS once we confirm the mode below. For the
+        // modeler path, initResizer() is called after the branch check.
+
+        // Build clipboard DI modules conditionally.
+        // In development (plain browser) NativeCopyPaste handles clipboard natively.
+        let clipboardModules: any[] | undefined;
+
+        if (process.env.NODE_ENV !== "development") {
+            const requestElementClipboard = async (): Promise<string> => {
+                elementClipboardResolver = createResolver<ClipboardQuery>();
+                host.postMessage(new GetClipboardCommand());
+                const q = await elementClipboardResolver.wait();
+                return q?.text ?? "";
+            };
+            const writeElementClipboard = (text: string): void => {
+                host.postMessage(new SetClipboardCommand(text));
+            };
+
+            const requestTextClipboard = async (): Promise<string> => {
+                textClipboardResolver = createResolver<TextClipboardQuery>();
+                host.postMessage(new GetTextClipboardCommand());
+                const q = await textClipboardResolver.wait();
+                return q?.text ?? "";
+            };
+            const writeTextClipboard = (text: string): void => {
+                host.postMessage(new SetTextClipboardCommand(text));
+            };
+
+            clipboardModules = [
+                VsCodeClipboardModule,
+                LabelClipboardModule,
+                {
+                    elementClipboardBridge: [
+                        "value",
+                        {
+                            requestClipboard: requestElementClipboard,
+                            writeClipboard: writeElementClipboard,
+                        },
+                    ],
+                    textClipboardBridge: [
+                        "value",
+                        {
+                            requestClipboard: requestTextClipboard,
+                            writeClipboard: writeTextClipboard,
+                        },
+                    ],
+                },
+            ];
+
+            /**
+             * The FEEL editor (CodeMirror 6) in the C8 properties panel lives
+             * outside the bpmn-js DI context, so the DI clipboard modules above
+             * don't reach it. This polyfill intercepts Cmd/Ctrl+C/V on
+             * contenteditable elements and bridges them through the extension
+             * host clipboard, and guards Ctrl+A in text-editing surfaces from
+             * being stolen by bpmn-js's Keyboard service (canvas Ctrl+A is owned
+             * by bpmn-js's SelectionKeyBindings).
+             */
+            installContentEditableClipboardPolyfill(requestTextClipboard, writeTextClipboard);
+        }
+
+        host.postMessage(new GetBpmnFileCommand());
+
+        const bpmnFileQuery = await bpmnFileResolver.wait();
+
+        /**
+         * Diff view: host told us this pane is one half of a diff, so bootstrap
+         * the readonly DiffMode and skip the editable modeler entirely.
+         */
+        if (bpmnFileQuery?.viewerMode === "viewer") {
+            document.body.classList.add("viewer-mode");
+            const canvas = document.getElementById("js-canvas");
+            const dropZone = document.getElementById("js-drop-zone");
+            if (!canvas || !dropZone) {
+                console.error("Diff mode: missing #js-canvas or #js-drop-zone");
+                return;
+            }
+            const diffMode = new DiffMode("#js-canvas", dropZone, host);
+            await diffMode.startWith(bpmnFileQuery.content);
+            return;
+        }
+
+        // Host HTML keeps its `js-canvas` / `js-properties-panel` ids; the
+        // facade takes the resolved elements, not selectors, so a second modeler
+        // (in-page diff, #1372) can pass its own DOM hosts with no ids.
+        const canvasEl = document.getElementById("js-canvas");
+        const propertiesPanelParent = document.getElementById("js-properties-panel");
+        if (!canvasEl || !propertiesPanelParent) {
+            host.postMessage(
+                new LogErrorCommand("Missing #js-canvas or #js-properties-panel in host HTML"),
+            );
+            return;
+        }
+
+        const propertiesPanelHandle = initResizer({
+            getToggleLabel: (state) =>
+                i18n.translate(
+                    state === "collapsed" ? "Open properties panel" : "Close properties panel",
+                ) + " (Shift+P)",
+            onLabelChange: (apply) => i18n.onChange(apply),
+        });
+        const capabilities = injectedCapabilities ?? createProtocolCapabilities();
+        const extraModules = [
+            TranslateModule,
+            ...(clipboardModules ?? []),
+            ...((injectedModules as any[]) ?? []),
+        ];
+        // The linting toggle is a webview-internal service (always registered via
+        // LintModule), so its host port is wired unconditionally — never gated on
+        // a capability. The facade registers a no-op when omitted, so a host-less
+        // consumer still resolves LintConfigService's DI.
+        bpmnModeler = createModeler(canvasEl, {
+            propertiesPanelParent,
+            extraModules,
+            capabilities,
+            lintingHost: {
+                setLintingEnabled: (enabled: boolean) =>
+                    host.postMessage(new SetLintingEnabledCommand(enabled)),
+            },
+            applyColorThemeMode: setColorThemeMode,
+            handleGlobalEscape: true,
+        });
+        await initializeModeler(bpmnFileQuery?.content, bpmnFileQuery?.engine);
+        modelerIsInitialized = true;
+
+        if (pendingFocusId !== undefined) {
+            bpmnModeler.viewport.centerOnElement(pendingFocusId);
+            pendingFocusId = undefined;
+        }
+
+        // The "Edit Script" / divergence bridge now lives entirely in the
+        // scripting capability port (InlineScriptingPortForwarder →
+        // createProtocolCapabilities), registered by capabilityModules on C7.
+        // Only the process-variable publisher stays here because it drives the
+        // host from a commandStack subscription rather than a lib-owned event. It
+        // belongs to the scripting capability, so gate it on both the engine and
+        // the port being present.
+        if (bpmnFileQuery?.engine === "c7" && capabilities.scripting) {
+            // Publish the process-variable model to the host so open script
+            // editors get live variable completion. The chain is a feedback loop,
+            // not an echo loop — a keystroke in a script edits the moddle, which
+            // fires commandStack.changed, which re-extracts — so it is gated
+            // twice: the 300ms debounce collapses per-keystroke bursts, and the
+            // JSON compare suppresses re-publishes when the model is unchanged.
+            let lastVariablesJson = "";
+            const sendVariables = asyncDebounce(async () => {
+                const variables = extractProcessVariables(bpmnModeler.getDefinitions());
+                const json = JSON.stringify(variables);
+                if (json === lastVariablesJson) {
+                    return;
+                }
+                lastVariablesJson = json;
+                host.postMessage(new UpdateScriptVariablesCommand(variables));
+            }, 300);
+            bpmnModeler.onCommandStackChanged(() => void sendVariables());
+            // commandStack.changed doesn't fire on import, and a webview reload
+            // starts with an empty host-side store, so seed it unconditionally on
+            // every load.
+            void sendVariables();
+        }
+
+        console.debug("[DEBUG] Modeler is initialized...");
+
+        stateManager = new WebviewStateManager(host, bpmnModeler, propertiesPanelParent);
+
+        // Phase 1: restore viewport (canvas exists after openXml). Retried from
+        // the observer because hosts mount the webview before laying it out, and
+        // the observer then keeps the cached viewbox in sync for the session.
+        stateManager.restoreViewport();
+        const canvas = bpmnModeler.getService<ResizableCanvas & { getContainer(): Element }>(
+            "canvas",
+        );
+        observeCanvasSize(canvas, canvas.getContainer(), {
+            applyInitialViewport: () => stateManager.restoreViewport(),
+        });
+
+        // Surface templates bpmn-js rejects (invalid schema, bad `appliesTo`, …).
+        // Subscribed *before* GetElementTemplatesCommand so the errors fired
+        // while the loader validates the reply are observed. It's a warning, not
+        // an error: bpmn-js skips an invalid template non-fatally, and its
+        // message already carries the offending template's id/name.
+        bpmnModeler.onElementTemplatesErrors((errors) => {
+            for (const error of errors ?? []) {
+                const message = error instanceof Error ? error.message : String(error);
+                host.postMessage(new LogWarningCommand(`Element template rejected: ${message}`));
+            }
+        });
+
+        // Request templates + settings + panel state, wait for all to apply
+        host.postMessage(new GetElementTemplatesCommand());
+        host.postMessage(new GetBpmnModelerSettingCommand());
+        host.postMessage(new GetPropertiesPanelStateCommand());
+        host.postMessage(new GetBpmnlintConfigCommand());
+
+        const [, , panelStateQuery] = await Promise.all([
+            elementTemplatesResolver.wait(),
+            settingsResolver.wait(),
+            panelStateResolver.wait(),
+        ]);
+
+        // Apply the host's global properties-panel default. A missing query
+        // (unlikely but possible if the resolver was cancelled) falls back to a
+        // visible panel so the user is never stranded without properties editing.
+        propertiesPanelHandle.setVisible(panelStateQuery?.visible ?? true);
+
+        // Report user toggles back to the host so the global default tracks the
+        // latest preference across all BPMN editors.
+        propertiesPanelHandle.onVisibilityChanged((visible) => {
+            host.postMessage(new SetPropertiesPanelStateCommand(visible));
+        });
+
+        // `p` focuses the properties panel (expanding it first if collapsed);
+        // `Shift+P` toggles panel visibility from anywhere except text fields.
+        // Escape stays with keyboardFocus.ts in BPMN — no escapeToCanvas here.
+        installPanelShortcuts({
+            handle: propertiesPanelHandle,
+            focusCanvas: () => bpmnModeler.getService<{ focus(): void }>("canvas").focus(),
+            isCanvasFocused: () =>
+                bpmnModeler.getService<{ isFocused(): boolean }>("canvas").isFocused(),
+        });
+
+        // Phase 2: restore selection + panel-side UI state (side-effects done)
+        stateManager.restoreSelection();
+        stateManager.restorePanelUiState();
+
+        // Phase 3: begin persisting changes
+        stateManager.startPersisting();
+    }
+
+    /**
+     * Creates the modeler for the given engine and loads the initial diagram.
+     * The container-scoped focus features (Escape guard + focus reticle) and the
+     * lint host / theme wiring are composed inside {@link BpmnModeler.create};
+     * this function only adds the host-driven bits: editor-action relay, warning
+     * sink, and the outbound-sync command-stack subscription.
+     *
+     * @param bpmn Initial BPMN XML, or `undefined` to create a blank diagram.
+     * @param engine Execution platform identifier (`"c7"` or `"c8"`).
+     */
+    async function initializeModeler(
+        bpmn: string | undefined,
+        engine: Engine | undefined,
+    ): Promise<void> {
+        if (!engine) {
+            host.postMessage(new LogErrorCommand("ExecutionPlatformVersion undefined!"));
+            return;
+        }
+
+        try {
+            bpmnModeler.create(engine);
+            // Lets the IntelliJ JCEF host drive undo/redo: it swallows
+            // Ctrl+Z/Ctrl+Y at the IDE level before bpmn-js sees them (works fine
+            // in VS Code/Theia).
+            installHostEditorActions((action) =>
+                bpmnModeler
+                    .getService<{ trigger(action: string): void }>("editorActions")
+                    .trigger(action),
+            );
+            // Forward the modeler's non-fatal warnings (element-not-found,
+            // missing inline script) to the output channel — console-only before.
+            bpmnModeler.onWarning((warning) => host.postMessage(new LogWarningCommand(warning)));
+            bpmnModeler.onCommandStackChanged(() => void debouncedSendXmlChanges());
+            await openXml(bpmn);
+        } catch (error: any) {
+            if (error instanceof NoModelerError) {
+                host.postMessage(new LogErrorCommand(error.message));
+            } else if (error instanceof UnsupportedEngineError) {
+                host.postMessage(new LogErrorCommand(error.message));
+            } else {
+                host.postMessage(new LogErrorCommand(`Unable to open XML\n${error.message}`));
+            }
+        }
+    }
+
+    /**
+     * Loads or replaces the diagram in the modeler with the given BPMN XML.
+     * Creates a blank diagram when `bpmn` is `undefined` or empty.
+     *
+     * @param bpmn BPMN XML string, or `undefined` for a new blank diagram.
+     * @throws {NoModelerError} If the modeler is not available.
+     */
+    async function openXml(bpmn?: string): Promise<void> {
+        let result: ImportXMLResult;
+        if (!bpmn) {
+            result = await bpmnModeler.newDiagram();
+        } else {
+            result = await bpmnModeler.loadDiagram(bpmn);
+        }
+
+        if (result.warnings.length > 0) {
+            const warnings = `Diagram opened with following warnings: ${formatErrors(result.warnings)}`;
+            host.postMessage(new LogWarningCommand(warnings));
+        }
+    }
+
+    /**
+     * Exports the current diagram XML and sends it to the backend to persist the
+     * changes, then triggers an align-to-origin pass if the setting is enabled.
+     *
+     * Runs at debounce-fire time now, not per model change. Align-to-origin
+     * therefore also runs debounced (and is skipped on the flush path, where we
+     * only export); the next edit realigns. That align emits its own
+     * `commandStack.changed`, which schedules one more debounced cycle — but a
+     * no-op align executes no commands, so the cycle terminates rather than looping.
+     */
+    async function sendXmlChanges(): Promise<void> {
+        // A rejection here only reaches the global unhandledrejection hook
+        // (diagram-js discards the returned promise) as a context-free line —
+        // catch it so the failure is named and deterministic on the channel.
+        try {
+            const bpmn = await bpmnModeler.exportDiagram();
+            host.postMessage(new SyncDocumentCommand(bpmn));
+            bpmnModeler.alignElementsToOrigin();
+        } catch (error) {
+            const e = error instanceof Error ? error : new Error(String(error));
+            host.postMessage(
+                new LogErrorCommand(`Failed to sync diagram changes: ${e.message}`, e.stack),
+            );
+        }
+    }
+
+    /**
+     * Routes incoming messages from the host application to the appropriate
+     * handler.
+     *
+     * @param message The raw `MessageEvent` from `window.addEventListener("message", …)`.
+     */
+    async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise<void> {
+        const queryOrCommand = message.data;
+        const errorPrefix = "Error receiving message: " + queryOrCommand.type + " — ";
+
+        switch (true) {
+            case queryOrCommand.type === "BpmnFileQuery": {
+                try {
+                    const bpmnFileQuery = message.data as BpmnFileQuery;
+                    if (modelerIsInitialized) {
+                        // A host push (e.g. a raw-XML side-by-side edit) is
+                        // authoritative. Drop any pending outbound sync first so a
+                        // stale export firing after the re-import can't clobber it.
+                        debouncedSendXmlChanges.cancel();
+                        await debouncedUpdateXML(bpmnFileQuery.content);
+                    } else {
+                        bpmnFileResolver.done(bpmnFileQuery);
+                    }
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "ElementTemplatesQuery": {
+                try {
+                    const elementTemplates = (message.data as ElementTemplatesQuery)
+                        .elementTemplates;
+                    console.debug("Received element templates: ", elementTemplates);
+                    bpmnModeler.setElementTemplates(elementTemplates);
+                    elementTemplatesResolver.done(message.data as ElementTemplatesQuery);
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "BpmnlintResultsQuery": {
+                try {
+                    const query = message.data as BpmnlintResultsQuery;
+                    bpmnModeler
+                        .getService<LintConfigService>("bpmnLintConfig")
+                        .render(query.results);
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "BpmnLintDisabledQuery": {
+                try {
+                    bpmnModeler.getService<LintConfigService>("bpmnLintConfig").renderDisabled();
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "BpmnModelerSettingQuery": {
+                try {
+                    const setting = (message.data as BpmnModelerSettingQuery).setting;
+                    bpmnModeler.setSettings(setting);
+                    settingsResolver.done(message.data as BpmnModelerSettingQuery);
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "PropertiesPanelStateQuery": {
+                panelStateResolver.done(message.data as PropertiesPanelStateQuery);
+                break;
+            }
+            case queryOrCommand.type === "ClipboardQuery": {
+                elementClipboardResolver.done(message.data as ClipboardQuery);
+                break;
+            }
+            case queryOrCommand.type === "TextClipboardQuery": {
+                textClipboardResolver.done(message.data as TextClipboardQuery);
+                break;
+            }
+            case queryOrCommand.type === "LanguageQuery": {
+                try {
+                    const query = message.data as LanguageQuery;
+                    // Switch the shared translator; the DI-bound service and all
+                    // onChange subscribers (resizer, diff legend, …) pick it up.
+                    // bpmn-js itself still needs a diagram re-import to re-invoke
+                    // translate() for already-rendered elements — skipped in
+                    // viewer mode where there is no editable modeler.
+                    i18n.setLanguage(query.locale as SupportedLocale);
+                    if (modelerIsInitialized) {
+                        await refreshDiagram();
+                    }
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "GetDiagramAsSVGCommand": {
+                try {
+                    const command = message.data as GetDiagramAsSVGCommand;
+                    // Populate the SVG field and echo the command back to the host.
+                    command.svg = await bpmnModeler.getDiagramSvg();
+                    host.postMessage(command);
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "OpenAllScriptTasksQuery": {
+                try {
+                    // Reply as a single bulk command so the host opens the scripts
+                    // sequentially; the variable model is identical for every
+                    // script in the diagram, so it is extracted once and shared.
+                    const scripts = bpmnModeler.collectInlineScriptTasks();
+                    host.postMessage(
+                        new OpenScriptEditorsCommand(
+                            scripts,
+                            extractProcessVariables(bpmnModeler.getDefinitions()),
+                        ),
+                    );
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "UpdateScriptContentQuery": {
+                try {
+                    const query = message.data as UpdateScriptContentQuery;
+                    bpmnModeler.updateScriptContent(
+                        query.elementId,
+                        query.kind,
+                        query.listenerIndex,
+                        query.content,
+                    );
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "UpdateScriptFormatQuery": {
+                try {
+                    const query = message.data as UpdateScriptFormatQuery;
+                    bpmnModeler.updateScriptFormat(
+                        query.elementId,
+                        query.kind,
+                        query.listenerIndex,
+                        query.scriptFormat,
+                    );
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "UpdateOpenScriptEditorsQuery": {
+                try {
+                    const query = message.data as UpdateOpenScriptEditorsQuery;
+                    bpmnModeler.applyOpenScriptEditors(query.openScripts);
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "ImplementationStatusQuery": {
+                try {
+                    const query = message.data as ImplementationStatusQuery;
+                    bpmnModeler.applyImplementationStatus(query.resolved);
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "FocusElementQuery": {
+                try {
+                    const { elementId } = message.data as FocusElementQuery;
+                    if (modelerIsInitialized) {
+                        bpmnModeler.viewport.centerOnElement(elementId);
+                    } else {
+                        pendingFocusId = elementId;
+                    }
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "FlushDocumentQuery": {
+                // The responder owns its own error handling (replies `undefined`
+                // on export failure), so it never throws into this dispatch.
+                await respondToFlush(message.data as FlushDocumentQuery);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Re-renders the diagram by exporting and re-importing the XML.
+     *
+     * Preserves the current drill-down plane, viewport, and selection so the
+     * user does not lose their place. Used after a language switch to force
+     * bpmn-js to re-invoke `translate()` for all UI elements.
+     */
+    async function refreshDiagram(): Promise<void> {
+        const xml = await bpmnModeler.exportDiagram();
+        const snapshot = stateManager.captureViewState();
+        await bpmnModeler.loadDiagram(xml);
+        stateManager.applyViewState(snapshot);
+    }
+
+    // Best-effort flush of the outbound sync debounce when the webview is hidden
+    // (tab switch / close). Reliable in the persistent JCEF host; in VS Code the
+    // webview context may be torn down mid-export, so this is a best-effort
+    // mitigation of the ≤300ms hide-loss window — the save path is fully covered
+    // by the flush protocol instead. Registered per-session (not at import) so a
+    // torn-down session leaves no listener behind.
+    document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "hidden") {
+            void debouncedSendXmlChanges.flush();
+            stateManager?.flushViewport();
+        }
+    });
+
     registerGlobalErrorHandlers();
     if (document.readyState === "complete") {
         void run();

--- a/apps/bpmn-webview/src/index.ts
+++ b/apps/bpmn-webview/src/index.ts
@@ -1,3 +1,5 @@
 export { bootstrap } from "./bootstrap";
+export { createModeler, BpmnModeler } from "./app";
+export type { CreateModelerOptions } from "./app";
 export type { WebviewState, ViewportData } from "./app/webviewState";
 export type { ModelerCapabilities } from "./app/capabilities";

--- a/apps/demo-webapp/bpmn/dual.html
+++ b/apps/demo-webapp/bpmn/dual.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <link
+            href="../../bpmn-webview/src/styles/light-theme/index.css"
+            id="theme-link"
+            rel="stylesheet"
+        />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Miragon Modeler — Dual Instance Demo</title>
+        <style>
+            body {
+                margin: 0;
+            }
+            /* Two independent modelers side by side — no #js-canvas ids. */
+            .dual {
+                display: flex;
+                height: 100vh;
+            }
+            .pane {
+                display: flex;
+                flex: 1 1 50%;
+                min-width: 0;
+                border-right: 1px solid #ddd;
+            }
+            .pane:last-child {
+                border-right: none;
+            }
+            .pane .canvas {
+                position: relative;
+                flex: 1 1 auto;
+                min-width: 0;
+                height: 100%;
+            }
+            .pane .properties-panel-parent {
+                width: 260px;
+                overflow: auto;
+                border-left: 1px solid #eee;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="dual">
+            <div class="pane">
+                <div class="canvas" id="canvas-a"></div>
+                <div class="properties-panel-parent" id="panel-a"></div>
+            </div>
+            <div class="pane">
+                <div class="canvas" id="canvas-b"></div>
+                <div class="properties-panel-parent" id="panel-b"></div>
+            </div>
+        </div>
+        <script src="/dual.ts" type="module"></script>
+    </body>
+</html>

--- a/apps/demo-webapp/bpmn/dual.ts
+++ b/apps/demo-webapp/bpmn/dual.ts
@@ -1,0 +1,67 @@
+import { createModeler } from "@miragon/bpmn-modeler-webview";
+import { getActiveModel } from "../src";
+
+/**
+ * Two-instance regression proof for issue #1372: two independent modelers on one
+ * page, each bound to its own canvas + panel host, neither using the legacy
+ * `#js-canvas` / `#js-properties-panel` ids (that absence is the proof). No host,
+ * no bootstrap — a bare {@link createModeler} per pane. Manual checks: pan/zoom/
+ * selection and the properties panels are independent, Escape in panel A focuses
+ * canvas A only, and each canvas paints its own lint/focus chrome.
+ */
+
+// A minimal Camunda 8 diagram so the second pane exercises the C8 engine path
+// (the bundled demo models are all C7). Kept inline rather than in the registry
+// because the registry only carries C7 models today.
+const C8_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_dual_c8" targetNamespace="http://bpmn.io/schema/bpmn" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_dual_c8" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start (C8)">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" name="Do work">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_dual_c8">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="180" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="280" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <dc:waypoint x="216" y="118" />
+        <dc:waypoint x="280" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+/** Stands up one modeler bound to the given canvas + panel elements. */
+async function mount(
+    canvasId: string,
+    panelId: string,
+    engine: "c7" | "c8",
+    xml: string,
+): Promise<void> {
+    const container = document.getElementById(canvasId);
+    const propertiesPanelParent = document.getElementById(panelId);
+    if (!container || !propertiesPanelParent) {
+        throw new Error(`Missing #${canvasId} or #${panelId}`);
+    }
+    // No host wiring: the default no-op lintingHost keeps DI resolvable, and
+    // handleGlobalEscape stays off so each instance only reacts to Escapes in
+    // its own subtrees.
+    const modeler = createModeler(container, { propertiesPanelParent });
+    modeler.create(engine);
+    await modeler.loadDiagram(xml);
+}
+
+// Left pane: the bundled C7 demo model. Right pane: the inline C8 diagram.
+const c7Model = getActiveModel("bpmn");
+
+void mount("canvas-a", "panel-a", "c7", c7Model.xml);
+void mount("canvas-b", "panel-b", "c8", C8_XML);

--- a/apps/demo-webapp/vite.config.mts
+++ b/apps/demo-webapp/vite.config.mts
@@ -59,6 +59,18 @@ export default defineConfig(({ mode }) => {
             chunkSizeWarningLimit: 1200,
             outDir: resolve(__dirname, `../../dist/demo/${target}`),
             emptyOutDir: true,
+            // The bpmn page ships a second entry — the two-instance regression
+            // proof at /bpmn/dual.html (issue #1372). The dev server serves it
+            // automatically; only the build needs the extra rollup input.
+            rollupOptions:
+                target === "bpmn"
+                    ? {
+                          input: {
+                              index: resolve(__dirname, "bpmn/index.html"),
+                              dual: resolve(__dirname, "bpmn/dual.html"),
+                          },
+                      }
+                    : undefined,
         },
         define: {
             "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -32,7 +32,9 @@
             ]
         },
         "apps/demo-webapp": {
-            "entry": ["dmn/main.ts"]
+            // dual.ts is reached only via bpmn/dual.html, which the vite plugin
+            // does not walk (single-mode root), so list it explicitly.
+            "entry": ["dmn/main.ts", "bpmn/dual.ts"]
         }
     }
 }

--- a/libs/inline-scripting/src/scriptEditorButtons.ts
+++ b/libs/inline-scripting/src/scriptEditorButtons.ts
@@ -51,19 +51,29 @@ const INJECTED_MARKER = "data-script-btn-injected";
 class ScriptEditorButtons {
     private observer: MutationObserver | undefined;
 
-    static $inject = ["eventBus", "selection", "scriptEditorOpener"];
+    // The properties-panel host element to observe. Resolved from the optional
+    // `propertiesPanelRoot` DI value (the modeler facade registers it per
+    // instance) so two modelers on one page each watch their own panel; falls
+    // back to the legacy `#js-properties-panel` id for hosts that register none.
+    private readonly panelRoot: Element | null;
+
+    static $inject = ["eventBus", "selection", "scriptEditorOpener", "injector"];
 
     constructor(
         private readonly eventBus: any,
         private readonly selection: any,
         private readonly opener: ScriptEditorOpener,
+        injector: { get(name: string, strict: false): HTMLElement | null | undefined },
     ) {
+        this.panelRoot =
+            injector.get("propertiesPanelRoot", false) ??
+            document.querySelector("#js-properties-panel");
         this.startObserving();
         this.eventBus.on("diagram.destroy", () => this.stopObserving());
     }
 
     private startObserving(): void {
-        const container = document.querySelector("#js-properties-panel");
+        const container = this.panelRoot;
         if (!container) {
             return;
         }


### PR DESCRIPTION
## Issue

Closes #1372

## Description

Replaces the hard-coded `#js-canvas`/`#js-properties-panel` ids and `bootstrap.ts`'s module-level state with an instance-based `createModeler(container, options)` factory, a prerequisite for the publishable package (#1293). Document-level side effects are scoped per instance: the Escape focus guard now checks the instance's roots and returns a disposer, lint state classes move from `document.body` onto the canvas container (with the `bpmnlint.css` rewrite), viewport palette and panel-state queries are scoped to the instance's elements, the clipboard polyfill gains an idempotency guard, and `scriptEditorButtons` resolves an optional per-instance `propertiesPanelRoot` DI value. The facade now composes keyboard focus, the focus reticle, and the lint-host DI value itself, and gains `destroy()`; `bootstrap.ts` folds all former module state into a session closure and keeps identical wiring, so all hosts behave unchanged. The demo-webapp gains a two-instances-on-one-page regression proof at `/bpmn/dual.html` (one C7, one C8 instance, no DOM ids). Page-level concerns (theme singleton, shared persistence key, viewer/diff branch) deliberately stay global — noted for #1375/#1376.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [ ] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
