### PR TITLE
feat(bpmn-webview): add linting tiers with lazy in-page bpmnlint

### DIFF
--- a/apps/bpmn-webview/package.json
+++ b/apps/bpmn-webview/package.json
@@ -26,6 +26,7 @@
         "@miragon/bpmn-modeler-inline-scripting": "workspace:*",
         "@miragon/bpmn-modeler-shared": "workspace:*",
         "@miragon/bpmn-modeler-types": "workspace:*",
+        "@miragon/bpmnlint-plugin-rules": "0.10.0",
         "@miragon/create-append-c7": "0.1.0",
         "bpmn-js": "18.19.0",
         "bpmn-js-bpmnlint": "0.24.0",

--- a/apps/bpmn-webview/package.json
+++ b/apps/bpmn-webview/package.json
@@ -50,7 +50,6 @@
         "jsdom": "30.0.1",
         "typescript": "6.0.3",
         "vite": "8.1.0",
-        "vite-plugin-static-copy": "4.1.1",
         "vite-tsconfig-paths": "6.1.1",
         "vitest": "4.1.9"
     }

--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
@@ -1,15 +1,32 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { LintConfigService } from "./LintConfigService";
+// The tier state machine is the unit under test; the actual browser lint run is
+// mocked so these tests never spin up bpmnlint. `runMock` is hoisted so the
+// `vi.mock` factory (itself hoisted) can close over it.
+const { runMock } = vi.hoisted(() => ({ runMock: vi.fn() }));
+vi.mock("./browserLinter", () => ({
+    // A class (not an arrow) so `new BrowserLinter()` constructs.
+    BrowserLinter: class {
+        run = runMock;
+    },
+}));
 
-/** The narrow host port; these render tests never reach its off/enable clicks. */
-const lintingHost = { setLintingEnabled: vi.fn() };
+import type { LintResults } from "@miragon/bpmn-modeler-types";
+
+import { LintConfigService, type LintCallbacks, type LintTierInit } from "./LintConfigService";
+
+/** A canned in-page lint outcome; distinct object identity lets us assert copies. */
+const LINT_EVENT = {
+    results: { "label-required": [{ id: "Task_1", message: "x", category: "warn" }] },
+    unresolved: ["some-plugin/some-rule"],
+};
 
 /** Minimal stand-in for the bpmn-js-bpmnlint `linting` DI service. */
 function fakeLinting() {
     return {
         active: false,
-        lint: undefined as undefined | (() => Promise<unknown>),
+        // Overwritten by the constructor; a real function keeps the fake assignable.
+        lint: (() => Promise.resolve({})) as () => Promise<LintResults>,
         isActive(): boolean {
             return this.active;
         },
@@ -22,14 +39,26 @@ function fakeLinting() {
 
 /**
  * A fake diagram-js `Canvas` over a fresh `.djs-container` in the document, so
- * the service's state classes and pill lookups are asserted per-container
- * instead of on `document.body` (the multi-instance scoping this test guards).
+ * the service's state classes and pill lookups are asserted per-container.
  */
 function fakeCanvas(): { getContainer(): HTMLElement } {
     const container = document.createElement("div");
     container.className = "djs-container";
     document.body.appendChild(container);
     return { getContainer: () => container };
+}
+
+/** A fake event bus that records handlers so a test can fire `import.done`. */
+function fakeEventBus() {
+    const handlers: Record<string, Array<(e: unknown) => void>> = {};
+    return {
+        on: (event: string, cb: (e: unknown) => void) => {
+            (handlers[event] ??= []).push(cb);
+        },
+        fire: (event: string, e?: unknown) => {
+            (handlers[event] ?? []).forEach((h) => h(e));
+        },
+    };
 }
 
 /** Appends a vendor summary pill (wrapped, as bpmn-js-bpmnlint mounts it) to a container. */
@@ -42,83 +71,234 @@ function addPill(container: HTMLElement): HTMLButtonElement {
     return pill;
 }
 
+type Bus = ReturnType<typeof fakeEventBus>;
+
+/** Builds a service under test with sensible fakes; overrides via `opts`. */
+function makeService(opts: {
+    tier: LintTierInit["tier"];
+    callbacks?: LintCallbacks;
+    imported?: boolean;
+    withPill?: boolean;
+}) {
+    const linting = fakeLinting();
+    const canvas = fakeCanvas();
+    if (opts.withPill !== false) {
+        addPill(canvas.getContainer());
+    }
+    const bus = fakeEventBus();
+    const callbacks: LintCallbacks = opts.callbacks ?? {
+        onLintResults: vi.fn(),
+        onLintingToggled: vi.fn(),
+    };
+    const bpmnjs = { getDefinitions: () => (opts.imported ? {} : null) };
+    const service = new LintConfigService(
+        linting,
+        { tier: opts.tier, engine: "c7" },
+        callbacks,
+        (s) => s,
+        canvas,
+        bpmnjs,
+        bus,
+    );
+    return { service, linting, canvas, bus: bus as Bus, callbacks };
+}
+
+function clickOffButton(container: HTMLElement): void {
+    container
+        .querySelector<HTMLButtonElement>(".lint-off-button")
+        ?.dispatchEvent(new Event("click"));
+}
+
+function clickEnableButton(container: HTMLElement): void {
+    container
+        .querySelector<HTMLButtonElement>(".lint-enable-button")
+        ?.dispatchEvent(new Event("click"));
+}
+
 beforeEach(() => {
     document.body.innerHTML = "";
     vi.clearAllMocks();
+    runMock.mockResolvedValue(LINT_EVENT);
 });
 
-describe("LintConfigService.render", () => {
-    it("overrides linting.lint to return the host-provided results", async () => {
-        const linting = fakeLinting();
-        const svc = new LintConfigService(linting, lintingHost, (s) => s, fakeCanvas());
+describe("LintConfigService: tier initialisation", () => {
+    it("external tier stays inactive and replays host-pushed results", async () => {
+        const onLintResults = vi.fn();
+        const { linting } = makeService({ tier: "external", callbacks: { onLintResults } });
 
-        const results = { "label-required": [{ id: "Task_1", message: "x", category: "warn" }] };
-        svc.render(results);
-
+        expect(linting.isActive()).toBe(false);
         expect(linting.lint).toBeDefined();
-        await expect(linting.lint!()).resolves.toEqual(results);
+        // Nothing pushed yet → empty results, and an external lint never echoes.
+        await expect(linting.lint()).resolves.toEqual({});
+        expect(onLintResults).not.toHaveBeenCalled();
     });
 
-    it("activates linting and marks the container active when results arrive", () => {
-        const linting = fakeLinting();
-        const canvas = fakeCanvas();
+    it("in-page tier activates on import.done and marks its container", () => {
+        const { linting, canvas, bus } = makeService({ tier: "in-page" });
 
-        new LintConfigService(linting, lintingHost, (s) => s, canvas).render({});
+        expect(linting.isActive()).toBe(false);
+        bus.fire("import.done");
 
         expect(linting.isActive()).toBe(true);
         expect(canvas.getContainer().classList.contains("bpmnlint-active")).toBe(true);
-        // Never leaks onto the page-global body — that is what let two modelers
-        // clobber each other before scoping.
+        expect(canvas.getContainer().querySelector(".lint-off-button")).not.toBeNull();
+    });
+
+    it("in-page tier activates immediately when a diagram is already imported", () => {
+        const { linting } = makeService({ tier: "in-page", imported: true });
+        expect(linting.isActive()).toBe(true);
+    });
+
+    it("in-page lint runs the browser linter, emits the raw event, and returns a copy", async () => {
+        const onLintResults = vi.fn();
+        const { linting, bus } = makeService({ tier: "in-page", callbacks: { onLintResults } });
+        bus.fire("import.done");
+
+        const returned = await linting.lint();
+
+        expect(runMock).toHaveBeenCalled();
+        expect(onLintResults).toHaveBeenCalledWith(LINT_EVENT);
+        // The vendor mutates the returned reports in place, so it must be a copy —
+        // never the object handed to onLintResults.
+        expect(returned).toEqual(LINT_EVENT.results);
+        expect(returned).not.toBe(LINT_EVENT.results);
+        expect((returned as typeof LINT_EVENT.results)["label-required"][0]).not.toBe(
+            LINT_EVENT.results["label-required"][0],
+        );
+    });
+});
+
+describe("LintConfigService: precedence (any push wins)", () => {
+    it("an external push switches an in-page instance to external and suspends in-page lint", async () => {
+        const onLintResults = vi.fn();
+        const { service, bus, linting } = makeService({
+            tier: "in-page",
+            callbacks: { onLintResults },
+        });
+        bus.fire("import.done");
+        onLintResults.mockClear();
+
+        const pushed = { "rule-y": [{ id: "B", message: "y", category: "error" }] };
+        service.applyLintResults(pushed);
+
+        // Now external: lint replays the pushed results and never echoes.
+        await expect(linting.lint()).resolves.toEqual(pushed);
+        expect(onLintResults).not.toHaveBeenCalled();
+        expect(runMock).not.toHaveBeenCalled();
+    });
+});
+
+describe("LintConfigService: toggle matrix", () => {
+    it("in-page off-button disables optimistically and reports the toggle", async () => {
+        const onLintingToggled = vi.fn();
+        const { service, canvas, bus, linting } = makeService({
+            tier: "in-page",
+            callbacks: { onLintingToggled },
+        });
+        void service;
+        bus.fire("import.done");
+        linting.toggle.mockClear();
+
+        clickOffButton(canvas.getContainer());
+
+        expect(onLintingToggled).toHaveBeenCalledWith(false);
+        expect(linting.toggle).toHaveBeenCalledWith(false);
+        expect(canvas.getContainer().querySelector(".lint-disabled-chip")).not.toBeNull();
+        // Suspended: a relint now yields nothing.
+        await expect(linting.lint()).resolves.toEqual({});
+    });
+
+    it("re-enable from the disabled chip reactivates in-page linting", async () => {
+        const onLintingToggled = vi.fn();
+        const { canvas, bus, linting } = makeService({
+            tier: "in-page",
+            callbacks: { onLintingToggled },
+        });
+        bus.fire("import.done");
+        clickOffButton(canvas.getContainer());
+        onLintingToggled.mockClear();
+
+        clickEnableButton(canvas.getContainer());
+
+        expect(onLintingToggled).toHaveBeenCalledWith(true);
+        expect(linting.isActive()).toBe(true);
+        await expect(linting.lint()).resolves.toEqual(LINT_EVENT.results);
+    });
+
+    it("external off-button reports the toggle only; overlays await the host push", () => {
+        const onLintingToggled = vi.fn();
+        const { service, canvas, linting } = makeService({
+            tier: "external",
+            callbacks: { onLintingToggled },
+        });
+        // Host pushed results first, so the off button exists.
+        service.applyLintResults({ "rule-z": [{ id: "C", message: "z", category: "warn" }] });
+        linting.toggle.mockClear();
+
+        clickOffButton(canvas.getContainer());
+
+        expect(onLintingToggled).toHaveBeenCalledWith(false);
+        // No optimistic local change in the external tier.
+        expect(linting.toggle).not.toHaveBeenCalled();
+        expect(canvas.getContainer().querySelector(".lint-disabled-chip")).toBeNull();
+    });
+
+    it("programmatic renders never fire the toggle callback", () => {
+        const onLintingToggled = vi.fn();
+        const { service } = makeService({ tier: "external", callbacks: { onLintingToggled } });
+
+        service.applyLintResults({});
+        service.applyLintResults(null);
+        service.applyLintingDisabled();
+
+        expect(onLintingToggled).not.toHaveBeenCalled();
+    });
+});
+
+describe("LintConfigService: external rendering (unchanged host flow)", () => {
+    it("activates linting and marks the container active when results arrive", () => {
+        const { service, canvas, linting } = makeService({ tier: "external" });
+
+        service.applyLintResults({});
+
+        expect(linting.isActive()).toBe(true);
+        expect(canvas.getContainer().classList.contains("bpmnlint-active")).toBe(true);
         expect(document.body.classList.contains("bpmnlint-active")).toBe(false);
     });
 
-    it("re-renders via update() when already active", () => {
-        const linting = fakeLinting();
-        linting.active = true;
-        const svc = new LintConfigService(linting, lintingHost, (s) => s, fakeCanvas());
-
-        svc.render({});
-
-        expect(linting.update).toHaveBeenCalledTimes(1);
-        expect(linting.toggle).not.toHaveBeenCalled();
-    });
-
     it("deactivates linting and clears the container class when results are null", () => {
-        const linting = fakeLinting();
-        linting.active = true;
-        const canvas = fakeCanvas();
-        canvas.getContainer().classList.add("bpmnlint-active");
+        const { service, canvas, linting } = makeService({ tier: "external" });
+        service.applyLintResults({});
+        linting.toggle.mockClear();
 
-        new LintConfigService(linting, lintingHost, (s) => s, canvas).render(null);
+        service.applyLintResults(null);
 
         expect(linting.toggle).toHaveBeenCalledWith(false);
         expect(canvas.getContainer().classList.contains("bpmnlint-active")).toBe(false);
-    });
-
-    it("does not toggle when already inactive and results are null", () => {
-        const linting = fakeLinting();
-
-        new LintConfigService(linting, lintingHost, (s) => s, fakeCanvas()).render(null);
-
-        expect(linting.toggle).not.toHaveBeenCalled();
     });
 });
 
 describe("LintConfigService: per-container scoping", () => {
     it("wraps only its own container's pill and marks only its own container", () => {
+        const linting = fakeLinting();
         const canvasA = fakeCanvas();
         const canvasB = fakeCanvas();
-        const containerA = canvasA.getContainer();
-        const containerB = canvasB.getContainer();
-        addPill(containerA);
-        addPill(containerB);
+        addPill(canvasA.getContainer());
+        addPill(canvasB.getContainer());
 
-        new LintConfigService(fakeLinting(), lintingHost, (s) => s, canvasA).render({});
+        new LintConfigService(
+            linting,
+            { tier: "external", engine: "c7" },
+            {},
+            (s) => s,
+            canvasA,
+            { getDefinitions: () => null },
+            fakeEventBus(),
+        ).applyLintResults({});
 
-        // The off-button toolbar is built around A's pill, inside A's container.
-        expect(containerA.querySelector(".lint-toolbar")).not.toBeNull();
-        expect(containerB.querySelector(".lint-toolbar")).toBeNull();
-        expect(containerA.classList.contains("bpmnlint-active")).toBe(true);
-        expect(containerB.classList.contains("bpmnlint-active")).toBe(false);
+        expect(canvasA.getContainer().querySelector(".lint-toolbar")).not.toBeNull();
+        expect(canvasB.getContainer().querySelector(".lint-toolbar")).toBeNull();
+        expect(canvasA.getContainer().classList.contains("bpmnlint-active")).toBe(true);
+        expect(canvasB.getContainer().classList.contains("bpmnlint-active")).toBe(false);
     });
 });

--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
@@ -1,25 +1,23 @@
-import { LintResults } from "@miragon/bpmn-modeler-types";
+import type {
+    BpmnlintConfig,
+    Engine,
+    LintResults,
+    LintRunEvent,
+} from "@miragon/bpmn-modeler-types";
+
+import { BrowserLinter } from "./browserLinter";
 
 /**
  * The subset of `bpmn-js-bpmnlint`'s `linting` module this service drives. The
  * package ships no types, so we declare only the members we touch: `lint` is
- * overridden to return host-computed results, and `update`/`isActive`/`toggle`
- * repaint or clear the overlays.
+ * overridden per tier, and `update`/`isActive`/`toggle` repaint or clear the
+ * overlays.
  */
 interface Linting {
     lint: () => Promise<LintResults>;
     update(): void;
     isActive(): boolean;
     toggle(active: boolean): void;
-}
-
-/**
- * The single host capability this service needs, registered as the `lintingHost`
- * DI value in bootstrap. Narrow on purpose so the service never touches the
- * postMessage protocol — bootstrap translates the call into the host command.
- */
-interface LintingHost {
-    setLintingEnabled(enabled: boolean): void;
 }
 
 /**
@@ -32,34 +30,112 @@ interface Canvas {
     getContainer(): HTMLElement;
 }
 
+/** The bpmn-js viewer, injected as `bpmnjs`; only its definitions root is read. */
+interface Bpmnjs {
+    getDefinitions(): unknown;
+}
+
+/** diagram-js's event bus, injected as `eventBus`; only import completion is observed. */
+interface EventBus {
+    on(event: string, callback: (event: unknown) => void): void;
+}
+
 type Translate = (template: string) => string;
+
+/**
+ * The per-instance tier decision, registered as the `lintTier` DI value by
+ * {@link createLintModule}. `"external"` keeps today's host-pushed flow;
+ * `"in-page"` runs {@link BrowserLinter} in the webview against the given
+ * `engine` (and optional explicit `config`). `false`/off never reaches here — a
+ * disabled instance registers no lint module at all.
+ */
+export interface LintTierInit {
+    tier: "external" | "in-page";
+    engine: Engine;
+    config?: BpmnlintConfig;
+}
+
+/**
+ * The facade callbacks, registered as the `lintCallbacks` DI value.
+ * `onLintResults` fires after every *in-page* run (never for an external push,
+ * so a host feeding results does not echo them); `onLintingToggled` fires when
+ * the user flips the in-canvas chrome, in every active tier.
+ */
+export interface LintCallbacks {
+    onLintResults?: (event: LintRunEvent) => void;
+    onLintingToggled?: (enabled: boolean) => void;
+}
+
+/**
+ * The live tier of one modeler instance.
+ *
+ *  - `external` — results arrive via {@link LintConfigService.applyLintResults};
+ *    the webview only paints them (the host runs the linter).
+ *  - `in-page` — the webview lints itself via {@link BrowserLinter} on every
+ *    relint the vendor schedules.
+ *  - `in-page-disabled` — the user turned in-page linting off from the canvas;
+ *    overlays are cleared and a re-enable chip is shown, but the tier is
+ *    remembered so a re-import does not silently reactivate it.
+ *
+ * Precedence: any external push wins — it switches an in-page instance to
+ * `external` and suspends the in-page run.
+ */
+type LintTierState = "external" | "in-page" | "in-page-disabled";
 
 // A slashed circle, painted in `currentColor` so it inherits the chip's text
 // colour like the vendor lint icon does.
 const OFF_ICON = `<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="6"/><line x1="4" y1="4" x2="12" y2="12"/></svg>`;
 
 /**
- * bpmn-js DI service (registered by {@link LintModule}) that renders
- * host-computed bpmnlint results in the canvas. The extension host now runs the
- * linter (a full Node context, so it resolves custom `bpmnlint-plugin-*` rules
- * against the workspace); the webview only paints overlays.
+ * Vendor `_formatIssues` mutates each report object in place (it writes
+ * `report.rule`, `report.isChildIssue`, …). So the object we hand the vendor must
+ * not be the one we emitted through `onLintResults`: copy every report first so
+ * the emitted {@link LintRunEvent} stays the pristine rule-keyed output.
+ */
+function shallowCopyResults(results: LintResults): LintResults {
+    const copy: LintResults = {};
+    for (const [rule, reports] of Object.entries(results)) {
+        copy[rule] = reports.map((report) => ({ ...report }));
+    }
+    return copy;
+}
+
+/**
+ * bpmn-js DI service (registered by {@link createLintModule}) that owns one
+ * modeler's bpmnlint tier and its in-canvas chrome.
  *
- * It feeds results into `bpmn-js-bpmnlint`'s `linting` module by overriding the
- * module's `lint()` to return whatever the host last sent, instead of running a
- * browser-side `Linter`. The module's own `update()` — fired on import, element
- * changes, and toggles — then diffs and draws the overlays exactly as before, so
- * no overlay/rendering code changes.
+ * It drives `bpmn-js-bpmnlint`'s `linting` module by overriding its `lint()` —
+ * the module's own `update()` (fired on import, element changes, toggles) then
+ * diffs and draws the overlays exactly as before, so no overlay/rendering code
+ * changes across tiers. The override's body depends on the tier: `external`
+ * returns the host's last-pushed results; `in-page` runs {@link BrowserLinter}
+ * against the live tree and emits the raw result through `onLintResults`;
+ * `in-page-disabled` returns nothing so the linter, which the vendor keeps
+ * running even while inactive, does no real work.
  *
  * It also owns the in-canvas **disable affordance**: an "off" button beside the
- * lint summary pill (so the hint advertises that it can be switched off), and a
- * muted "Linting off" chip shown in its place once disabled — the entry points a
- * non-technical user needs, since they may never open VS Code settings. Both
- * write the choice back through the host, which re-lints and pushes the new
- * state down ({@link render} / {@link renderDisabled}); the webview never flips
- * its own overlays optimistically.
+ * lint summary pill, and a muted "Linting off" chip with an "Enable" action in
+ * its place once disabled — the entry points a non-technical user needs, since
+ * they may never open host settings. In the in-page tier the toggle is applied
+ * optimistically (the webview owns the linter); in the external tier it is
+ * reported through `onLintingToggled` and the overlays wait for the host's push,
+ * exactly as before.
  */
 export class LintConfigService {
-    static $inject = ["linting", "lintingHost", "translate", "canvas"];
+    static $inject = [
+        "linting",
+        "lintTier",
+        "lintCallbacks",
+        "translate",
+        "canvas",
+        "bpmnjs",
+        "eventBus",
+    ];
+
+    private state: LintTierState;
+
+    // Present only in the in-page tier; undefined for external instances.
+    private readonly browserLinter?: BrowserLinter;
 
     private results: LintResults = {};
 
@@ -71,15 +147,88 @@ export class LintConfigService {
 
     constructor(
         private readonly linting: Linting,
-        private readonly lintingHost: LintingHost,
+        tierInit: LintTierInit,
+        private readonly callbacks: LintCallbacks,
         private readonly translate: Translate,
         private readonly canvas: Canvas,
+        private readonly bpmnjs: Bpmnjs,
+        eventBus: EventBus,
     ) {
-        // Replace the browser-side lint run with the host's precomputed results.
-        // `update()` calls `this.lint()`; returning the stored results makes every
-        // relint (import.done / elements.changed) repaint them until the host,
-        // which re-lints on document change, sends a fresh set.
-        this.linting.lint = () => Promise.resolve(this.results);
+        this.state = tierInit.tier === "in-page" ? "in-page" : "external";
+        if (tierInit.tier === "in-page") {
+            this.browserLinter = new BrowserLinter(tierInit.engine, tierInit.config);
+        }
+
+        // One `lint` override for every tier; {@link runLint} branches on state.
+        // The vendor calls it from `update()` on import.done / elements.changed.
+        this.linting.lint = () => this.runLint();
+
+        // In-page linting switches itself on once a diagram is present. Guarded on
+        // the current state so a re-import never resurrects a user-disabled linter.
+        if (tierInit.tier === "in-page") {
+            eventBus.on("import.done", () => {
+                if (this.state === "in-page") {
+                    this.activateInPage();
+                }
+            });
+            if (this.bpmnjs.getDefinitions()) {
+                this.activateInPage();
+            }
+        }
+    }
+
+    /**
+     * Applies host-pushed results (external tier). Any push wins: an in-page
+     * instance switches to `external` and its in-page run is suspended. `null`
+     * deactivates linting — the no-config experience, unchanged from before.
+     */
+    applyLintResults(results: LintResults | null): void {
+        this.state = "external";
+        this.render(results);
+    }
+
+    /**
+     * Applies the host's **user-disabled** push (external tier): clears the
+     * overlays and shows the re-enable chip. Switches an in-page instance to
+     * `external` as any push does.
+     */
+    applyLintingDisabled(): void {
+        this.state = "external";
+        this.renderDisabled();
+    }
+
+    /**
+     * The tier-dependent body behind the vendor's `lint()`. Only the in-page tier
+     * emits `onLintResults`, and only it returns freshly copied reports (the
+     * vendor mutates them); the external tier replays the host's last results and
+     * the disabled tier returns nothing so no overlays are drawn.
+     */
+    private async runLint(): Promise<LintResults> {
+        if (this.state === "in-page" && this.browserLinter) {
+            const event = await this.browserLinter.run(this.bpmnjs.getDefinitions());
+            this.callbacks.onLintResults?.(event);
+            return shallowCopyResults(event.results);
+        }
+        if (this.state === "in-page-disabled") {
+            return {};
+        }
+        return this.results;
+    }
+
+    /**
+     * Switches the in-page linter on: marks the container, activates the vendor
+     * module (which triggers the first relint through our override), and shows the
+     * off button. Idempotent — a relint reuses the existing chrome.
+     */
+    private activateInPage(): void {
+        this.hideDisabledChip();
+        this.canvas.getContainer().classList.add("bpmnlint-active");
+        if (this.linting.isActive()) {
+            this.linting.update();
+        } else {
+            this.linting.toggle(true);
+        }
+        this.showOffButton();
     }
 
     /**
@@ -87,7 +236,7 @@ export class LintConfigService {
      * `.bpmnlintrc`, or a host read/lint failure) — keeping the no-config
      * experience identical to before linting moved to the host.
      */
-    render(results: LintResults | null): void {
+    private render(results: LintResults | null): void {
         this.hideDisabledChip();
         if (!results) {
             this.results = {};
@@ -117,7 +266,7 @@ export class LintConfigService {
      * chip so the user can turn linting back on from inside the canvas — the
      * summary pill they would otherwise click is gone.
      */
-    renderDisabled(): void {
+    private renderDisabled(): void {
         this.results = {};
         if (this.linting.isActive()) {
             this.linting.toggle(false);
@@ -125,6 +274,33 @@ export class LintConfigService {
         this.canvas.getContainer().classList.remove("bpmnlint-active");
         this.hideOffButton();
         this.showDisabledChip();
+    }
+
+    /**
+     * Handles the off button. Reports the toggle to the host in every tier; in the
+     * in-page tier it also flips the state and clears the overlays optimistically
+     * (the webview owns the linter). In the external tier the render waits for the
+     * host's disabled push — today's behaviour.
+     */
+    private handleOffClick(): void {
+        this.callbacks.onLintingToggled?.(false);
+        if (this.state === "in-page") {
+            this.state = "in-page-disabled";
+            this.renderDisabled();
+        }
+    }
+
+    /**
+     * Handles the re-enable chip. Reports the toggle in every tier; in the in-page
+     * tier it also flips back and re-runs the in-page lint. In the external tier
+     * the overlays wait for the host's push.
+     */
+    private handleEnableClick(): void {
+        this.callbacks.onLintingToggled?.(true);
+        if (this.state === "in-page-disabled") {
+            this.state = "in-page";
+            this.activateInPage();
+        }
     }
 
     /**
@@ -171,7 +347,7 @@ export class LintConfigService {
             button.title = label;
             button.setAttribute("aria-label", label);
             button.addEventListener("click", () => {
-                this.lintingHost.setLintingEnabled(false);
+                this.handleOffClick();
             });
             this.offButton = button;
         }
@@ -209,7 +385,7 @@ export class LintConfigService {
             enable.className = "lint-enable-button";
             enable.textContent = this.translate("Enable");
             enable.addEventListener("click", () => {
-                this.lintingHost.setLintingEnabled(true);
+                this.handleEnableClick();
             });
 
             chip.appendChild(text);

--- a/apps/bpmn-webview/src/app/bpmnlint/browserLinter.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/browserLinter.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { BrowserLinter } from "./browserLinter";
+
+type ModdleFactory = (ext?: Record<string, unknown>) => {
+    fromXML: (x: string) => Promise<{ rootElement: unknown }>;
+};
+
+/**
+ * The browser-compat gate for #1373: `@miragon/bpmnlint-plugin-rules` and
+ * bpmnlint's `Linter` have only ever run in Node here. This drives the real stack
+ * (no mocks) over a parsed moddle tree in jsdom, so a rule reaching for a Node API
+ * fails here — the earliest signal — rather than blank in a host webview. A rule
+ * the bundled resolver cannot cover would degrade to `unresolved`, never throw.
+ */
+
+// A minimal C7 diagram with an unlabelled task — enough tree for the structural
+// rules to walk without needing any Camunda-namespaced properties.
+const XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+  </bpmn:process>
+</bpmn:definitions>`;
+
+async function parse(xml: string): Promise<unknown> {
+    // bpmn-moddle's default export is the factory (called, not `new`); its ESM
+    // interop exposes it under `default` or `BpmnModdle`, mirroring NodeBpmnLinter.
+    const mod = (await import("bpmn-moddle")) as unknown as {
+        default?: ModdleFactory;
+        BpmnModdle?: ModdleFactory;
+    };
+    const factory = mod.default ?? mod.BpmnModdle;
+    if (!factory) {
+        throw new Error("bpmn-moddle exposed no factory");
+    }
+    const { rootElement } = await factory().fromXML(xml);
+    return rootElement;
+}
+
+describe("BrowserLinter (jsdom browser-compat smoke)", () => {
+    it("lints a parsed tree with the engine-aware default config without throwing", async () => {
+        const definitions = await parse(XML);
+
+        const event = await new BrowserLinter("c7").run(definitions);
+
+        expect(event.results).toBeTypeOf("object");
+        expect(Array.isArray(event.unresolved)).toBe(true);
+        // Every value in a lint result is a rule's report array.
+        for (const reports of Object.values(event.results)) {
+            expect(Array.isArray(reports)).toBe(true);
+        }
+    });
+
+    it("flags a missing label with the default modeling preset", async () => {
+        const definitions = await parse(XML);
+
+        const { results } = await new BrowserLinter("c7").run(definitions);
+
+        // The task carries no name; bpmnlint:recommended's label-required is part of
+        // the structural base, so it must report at least one finding.
+        expect(results["label-required"]?.length ?? 0).toBeGreaterThan(0);
+    });
+});

--- a/apps/bpmn-webview/src/app/bpmnlint/browserLinter.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/browserLinter.ts
@@ -1,0 +1,55 @@
+import type {
+    BpmnlintConfig,
+    Engine,
+    LintResults,
+    LintRunEvent,
+} from "@miragon/bpmn-modeler-types";
+import { getDefaultLintConfig } from "@miragon/bpmnlint-plugin-rules";
+import { Linter } from "bpmnlint";
+
+import { RecordingBrowserResolver, staticUnresolvedModdleExtensions } from "./browserResolver";
+
+/**
+ * Runs bpmnlint against the *live* bpmn-js definitions tree, in the browser.
+ *
+ * This is the in-page tier of the #1373 lint ladder: instead of the host running
+ * `NodeBpmnLinter` and pushing results down, the webview lints itself. The config
+ * is either an explicit `{config}` a consumer supplied or the engine-aware
+ * zero-config default (`getDefaultLintConfig({engine, preset: "modeling"})`,
+ * matching the hosts' preset for later parity). Rules the bundled resolver cannot
+ * cover degrade to no-ops and are reported via {@link LintRunEvent.unresolved},
+ * so an unusual `{config}` is never fatal.
+ *
+ * The resolver is created once and reused; each {@link run} resets its recorded
+ * misses so the emitted `unresolved` reflects that single lint. `moddleExtensions`
+ * the browser cannot honour are computed once at construction (the config is
+ * immutable for the instance's life) and merged into every run's `unresolved`.
+ */
+export class BrowserLinter {
+    private readonly config: BpmnlintConfig;
+
+    private readonly resolver = new RecordingBrowserResolver();
+
+    private readonly staticUnresolved: string[];
+
+    constructor(engine: Engine, config?: BpmnlintConfig) {
+        this.config = config ?? getDefaultLintConfig({ engine, preset: "modeling" });
+        this.staticUnresolved = staticUnresolvedModdleExtensions(this.config);
+    }
+
+    /**
+     * Lints the given definitions tree and returns the rule-keyed results plus the
+     * rules/configs/moddleExtensions that could not be resolved. `definitions` is
+     * the moddle root bpmn-js hands to its own `Linting.lint` — already parsed with
+     * every registered extension, so bpmnlint walks it without re-reading XML.
+     */
+    async run(definitions: unknown): Promise<LintRunEvent> {
+        this.resolver.reset();
+        const linter = new Linter({ config: this.config, resolver: this.resolver });
+        const results = (await linter.lint(definitions)) as LintResults;
+        return {
+            results,
+            unresolved: [...this.resolver.unresolved, ...this.staticUnresolved],
+        };
+    }
+}

--- a/apps/bpmn-webview/src/app/bpmnlint/browserResolver.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/browserResolver.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { RecordingBrowserResolver, staticUnresolvedModdleExtensions } from "./browserResolver";
+
+describe("RecordingBrowserResolver", () => {
+    it("resolves a bundled Miragon rule without recording it as unresolved", () => {
+        const resolver = new RecordingBrowserResolver();
+
+        const rule = resolver.resolveRule("@miragon/bpmnlint-plugin-rules", "no-generated-ids");
+
+        expect(rule).toBeDefined();
+        expect(resolver.unresolved).toEqual([]);
+    });
+
+    it("records an unknown rule and returns a reporting no-op", () => {
+        const resolver = new RecordingBrowserResolver();
+
+        const rule = resolver.resolveRule("bpmnlint-plugin-ghost", "does-not-exist");
+
+        // The no-op is a rule *factory*; invoking it yields an empty check visitor,
+        // so bpmnlint's testRule guard is satisfied and the run does not fail.
+        const built = (rule as () => { check: unknown })();
+        expect(built.check).toBeTypeOf("function");
+        expect(resolver.unresolved).toEqual(["bpmnlint-plugin-ghost/does-not-exist"]);
+    });
+
+    it("records an unknown config under its plugin: key and returns an empty config", () => {
+        const resolver = new RecordingBrowserResolver();
+
+        const config = resolver.resolveConfig("bpmnlint-plugin-ghost", "recommended");
+
+        expect(config).toEqual({ rules: {} });
+        expect(resolver.unresolved).toEqual(["plugin:bpmnlint-plugin-ghost/recommended"]);
+    });
+
+    it("reset() clears the recorded misses between runs", () => {
+        const resolver = new RecordingBrowserResolver();
+        resolver.resolveRule("bpmnlint-plugin-ghost", "x");
+        expect(resolver.unresolved).toHaveLength(1);
+
+        resolver.reset();
+
+        expect(resolver.unresolved).toEqual([]);
+    });
+});
+
+describe("staticUnresolvedModdleExtensions", () => {
+    it("returns nothing when no moddleExtensions are declared", () => {
+        expect(staticUnresolvedModdleExtensions({})).toEqual([]);
+    });
+
+    it("reports string-valued extensions (a browser cannot require a module path)", () => {
+        expect(
+            staticUnresolvedModdleExtensions({
+                moddleExtensions: { custom: "custom-moddle" },
+            }),
+        ).toEqual(["moddleExtension:custom"]);
+    });
+
+    it("honours object extensions on prefixes the live tree already registers", () => {
+        expect(
+            staticUnresolvedModdleExtensions({
+                moddleExtensions: { camunda: { name: "Camunda" }, zeebe: { name: "Zeebe" } },
+            }),
+        ).toEqual([]);
+    });
+
+    it("reports object extensions on prefixes the live tree does not register", () => {
+        expect(
+            staticUnresolvedModdleExtensions({
+                moddleExtensions: { acme: { name: "Acme" } },
+            }),
+        ).toEqual(["moddleExtension:acme"]);
+    });
+});

--- a/apps/bpmn-webview/src/app/bpmnlint/browserResolver.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/browserResolver.ts
@@ -1,0 +1,103 @@
+import type { BpmnlintConfig } from "@miragon/bpmn-modeler-types";
+import { createBundledResolver, type Resolver } from "@miragon/bpmnlint-plugin-rules";
+
+/**
+ * A bpmnlint rule that reports nothing. Substituted for a rule/config the bundled
+ * resolver cannot provide so a single unknown `bpmnlint-plugin-*` reference never
+ * fails the whole run (bpmnlint's `Linter` rejects the entire lint if
+ * `resolveRule`/`resolveConfig` throws). `check` is an empty visitor — a bare
+ * `{}` trips testRule's "no check implemented" guard and surfaces a spurious
+ * rule-error marker.
+ */
+const NOOP_RULE = () => ({ check: () => undefined });
+
+/** An empty shareable config — the `resolveConfig` fallback for a missing plugin config. */
+const NOOP_CONFIG = { rules: {} };
+
+/**
+ * The moddle prefixes the live bpmn-js tree already registers. The webview lints
+ * the in-memory definitions (not re-parsed XML), so any `moddleExtensions` entry
+ * targeting one of these is already satisfied — the typed properties the rules
+ * inspect are present on the tree. Everything else cannot be honoured in a
+ * browser (no `require`), so it is reported, never loaded.
+ */
+const LIVE_MODDLE_PREFIXES = new Set(["bpmn", "bpmndi", "dc", "di", "camunda", "zeebe", "modeler"]);
+
+/**
+ * Wraps `@miragon/bpmnlint-plugin-rules`' bundled resolver (bpmnlint built-ins +
+ * camunda-compat engine layers + the Miragon rules) and *records* every rule or
+ * config the bundle cannot cover instead of throwing. This is the browser twin of
+ * modeler-core's `CompositeResolver`: an unresolved reference is collected in
+ * {@link unresolved} and backed by a no-op, so an explicit `{config}` that names
+ * a rule only a workspace install would provide degrades gracefully rather than
+ * killing the lint.
+ *
+ * The instance is reused across lint runs; {@link reset} clears the list at the
+ * start of each run so `unresolved` always reflects the latest lint alone.
+ */
+export class RecordingBrowserResolver implements Resolver {
+    /** Names of rules/configs the bundle could not resolve this run. */
+    readonly unresolved: string[] = [];
+
+    private readonly bundled: Resolver = createBundledResolver();
+
+    resolveRule(pkg: string, ruleName: string): unknown {
+        const resolved = this.tryResolve(() => this.bundled.resolveRule(pkg, ruleName));
+        if (resolved != null) {
+            return resolved;
+        }
+        this.unresolved.push(`${pkg}/${ruleName}`);
+        return NOOP_RULE;
+    }
+
+    resolveConfig(pkg: string, configName: string): unknown {
+        const resolved = this.tryResolve(() => this.bundled.resolveConfig(pkg, configName));
+        if (resolved != null) {
+            return resolved;
+        }
+        this.unresolved.push(`plugin:${pkg}/${configName}`);
+        return NOOP_CONFIG;
+    }
+
+    /** Clears the recorded misses so a fresh run starts from an empty list. */
+    reset(): void {
+        this.unresolved.length = 0;
+    }
+
+    /**
+     * The bundled resolver throws on a miss, so a throw is a normal miss (not an
+     * error to propagate); only a nullish result also counts as a miss.
+     */
+    private tryResolve(resolve: () => unknown): unknown {
+        try {
+            const resolved = resolve();
+            return resolved != null ? resolved : undefined;
+        } catch {
+            return undefined;
+        }
+    }
+}
+
+/**
+ * The `moddleExtensions` a browser lint run cannot honour, in the same
+ * `moddleExtension:<prefix>` form the Node linter reports. A string value is a
+ * module path only Node can `require`; an object value is only usable when its
+ * prefix is one the live tree already registers (otherwise its typed properties
+ * were never parsed onto the model). Everything unhonourable is returned so it
+ * can be merged into the run's `unresolved` list — informational, never fatal.
+ */
+export function staticUnresolvedModdleExtensions(config: BpmnlintConfig): string[] {
+    const declared = config.moddleExtensions;
+    if (!declared || typeof declared !== "object") {
+        return [];
+    }
+    const unresolved: string[] = [];
+    for (const [prefix, value] of Object.entries(declared)) {
+        const honoured =
+            value != null && typeof value === "object" && LIVE_MODDLE_PREFIXES.has(prefix);
+        if (!honoured) {
+            unresolved.push(`moddleExtension:${prefix}`);
+        }
+    }
+    return unresolved;
+}

--- a/apps/bpmn-webview/src/app/bpmnlint/index.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/index.ts
@@ -1,24 +1,39 @@
 /**
- * Self-contained bpmn-js DI module for in-canvas bpmnlint overlays.
+ * Lazy-loaded chunk entry for in-canvas bpmnlint (#1373, AC 6).
  *
- * Pulls in `bpmn-js-bpmnlint` (the linter's in-canvas button + overlays) and its
- * stylesheet, and registers {@link LintConfigService}, which renders the
- * host-computed lint results. The linter itself now runs in the extension host
- * (so it can resolve custom `bpmnlint-plugin-*` rules against the workspace); the
- * webview only paints overlays. Drop {@link LintModule} into the modeler's
- * `additionalModules` like any other module; the host's results arrive later via
- * the `bpmnLintConfig` service.
+ * This module — and only this module — statically imports the lint stack
+ * (`bpmn-js-bpmnlint`, `bpmnlint`'s `Linter`, `@miragon/bpmnlint-plugin-rules`,
+ * and the CSS). Because {@link BpmnModeler.create} reaches it through a dynamic
+ * `import("./bpmnlint")`, the whole stack lands in a separate chunk that is
+ * fetched only when an instance actually lints (`linting !== false`), keeping it
+ * out of the main webview bundle.
+ *
+ * bpmn-js modules are fixed at construction, so the chunk must resolve *before*
+ * `new BpmnModeler7/8`. The facade awaits this import, then calls
+ * {@link createLintModule} with the per-instance tier + config + callbacks and
+ * drops the returned module into `additionalModules`.
  */
 import bpmnLintingModule from "bpmn-js-bpmnlint";
 import "bpmn-js-bpmnlint/dist/assets/css/bpmn-js-bpmnlint.css";
 import "./bpmnlint.css";
 
-import { LintConfigService } from "./LintConfigService";
+import { LintCallbacks, LintConfigService, LintTierInit } from "./LintConfigService";
 
-const LintModule = {
-    __depends__: [bpmnLintingModule],
-    bpmnLintConfig: ["type", LintConfigService],
-};
+/**
+ * Builds the bpmn-js DI module for one modeler instance: the vendor overlay
+ * module plus {@link LintConfigService} and the two per-instance value providers
+ * it injects (`lintTier`, `lintCallbacks`). `bpmnLintConfig` is eagerly
+ * initialised (`__init__`) so the in-page tier can subscribe to `import.done`
+ * and start linting without the host ever calling `getService`.
+ */
+export function createLintModule(tier: LintTierInit, callbacks: LintCallbacks): unknown {
+    return {
+        __depends__: [bpmnLintingModule],
+        __init__: ["bpmnLintConfig"],
+        bpmnLintConfig: ["type", LintConfigService],
+        lintTier: ["value", tier],
+        lintCallbacks: ["value", callbacks],
+    };
+}
 
-export default LintModule;
-export { LintConfigService } from "./LintConfigService";
+export type { LintCallbacks, LintTierInit } from "./LintConfigService";

--- a/apps/bpmn-webview/src/app/createModeler.ts
+++ b/apps/bpmn-webview/src/app/createModeler.ts
@@ -1,5 +1,6 @@
-import type { BpmnModelerSetting } from "@miragon/bpmn-modeler-types";
+import type { BpmnModelerSetting, LintRunEvent } from "@miragon/bpmn-modeler-types";
 import type { ModelerCapabilities } from "./capabilities";
+import type { LintingOptions } from "./publicApi";
 import { BpmnModeler } from "./modeler";
 
 /**
@@ -17,10 +18,21 @@ export interface CreateModelerOptions {
     /** Per-feature host ports; each present port registers its feature's module. */
     capabilities?: ModelerCapabilities;
     /**
-     * Lint on/off chip port. Defaults to a no-op so a host-less consumer works
-     * — `LintConfigService.$inject` requires the `lintingHost` DI value.
+     * The bpmnlint tier — see {@link LintingOptions}. Omitted (`undefined`) means
+     * in-page linting is on with the engine-aware default config.
      */
-    lintingHost?: { setLintingEnabled(enabled: boolean): void };
+    linting?: LintingOptions;
+    /**
+     * Fired after every in-page lint run with the raw rule-keyed results and the
+     * rules the bundled resolver could not cover. Never fires for an external
+     * push, so a host feeding results does not echo them back.
+     */
+    onLintResults?: (event: LintRunEvent) => void;
+    /**
+     * Fired when the user toggles linting via the in-canvas chrome, in every
+     * active tier. bootstrap forwards it to the host as `SetLintingEnabledCommand`.
+     */
+    onLintingToggled?: (enabled: boolean) => void;
     /**
      * Page-level colour theme stays outside the facade (it is shared with the
      * dmn-webview and owns a single `#theme-link`). bootstrap passes

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -13,6 +13,7 @@ import { CreateAppendC7ElementTemplatesModule } from "@miragon/create-append-c7"
 import {
     BpmnModelerSetting,
     Engine,
+    LintResults,
     NoModelerError,
     OpenScriptEditorRef,
     ScriptKind,
@@ -29,10 +30,11 @@ import { ViewportManager } from "./viewport";
 import { SelectionManager } from "./selection";
 import { RootElementManager } from "./rootElement";
 import { deriveEngines } from "./engines";
-import LintModule from "./bpmnlint";
 import { installKeyboardFocus } from "./keyboardFocus";
 import { installCanvasFocusIndicator } from "./canvasFocusIndicator";
 import type { CreateModelerOptions } from "./createModeler";
+// Type-only: erased at build so it never pulls the lazy lint chunk into the main bundle.
+import type { LintConfigService } from "./bpmnlint/LintConfigService";
 
 const DEFAULT_SETTINGS: BpmnModelerSetting = {
     alignToOrigin: false,
@@ -148,17 +150,9 @@ export class BpmnModeler {
      *   `"c8"` for Camunda Cloud 8.
      * @throws {UnsupportedEngineError} If the engine string is not recognised.
      */
-    create(engine: Engine): void {
+    async create(engine: Engine): Promise<void> {
         this.disposeFocusFeatures();
 
-        // The linting toggle is always registered (LintModule) but its host port
-        // is optional; a no-op keeps LintConfigService's DI resolvable host-less.
-        const lintingHostModule = {
-            lintingHost: [
-                "value",
-                this.options.lintingHost ?? { setLintingEnabled: () => undefined },
-            ],
-        };
         // Per-instance panel host, so id-coupled DI services (scriptEditorButtons)
         // observe this modeler's own panel instead of the first `#js-properties-panel`.
         const propertiesPanelRootModule = {
@@ -166,11 +160,10 @@ export class BpmnModeler {
         };
         const commonModules = [
             TokenSimulationModule,
-            LintModule,
+            ...(await this.buildLintModules(engine)),
             ElementTemplateChooserModule,
             AppendMenuModule,
             FlowNavigationModule,
-            lintingHostModule,
             propertiesPanelRootModule,
         ];
         const capModules = capabilityModules(engine, this.options.capabilities);
@@ -227,6 +220,76 @@ export class BpmnModeler {
                 appendMenuOverride.setFavourites(this.settings.favouriteBpmnElements);
             }
         }
+    }
+
+    /**
+     * Resolves the bpmnlint DI module(s) for the chosen tier, importing the lint
+     * chunk only when linting is not disabled (#1373, AC 6). `linting: false`
+     * returns no modules — the chunk, and the whole bpmnlint/rules stack, is never
+     * fetched. Every other value dynamically imports {@link createLintModule} and
+     * registers one instance-scoped module carrying the tier, engine, explicit
+     * config, and the facade callbacks.
+     */
+    private async buildLintModules(engine: Engine): Promise<unknown[]> {
+        const linting = this.options.linting;
+        if (linting === false) {
+            return [];
+        }
+        // `undefined` and `{ config }` are in-page; only `{ results: "external" }`
+        // opts out. Narrowing on `results` keeps `config` off the external variant.
+        let tier: "external" | "in-page" = "in-page";
+        let config;
+        if (typeof linting === "object") {
+            if (linting.results === "external") {
+                tier = "external";
+            } else {
+                config = linting.config;
+            }
+        }
+        const { createLintModule } = await import("./bpmnlint");
+        return [
+            createLintModule(
+                { tier, engine, config },
+                {
+                    onLintResults: this.options.onLintResults,
+                    onLintingToggled: this.options.onLintingToggled,
+                },
+            ),
+        ];
+    }
+
+    /**
+     * Feeds host-computed lint results to the in-canvas overlays (external tier).
+     * Any push switches an in-page instance to the external tier. `null`
+     * deactivates linting (no `.bpmnlintrc` / read failure). A no-op with a warning
+     * when the instance was created with `linting: false` (no lint service).
+     *
+     * @throws {NoModelerError} If the modeler has not been created yet.
+     */
+    applyLintResults(results: LintResults | null): void {
+        const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
+        if (!service) {
+            console.warn("applyLintResults ignored: this modeler was created with linting: false");
+            return;
+        }
+        service.applyLintResults(results);
+    }
+
+    /**
+     * Renders the host's user-disabled lint state (external tier): clears overlays
+     * and shows the re-enable chip. A no-op with a warning when `linting: false`.
+     *
+     * @throws {NoModelerError} If the modeler has not been created yet.
+     */
+    applyLintingDisabled(): void {
+        const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
+        if (!service) {
+            console.warn(
+                "applyLintingDisabled ignored: this modeler was created with linting: false",
+            );
+            return;
+        }
+        service.applyLintingDisabled();
     }
 
     /**

--- a/apps/bpmn-webview/src/app/publicApi.spec.ts
+++ b/apps/bpmn-webview/src/app/publicApi.spec.ts
@@ -33,8 +33,8 @@ const _conformance = (modeler: BpmnModeler): StableModelerSurface => modeler;
 void _conformance;
 
 // The full target handle is a superset the current class does *not* yet meet
-// (setTheme / applyLintResults / applyLintingDisabled are target-only), so we
-// only assert the stable subset above — this keeps the two facts distinct.
+// (setTheme is target-only; #1376), so we only assert the stable subset above
+// — this keeps the two facts distinct.
 type _HandleIsSuperset = BpmnModelerHandle extends StableModelerSurface ? true : never;
 const _handleSuperset: _HandleIsSuperset = true;
 void _handleSuperset;

--- a/apps/bpmn-webview/src/app/publicApi.ts
+++ b/apps/bpmn-webview/src/app/publicApi.ts
@@ -60,8 +60,14 @@ export type ThemeMode = "light" | "dark" | "automatic";
  * - `{ results: "external" }` — the modeler renders results the host computes
  *   and pushes through {@link BpmnModelerHandle.applyLintResults}; no in-webview
  *   linter runs.
+ *
+ * `results?: never` on the config variant makes the union discriminable on
+ * `results`, so the runtime tier selection narrows without type guards.
  */
-export type LintingOptions = false | { config?: BpmnlintConfig } | { results: "external" };
+export type LintingOptions =
+    | false
+    | { config?: BpmnlintConfig; results?: never }
+    | { results: "external" };
 
 /**
  * [B] Clipboard override. Default (option omitted) is the native browser
@@ -166,10 +172,10 @@ export interface ModelerOptions {
  * The instance handle {@link createModeler} resolves to — the designed
  * replacement for today's {@link BpmnModeler} class surface. Members are the
  * union of the **stable subset** (already implemented and frozen in shape) and
- * the **target-only** additions (`setTheme`, `applyLintResults`,
- * `applyLintingDisabled`) that #1373/#1376 add. `publicApi.spec.ts` asserts the
- * current facade satisfies the stable subset; the additions are documented in
- * the ADR's rename/reshape map.
+ * the **target-only** addition (`setTheme`) that #1376 adds
+ * (`applyLintResults` / `applyLintingDisabled` landed with #1373's tier
+ * ladder). `publicApi.spec.ts` asserts the current facade satisfies the stable
+ * subset; the additions are documented in the ADR's rename/reshape map.
  */
 export interface BpmnModelerHandle {
     // ── [A] Engine-intrinsic ────────────────────────────────────────────────
@@ -206,11 +212,11 @@ export interface BpmnModelerHandle {
 
     /**
      * [B] Render host-computed lint results, or clear them with `null`
-     * (target-only; #1373's `results: "external"` tier).
+     * (#1373's `results: "external"` tier).
      */
     applyLintResults(results: LintResults | null): void;
 
-    /** [B] Turn off the in-webview linter and clear its overlay (target-only; #1373). */
+    /** [B] Turn off the in-webview linter and clear its overlay (#1373). */
     applyLintingDisabled(): void;
 
     // ── Escape hatch ────────────────────────────────────────────────────────
@@ -260,4 +266,6 @@ export type StableModelerSurface = Pick<
     | "selection"
     | "destroy"
     | "getService"
+    | "applyLintResults"
+    | "applyLintingDisabled"
 >;

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -69,11 +69,11 @@ import {
     UnsupportedEngineError,
 } from "./app";
 import type { HostApi } from "@miragon/bpmn-modeler-shared";
-import type { ResizableCanvas } from "@miragon/bpmn-modeler-types";
+import type { LintRunEvent, ResizableCanvas } from "@miragon/bpmn-modeler-types";
 import type { ModelerCapabilities } from "./app/capabilities";
+import type { LintingOptions } from "./app";
 import type { WebviewState } from "./app/webviewState";
 import { DiffMode } from "./app/diff/DiffMode";
-import type { LintConfigService } from "./app/bpmnlint";
 import { installHostEditorActions } from "./app/hostEditorActions";
 import { WebviewStateManager } from "./app/state";
 
@@ -86,9 +86,20 @@ import { WebviewStateManager } from "./app/state";
  */
 export function bootstrap(
     injectedHost: HostApi<WebviewState, Command | Query>,
-    opts: { extraModules?: unknown[]; capabilities?: ModelerCapabilities } = {},
+    opts: {
+        extraModules?: unknown[];
+        capabilities?: ModelerCapabilities;
+        linting?: LintingOptions;
+        onLintResults?: (event: LintRunEvent) => void;
+    } = {},
 ): void {
-    startSession(injectedHost, opts.extraModules, opts.capabilities);
+    startSession(
+        injectedHost,
+        opts.extraModules,
+        opts.capabilities,
+        opts.linting,
+        opts.onLintResults,
+    );
 }
 
 /**
@@ -103,11 +114,17 @@ export function bootstrap(
  * @param injectedModules Host-specific extra bpmn-js DI modules.
  * @param injectedCapabilities Explicit per-feature ports; `undefined` selects
  *   the full protocol adapter so every real host keeps all features.
+ * @param injectedLinting The bpmnlint tier; `undefined` selects the external
+ *   (host-pushed) tier so every real host stays byte-identical to today.
+ * @param injectedOnLintResults In-page lint-run sink; only a consumer opting into
+ *   in-page linting (the demo) passes one. Real hosts run the linter themselves.
  */
 function startSession(
     host: HostApi<WebviewState, Command | Query>,
     injectedModules: unknown[] | undefined,
     injectedCapabilities: ModelerCapabilities | undefined,
+    injectedLinting: LintingOptions | undefined,
+    injectedOnLintResults: ((event: LintRunEvent) => void) | undefined,
 ): void {
     // Assigned in run() once the engine is known — flush/capability callbacks
     // only fire post-init, so the definite-assignment assertion is safe.
@@ -391,18 +408,19 @@ function startSession(
             ...(clipboardModules ?? []),
             ...((injectedModules as any[]) ?? []),
         ];
-        // The linting toggle is a webview-internal service (always registered via
-        // LintModule), so its host port is wired unconditionally — never gated on
-        // a capability. The facade registers a no-op when omitted, so a host-less
-        // consumer still resolves LintConfigService's DI.
+        // Real hosts run the linter themselves and push results, so the default
+        // tier is external — keeping VS Code / IntelliJ / Theia byte-identical to
+        // today. A consumer (or the demo) can opt into in-page linting by passing
+        // an explicit `linting`. The user's in-canvas toggle is relayed to the host
+        // as before; the host re-lints and pushes the new state down.
         bpmnModeler = createModeler(canvasEl, {
             propertiesPanelParent,
             extraModules,
             capabilities,
-            lintingHost: {
-                setLintingEnabled: (enabled: boolean) =>
-                    host.postMessage(new SetLintingEnabledCommand(enabled)),
-            },
+            linting: injectedLinting ?? { results: "external" },
+            onLintResults: injectedOnLintResults,
+            onLintingToggled: (enabled: boolean) =>
+                host.postMessage(new SetLintingEnabledCommand(enabled)),
             applyColorThemeMode: setColorThemeMode,
             handleGlobalEscape: true,
         });
@@ -533,7 +551,10 @@ function startSession(
         }
 
         try {
-            bpmnModeler.create(engine);
+            // Async now: the engine-aware step awaits the lazy lint chunk before
+            // constructing bpmn-js. A rejection (e.g. UnsupportedEngineError) is
+            // caught below exactly as the sync throw was.
+            await bpmnModeler.create(engine);
             // Lets the IntelliJ JCEF host drive undo/redo: it swallows
             // Ctrl+Z/Ctrl+Y at the IDE level before bpmn-js sees them (works fine
             // in VS Code/Theia).
@@ -648,9 +669,7 @@ function startSession(
             case queryOrCommand.type === "BpmnlintResultsQuery": {
                 try {
                     const query = message.data as BpmnlintResultsQuery;
-                    bpmnModeler
-                        .getService<LintConfigService>("bpmnLintConfig")
-                        .render(query.results);
+                    bpmnModeler.applyLintResults(query.results);
                 } catch (error: any) {
                     host.postMessage(new LogErrorCommand(errorPrefix + error.message));
                 }
@@ -658,7 +677,7 @@ function startSession(
             }
             case queryOrCommand.type === "BpmnLintDisabledQuery": {
                 try {
-                    bpmnModeler.getService<LintConfigService>("bpmnLintConfig").renderDisabled();
+                    bpmnModeler.applyLintingDisabled();
                 } catch (error: any) {
                     host.postMessage(new LogErrorCommand(errorPrefix + error.message));
                 }

--- a/apps/bpmn-webview/src/index.ts
+++ b/apps/bpmn-webview/src/index.ts
@@ -1,5 +1,5 @@
 export { bootstrap } from "./bootstrap";
 export { createModeler, BpmnModeler } from "./app";
-export type { CreateModelerOptions } from "./app";
+export type { CreateModelerOptions, LintingOptions } from "./app";
 export type { WebviewState, ViewportData } from "./app/webviewState";
 export type { ModelerCapabilities } from "./app/capabilities";

--- a/apps/bpmn-webview/src/types/bpmnlint.d.ts
+++ b/apps/bpmn-webview/src/types/bpmnlint.d.ts
@@ -1,10 +1,21 @@
 /**
- * `bpmn-js-bpmnlint` exports a single bpmn-js DI module with no types. The
- * linter itself now runs in the extension host (so it can resolve custom
- * `bpmnlint-plugin-*` rules against the workspace), so the webview no longer
- * imports `bpmnlint`'s rules/configs/resolver by path — only the overlay module.
+ * `bpmn-js-bpmnlint` exports a single bpmn-js DI module with no types.
  */
 declare module "bpmn-js-bpmnlint" {
     const lintModule: unknown;
     export default lintModule;
+}
+
+/**
+ * `bpmnlint` ships no type declarations. The in-page linter (#1373) drives only
+ * `Linter` directly — it builds the rule/config resolver from
+ * `@miragon/bpmnlint-plugin-rules` (which is typed), so this shim needs only the
+ * one class the webview constructs. Rule/config shapes are opaque, passed
+ * straight through to the resolver, so `unknown` is the honest type.
+ */
+declare module "bpmnlint" {
+    export class Linter {
+        constructor(options: { config: unknown; resolver: unknown });
+        lint(moddleRoot: unknown): Promise<Record<string, unknown[]>>;
+    }
 }

--- a/apps/bpmn-webview/vite.config.mts
+++ b/apps/bpmn-webview/vite.config.mts
@@ -1,6 +1,5 @@
 /// <reference types="vitest" />
 import { defineConfig } from "vite";
-import { viteStaticCopy } from "vite-plugin-static-copy";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { resolve } from "path";
 
@@ -8,23 +7,13 @@ import { resolve } from "path";
 // The static browser demo lives in apps/demo-webapp (which reuses this app's bootstrap()).
 export default defineConfig({
     root: __dirname,
-    base: "/",
+    // Relative base: the preload helper bakes `base` into async-chunk dep URLs
+    // (e.g. bpmnlint.css). With "/" they resolve to the host's origin root —
+    // a 404 under VS Code's vscode-resource scheme, rejecting the dynamic
+    // import. Relative deps resolve against import.meta.url in every host.
+    base: "./",
     cacheDir: "../../node_modules/.vite/bpmn-webview",
-    plugins: [
-        tsconfigPaths(),
-        viteStaticCopy({
-            targets: [
-                {
-                    src: "../../node_modules/camunda-bpmn-js/dist/assets/bpmn-font/css/**",
-                    dest: "css/",
-                },
-                {
-                    src: "../../node_modules/camunda-bpmn-js/dist/assets/bpmn-font/font/**",
-                    dest: "font/",
-                },
-            ],
-        }),
-    ],
+    plugins: [tsconfigPaths()],
     esbuild: {
         jsx: "automatic",
         jsxImportSource: "preact",

--- a/apps/bpmn-webview/vite.config.mts
+++ b/apps/bpmn-webview/vite.config.mts
@@ -30,7 +30,7 @@ export default defineConfig({
         jsxImportSource: "preact",
     },
     optimizeDeps: {
-        include: ["bpmnlint", "bpmn-js-bpmnlint"],
+        include: ["bpmnlint", "bpmn-js-bpmnlint", "@miragon/bpmnlint-plugin-rules"],
     },
     resolve: {
         dedupe: [

--- a/apps/bpmn-webview/vitest.config.ts
+++ b/apps/bpmn-webview/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
         name: "bpmn-webview",
         environment: "jsdom",
         include: ["src/**/*.{spec,test}.ts"],
+        // The rules plugin ships pure ESM with a subpath `exports` map Vitest's
+        // default externalisation mishandles; inline it so the in-page linter
+        // specs import it the same way the bundle does (mirrors modeler-core).
+        server: { deps: { inline: [/@miragon\/bpmnlint-plugin-rules/] } },
         alias: {
             "@miragon/bpmn-modeler-shared": resolve(__dirname, "../../libs/shared/src/index.ts"),
             "@miragon/bpmn-modeler-types": resolve(

--- a/apps/demo-webapp/bpmn/demoHost.ts
+++ b/apps/demo-webapp/bpmn/demoHost.ts
@@ -1,6 +1,5 @@
 import {
     BpmnFileQuery,
-    BpmnlintResultsQuery,
     BpmnModelerSettingQuery,
     ClipboardQuery,
     Command,
@@ -59,9 +58,9 @@ export class BpmnDemoHost extends MockHostApi<WebviewState, MessageType> {
             case "GetClipboardCommand":
                 dispatch(new ClipboardQuery(""));
                 break;
-            case "GetBpmnlintConfigCommand":
-                dispatch(new BpmnlintResultsQuery(null));
-                break;
+            // Deliberately no GetBpmnlintConfigCommand reply: the demo lints
+            // in-page (`linting: {}`), and an external results/null push would
+            // switch the instance to the external tier and suspend that.
         }
     }
 }

--- a/apps/demo-webapp/bpmn/dual.ts
+++ b/apps/demo-webapp/bpmn/dual.ts
@@ -52,11 +52,13 @@ async function mount(
     if (!container || !propertiesPanelParent) {
         throw new Error(`Missing #${canvasId} or #${panelId}`);
     }
-    // No host wiring: the default no-op lintingHost keeps DI resolvable, and
-    // handleGlobalEscape stays off so each instance only reacts to Escapes in
-    // its own subtrees.
+    // No host wiring: `linting` is omitted, so each pane lints in-page with the
+    // engine-aware default config (the multi-instance proof — both panes lint
+    // independently). handleGlobalEscape stays off so each instance only reacts
+    // to Escapes in its own subtrees. `create` is async now (it awaits the lazy
+    // lint chunk), so it must be awaited before loading the diagram.
     const modeler = createModeler(container, { propertiesPanelParent });
-    modeler.create(engine);
+    await modeler.create(engine);
     await modeler.loadDiagram(xml);
 }
 

--- a/apps/demo-webapp/bpmn/main.ts
+++ b/apps/demo-webapp/bpmn/main.ts
@@ -6,8 +6,17 @@ mountDemoHeader("bpmn");
 // The demo supplies only the model-navigation capability; codeLink and scripting
 // are omitted, so their context-pad entries / lock UI genuinely never render
 // (AC3 — a host-less consumer no longer gets dead buttons).
+//
+// `linting: {}` opts into in-page linting with the engine-aware default config —
+// the host-less proof that the webview lints itself (#1373, AC 1). onLintResults
+// logs each run so the browser console shows the rule-keyed output + any rules
+// the bundled resolver could not cover.
 bootstrap(new BpmnDemoHost(), {
     extraModules: [DemoGrayoutModule],
+    linting: {},
+    onLintResults: ({ results, unresolved }) => {
+        console.debug("[demo] in-page lint", { results, unresolved });
+    },
     capabilities: {
         modelNavigation: {
             openReference: ({ id, kind }) => {

--- a/apps/demo-webapp/package.json
+++ b/apps/demo-webapp/package.json
@@ -18,7 +18,6 @@
     "devDependencies": {
         "npm-run-all": "4.1.5",
         "vite": "8.1.0",
-        "vite-plugin-static-copy": "4.1.1",
         "vite-tsconfig-paths": "6.1.1"
     }
 }

--- a/apps/demo-webapp/vite.config.mts
+++ b/apps/demo-webapp/vite.config.mts
@@ -1,12 +1,11 @@
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
-import { viteStaticCopy } from "vite-plugin-static-copy";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 // One app, two demo pages: `--mode bpmn` / `--mode dmn`. Each page folder is
 // the Vite build root, so it emits a flat static site under dist/demo/<mode>/
 // (served at /<mode>/). Because the demo builds the webview apps' source, it
-// mirrors their build essentials (bpmn-font assets, preact JSX, dedupe).
+// mirrors their build essentials (preact JSX, dedupe).
 export default defineConfig(({ mode }) => {
     const target = mode === "dmn" ? "dmn" : "bpmn";
     return {
@@ -14,27 +13,7 @@ export default defineConfig(({ mode }) => {
         base: `/${target}/`,
         publicDir: resolve(__dirname, "public"),
         cacheDir: resolve(__dirname, `../../node_modules/.vite/demo-${target}`),
-        plugins: [
-            tsconfigPaths(),
-            viteStaticCopy({
-                targets: [
-                    {
-                        src: resolve(
-                            __dirname,
-                            "../../node_modules/camunda-bpmn-js/dist/assets/bpmn-font/css/**",
-                        ),
-                        dest: "css/",
-                    },
-                    {
-                        src: resolve(
-                            __dirname,
-                            "../../node_modules/camunda-bpmn-js/dist/assets/bpmn-font/font/**",
-                        ),
-                        dest: "font/",
-                    },
-                ],
-            }),
-        ],
+        plugins: [tsconfigPaths()],
         esbuild: { jsx: "automatic", jsxImportSource: "preact" },
         optimizeDeps: { include: ["bpmnlint", "bpmn-js-bpmnlint"] },
         resolve: {

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WebviewServer.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WebviewServer.kt
@@ -140,7 +140,6 @@ class WebviewServer : Disposable {
             "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"/>",
             "  <link href=\"/index.css\" rel=\"stylesheet\"/>",
             "  <link href=\"/lightTheme.css\" rel=\"stylesheet\" id=\"theme-link\"/>",
-            "  <link href=\"$FONT_CSS\" rel=\"stylesheet\"/>",
             "  <title>BPMN Modeler</title>",
             "  <style>html, body { margin: 0; height: 100%; } #app { height: 100vh; }</style>",
             "  <style id=\"ide-theme-vars\">${signal.themeVarsCss()}</style>",
@@ -224,16 +223,6 @@ class WebviewServer : Disposable {
     }
 
     private companion object {
-        /**
-         * bpmn-js icon font. The Vite `viteStaticCopy` glob preserves the source
-         * `node_modules/...` path, so the font CSS lands at this nested location.
-         * The embedded variant inlines the font as base64, so palette/context-pad
-         * icons render even though its sibling `../font` URLs don't resolve under
-         * this layout.
-         */
-        const val FONT_CSS =
-            "/css/node_modules/camunda-bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css"
-
         /**
          * The `acquireVsCodeApi()` shim. Runs as a classic (non-module) script so
          * the global exists before the deferred ES module calls `getVsCodeApi()` at

--- a/apps/vscode-plugin/src/shared/infrastructure/WebviewHtml.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/WebviewHtml.ts
@@ -34,7 +34,6 @@ export function bpmnEditorUi(
 
     const scriptUri = webview.asWebviewUri(Uri.joinPath(baseUri, "index.js"));
     const styleUri = webview.asWebviewUri(Uri.joinPath(baseUri, "index.css"));
-    const fontUri = webview.asWebviewUri(Uri.joinPath(baseUri, "css", "bpmn.css"));
     const themeUri = webview.asWebviewUri(Uri.joinPath(baseUri, "lightTheme.css"));
 
     const nonce = getNonce();
@@ -44,6 +43,9 @@ export function bpmnEditorUi(
     const resizerClass = initialPanelVisible ? "panel-resizer" : "panel-resizer collapsed";
     const panelStyle = initialPanelVisible ? "" : ` style="width: 0"`;
 
+    // The script must load as a module: the bundle code-splits the lazy
+    // bpmnlint chunk, whose URL is resolved via import.meta.url — a syntax
+    // error in a classic script. Matches the IntelliJ host.
     return `
         <!DOCTYPE html>
         <html lang="en">
@@ -52,7 +54,6 @@ export function bpmnEditorUi(
                 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
                 <link href="${styleUri}" rel="stylesheet"/>
                 <link href="${themeUri}" rel="stylesheet" id="theme-link"/>
-                <link href="${fontUri}" rel="stylesheet"/>
                 <title>BPMN Modeler</title>
             </head>
             <body>
@@ -61,7 +62,7 @@ export function bpmnEditorUi(
                     <div id="js-panel-resizer" class="${resizerClass}"></div>
                     <div class="${panelClass}" id="js-properties-panel"${panelStyle}></div>
                 </div>
-                <script nonce="${nonce}" src="${scriptUri}"></script>
+                <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
             </body>
         </html>
     `;

--- a/libs/modeler-types/src/lint.ts
+++ b/libs/modeler-types/src/lint.ts
@@ -34,10 +34,14 @@ export type BpmnlintRuleConfig = BpmnlintRuleSeverity | readonly [BpmnlintRuleSe
  * import of bpmnlint's own types — so the published API surface does not leak a
  * transitive bpmnlint dependency. Unresolvable `extends`/`rules` degrade
  * gracefully at load and surface via {@link LintRunEvent.unresolved}.
+ * Serializable when `moddleExtensions` is omitted or carries only string module
+ * paths — so it can cross the webview↔host protocol as a plain data value; a
+ * browser lint run reports unhonourable entries as `moddleExtension:<prefix>`.
  */
 export interface BpmnlintConfig {
     readonly extends?: string | readonly string[];
     readonly rules?: Readonly<Record<string, BpmnlintRuleConfig>>;
+    readonly moddleExtensions?: Readonly<Record<string, unknown>>;
 }
 
 /**
@@ -45,7 +49,9 @@ export interface BpmnlintConfig {
  * the findings the overlay renders plus the rule names that could not be
  * resolved from the supplied {@link BpmnlintConfig}. `unresolved` is how the
  * modeler reports graceful degradation instead of failing the whole run when a
- * `{ config }` references a rule the bundled resolver does not carry.
+ * `{ config }` references a rule the bundled resolver does not carry. Emitted
+ * only after an in-page run — never for an external push, so a host feeding
+ * the webview its own results does not echo them back.
  */
 export interface LintRunEvent {
     readonly results: LintResults;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3864,6 +3864,7 @@ __metadata:
     "@miragon/bpmn-modeler-inline-scripting": "workspace:*"
     "@miragon/bpmn-modeler-shared": "workspace:*"
     "@miragon/bpmn-modeler-types": "workspace:*"
+    "@miragon/bpmnlint-plugin-rules": "npm:0.10.0"
     "@miragon/create-append-c7": "npm:0.1.0"
     "@types/vscode-webview": "npm:1.57.5"
     "@vitest/coverage-v8": "npm:4.1.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3676,7 +3676,6 @@ __metadata:
     "@miragon/dmn-modeler-webview": "workspace:*"
     npm-run-all: "npm:4.1.5"
     vite: "npm:8.1.0"
-    vite-plugin-static-copy: "npm:4.1.1"
     vite-tsconfig-paths: "npm:6.1.1"
   languageName: unknown
   linkType: soft
@@ -3885,7 +3884,6 @@ __metadata:
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.3"
     vite: "npm:8.1.0"
-    vite-plugin-static-copy: "npm:4.1.1"
     vite-tsconfig-paths: "npm:6.1.1"
     vitest: "npm:4.1.9"
     zeebe-bpmn-moddle: "npm:1.15.0"
@@ -10051,7 +10049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
+"chokidar@npm:^3.5.3":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -17900,7 +17898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-map@npm:^7.0.3, p-map@npm:^7.0.4":
+"p-map@npm:^7.0.3":
   version: 7.0.4
   resolution: "p-map@npm:7.0.4"
   checksum: 10c0/a5030935d3cb2919d7e89454d1ce82141e6f9955413658b8c9403cfe379283770ed3048146b44cde168aa9e8c716505f196d5689db0ae3ce9a71521a2fef3abd
@@ -22404,20 +22402,6 @@ __metadata:
   version: 3.0.2
   resolution: "vhost@npm:3.0.2"
   checksum: 10c0/a8cc383d66c20cd41433fd153106186d6b37b65f1fccce10f51d78a40c3ef8004003f8b4739e64f5819807a97d9ff0310a1672297a9e6fa8799b6ad34ba040d3
-  languageName: node
-  linkType: hard
-
-"vite-plugin-static-copy@npm:4.1.1":
-  version: 4.1.1
-  resolution: "vite-plugin-static-copy@npm:4.1.1"
-  dependencies:
-    chokidar: "npm:^3.6.0"
-    p-map: "npm:^7.0.4"
-    picocolors: "npm:^1.1.1"
-    tinyglobby: "npm:^0.2.17"
-  peerDependencies:
-    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 10c0/71ddeeed556275ef95c13e2b1d2af081603a98921fe4d58a91e0d64afc8e122c94f1310e4eec70e0c78118b9667e94b251cbb0ca38e2eeed220be84628b4cd82
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issue

Part of #1373 (Phase A of the phasing plan in the issue — Phases B/C follow in separate PRs).

## Description

Adds the four-tier linting ladder to the modeler facade: `linting` on `CreateModelerOptions` selects in-page linting (default, engine-aware `getDefaultLintConfig`), an explicit `{ config }` with graceful degradation via a recording resolver, host-pushed `{ results: "external" }`, or `false`. The lint stack (`bpmn-js-bpmnlint`, `bpmnlint`, `@miragon/bpmnlint-plugin-rules`) moves behind a dynamic import — `create(engine)` is now async — so `linting: false` consumers never load the ~274 kB chunk (verified absent from the main bundle). Hosted webviews keep constructing on the external tier, so VS Code / IntelliJ / Theia behaviour is unchanged; the demo-webapp (`main.ts` + the dual-instance page) opts into in-page linting as the host-less proof. New facade methods `applyLintResults` / `applyLintingDisabled` replace the `getService("bpmnLintConfig")` escape hatch, and the `lintingHost` option is absorbed by `onLintingToggled`; `onLintResults` emits each in-page run (never external pushes) for the Phase B host feed.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A) — tier ladder + phasing documented in #1373
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [ ] Verified in the affected hosts — VS Code / IntelliJ / standalone (hosts are behaviorally unchanged on the external tier; the lazy-chunk fetch under `vscode-webview://` / JCEF still needs a manual smoke check)
