### PR TITLE
refactor(bpmn-webview): design the public modeler api surface

### DIFF
--- a/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
+++ b/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
@@ -1,4 +1,9 @@
 /**
+ * @internal Package-internal wiring — the green canvas focus reticle the
+ * factory installs per instance. Not part of the designed public API (#1375).
+ */
+
+/**
  * Injected dependencies for the canvas focus indicator.
  *
  * Closures rather than a live modeler handle so this stays testable under

--- a/apps/bpmn-webview/src/app/host.ts
+++ b/apps/bpmn-webview/src/app/host.ts
@@ -1,3 +1,8 @@
+/**
+ * @internal Host-adapter surface — the VS Code protocol adapter (Query/Command
+ * wiring, `bootstrap`'s host handshake). Not part of the designed public API
+ * (#1375); relocated out of the publishable boundary in #1377.
+ */
 import {
     ApplyDiffHighlightsQuery,
     BpmnFileQuery,

--- a/apps/bpmn-webview/src/app/index.ts
+++ b/apps/bpmn-webview/src/app/index.ts
@@ -1,5 +1,6 @@
 export * from "./modeler";
 export * from "./createModeler";
+export * from "./publicApi";
 export * from "./capabilities";
 export * from "./viewport";
 export * from "./selection";

--- a/apps/bpmn-webview/src/app/keyboardFocus.ts
+++ b/apps/bpmn-webview/src/app/keyboardFocus.ts
@@ -1,4 +1,9 @@
 /**
+ * @internal Package-internal wiring — the canvas-focus keyboard guard the
+ * factory installs per instance. Not part of the designed public API (#1375).
+ */
+
+/**
  * Injected dependencies for the webview-level "Escape → focus canvas" guard.
  *
  * Closures rather than a service handle so this stays testable without a live

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -120,6 +120,8 @@ export class BpmnModeler {
     /**
      * Access the root element manager after {@link create}.
      *
+     * @internal Host-adapter surface (drill-down state restore); not part of the
+     *   designed public handle (#1375).
      * @throws {NoModelerError} If the modeler has not been created yet.
      */
     get rootElement(): RootElementManager {
@@ -137,6 +139,10 @@ export class BpmnModeler {
      * the facade (flush responder, protocol capabilities) are wired before that.
      * The per-instance DI extras and capabilities come from the constructor
      * options. Re-`create()` disposes the prior instance's focus installs first.
+     *
+     * @internal Migration-only two-step construction. The designed public API
+     *   takes the engine up front and returns a ready handle from an async
+     *   `createModeler` (#1375); #1376 collapses this second step into it.
      *
      * @param engine Camunda engine version — `"c7"` for Camunda Platform 7,
      *   `"c8"` for Camunda Cloud 8.
@@ -318,6 +324,8 @@ export class BpmnModeler {
     /**
      * Subscribes to the `commandStack.changed` event on the modeler's event bus.
      *
+     * @internal Raw change hook. The designed API exposes the debounced
+     *   `onContentSaved` event instead; this stays for the host adapter (#1375).
      * @param cb Callback invoked whenever the command stack changes.
      * @throws {NoModelerError} If the modeler has not been created yet.
      */
@@ -342,6 +350,7 @@ export class BpmnModeler {
      * scan and filtering rules live in {@link collectInlineScriptTasks} so the
      * bulk path and the single-open path stay in agreement.
      *
+     * @internal Host-adapter surface (inline-scripting capability, #1375).
      * @throws {NoModelerError} If the modeler has not been created yet.
      */
     collectInlineScriptTasks(): ScriptTaskScript[] {
@@ -480,6 +489,9 @@ export class BpmnModeler {
     /**
      * Triggers the align-to-origin plugin if the setting is enabled.
      *
+     * @internal Host-adapter surface (invoked on save by the VS Code editor
+     *   controller); folded behind the `alignToOrigin` setting in the designed
+     *   API (#1375).
      * @throws {NoModelerError} If the modeler has not been created yet.
      */
     alignElementsToOrigin(): void {
@@ -491,6 +503,10 @@ export class BpmnModeler {
     /**
      * Returns a service from the modeler's dependency injection container.
      *
+     * @remarks Unstable escape hatch — kept public deliberately (see the
+     *   ADR 0007, `docs/adr`) so advanced integrations are not blocked, but
+     *   not covered by semver: DI service names can change across minor
+     *   versions. Prefer a typed option/method where one exists.
      * @param name The DI service name (e.g. `"customTranslator"`).
      * @returns The service instance.
      * @throws {NoModelerError} If the modeler has not been created yet.
@@ -509,6 +525,7 @@ export class BpmnModeler {
      * - `execution-listener` / `task-listener`: writes to the listener's
      *   nested `camunda:Script.scriptFormat`.
      *
+     * @internal Host-adapter surface (inline-scripting capability, #1375).
      * @throws {NoModelerError} If the modeler has not been created yet.
      */
     updateScriptFormat(
@@ -559,6 +576,7 @@ export class BpmnModeler {
      *   `listenerIndex` within the parent's filtered list of that listener
      *   type, then writes to its nested `camunda:Script` element's `value`.
      *
+     * @internal Host-adapter surface (inline-scripting capability, #1375).
      * @throws {NoModelerError} If the modeler has not been created yet.
      */
     updateScriptContent(
@@ -609,6 +627,8 @@ export class BpmnModeler {
      * script fields (single-writer arbitration). C7-only: the store/provider
      * modules are not registered for C8, so the service is resolved defensively
      * and the call is a no-op there.
+     *
+     * @internal Host-adapter surface (inline-scripting capability, #1375).
      */
     applyOpenScriptEditors(refs: OpenScriptEditorRef[]): void {
         this.getModeler().get<OpenScriptEditorsStore>("openScriptEditorsStore", false)?.set(refs);
@@ -633,6 +653,7 @@ export class BpmnModeler {
      * omits the codeLink capability registers no `codeLinkMapClient`, and a
      * stray status push must then be a no-op rather than throw.
      *
+     * @internal Host-adapter surface (code-link capability, #1375).
      * @throws {NoModelerError} If the modeler has not been created yet.
      */
     applyImplementationStatus(resolved: Record<string, boolean>): void {

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
@@ -1,3 +1,8 @@
+/**
+ * @internal Host-adapter surface — routes the panel's plain-text copy/paste
+ * through the extension-host clipboard bridge. Not part of the designed public
+ * API (#1375); folded behind the `clipboard` option's bridge.
+ */
 import { isTextEditingSurface } from "@miragon/bpmn-modeler-types";
 export { isTextEditingSurface };
 

--- a/apps/bpmn-webview/src/app/publicApi.spec.ts
+++ b/apps/bpmn-webview/src/app/publicApi.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import type { ModelNavigationPort } from "@miragon/bpmn-model-navigation";
+import { BpmnModeler } from "./modeler";
+import type {
+    BpmnModelerHandle,
+    ClipboardOptions,
+    ContentSavedEvent,
+    CreateModeler,
+    LintingOptions,
+    ModelerOptions,
+    StableModelerSurface,
+    ThemeMode,
+} from "./publicApi";
+
+/**
+ * Type-level conformance + scenario spec for the designed public API (#1375).
+ *
+ * The assertions below are compile-checked (this file is type-checked by
+ * `tsconfig.spec.json`); the single runtime `it` exists only so the test runner
+ * has something to execute — esbuild strips the types without checking them, so
+ * the guarantee is the `tsc` pass, not the vitest run. Each block encodes one
+ * deliverable: (a) the current facade already satisfies the stable subset;
+ * (b) the three bpm-iq scenarios type-check; (c) a demo-webapp-shaped literal.
+ *
+ * `satisfies` is used instead of a plain annotation so the checks cannot be
+ * widened away by an over-broad target type.
+ */
+
+// (a) Conformance: the current BpmnModeler class satisfies the frozen stable
+// subset of the designed handle. If a future refactor reshapes one of these
+// members, this line stops compiling.
+const _conformance = (modeler: BpmnModeler): StableModelerSurface => modeler;
+void _conformance;
+
+// The full target handle is a superset the current class does *not* yet meet
+// (setTheme / applyLintResults / applyLintingDisabled are target-only), so we
+// only assert the stable subset above — this keeps the two facts distinct.
+type _HandleIsSuperset = BpmnModelerHandle extends StableModelerSurface ? true : never;
+const _handleSuperset: _HandleIsSuperset = true;
+void _handleSuperset;
+
+// (b1) bpm-iq scenario 1 — element templates arrive as fetched data, not a path.
+const _scenarioTemplates = {
+    engine: "c7",
+    propertiesPanel: { parent: document.createElement("div") },
+    elementTemplates: [{ id: "tpl", name: "Fetched template" }],
+} satisfies ModelerOptions;
+void _scenarioTemplates;
+
+// (b2) bpm-iq scenario 2 — an async ModelNavigationPort (GitHub-API resolution
+// before opening a tab). The widened return type must accept `async`.
+const _asyncNavigation: ModelNavigationPort = {
+    async openReference({ id, kind }) {
+        await Promise.resolve();
+        void id;
+        void kind;
+    },
+};
+const _scenarioAsyncNav = {
+    engine: "c8",
+    propertiesPanel: { parent: document.createElement("div") },
+    capabilities: { modelNavigation: _asyncNavigation },
+} satisfies ModelerOptions;
+void _scenarioAsyncNav;
+
+// (b3) bpm-iq scenario 3 — graceful `{ config }` linting. The literal type-checks
+// against the BpmnlintConfig mirror; unresolvable rules degrade at runtime and
+// surface via onLintResults({ results, unresolved }).
+const _scenarioLintConfig = {
+    engine: "c7",
+    propertiesPanel: { parent: document.createElement("div") },
+    linting: { config: { extends: "bpmnlint:recommended", rules: { "label-required": "warn" } } },
+    onLintResults: ({ results, unresolved }) => {
+        void results;
+        void unresolved;
+    },
+} satisfies ModelerOptions;
+void _scenarioLintConfig;
+
+// [B] Opinionated built-ins: each tier/override type-checks in isolation, and
+// the target factory type is nameable. These exercise the built-in and event
+// declarations the scenario literals above don't reach.
+const _themes = ["light", "dark", "automatic"] satisfies ThemeMode[];
+void _themes;
+const _lintOff: LintingOptions = false;
+const _lintExternal: LintingOptions = { results: "external" };
+const _lintConfig: LintingOptions = { config: {} };
+void [_lintOff, _lintExternal, _lintConfig];
+const _clipboard: ClipboardOptions = {
+    bridge: { requestClipboard: () => Promise.resolve(""), writeClipboard: () => undefined },
+};
+const _builtinsShape = {
+    engine: "c7",
+    propertiesPanel: { parent: document.createElement("div") },
+    theme: "dark",
+    locale: "de",
+    linting: false,
+    clipboard: _clipboard,
+    onContentSaved: ({ xml }: ContentSavedEvent) => void xml,
+} satisfies ModelerOptions;
+void _builtinsShape;
+
+// The designed async factory signature is nameable and distinct from today's
+// synchronous `createModeler` (which #1376 collapses into this shape).
+type _FactoryReturn = ReturnType<CreateModeler>;
+const _factoryReturns: _FactoryReturn extends Promise<BpmnModelerHandle> ? true : never = true;
+void _factoryReturns;
+
+// (c) demo-webapp-shaped literal — model navigation only, no code-link/scripting.
+const _demoShape = {
+    engine: "c7",
+    propertiesPanel: { parent: document.createElement("div") },
+    capabilities: {
+        modelNavigation: {
+            openReference: ({ id, kind }) => {
+                void id;
+                void kind;
+            },
+        },
+    },
+} satisfies ModelerOptions;
+void _demoShape;
+
+describe("public API skeleton (#1375)", () => {
+    it("is a type-only conformance spec; the guarantee is the tsc pass", () => {
+        expect(true).toBe(true);
+    });
+});

--- a/apps/bpmn-webview/src/app/publicApi.ts
+++ b/apps/bpmn-webview/src/app/publicApi.ts
@@ -1,0 +1,263 @@
+import type { ImportXMLResult } from "bpmn-js/lib/BaseViewer";
+import type {
+    BpmnlintConfig,
+    BpmnModelerSetting,
+    Engine,
+    LintResults,
+    LintRunEvent,
+} from "@miragon/bpmn-modeler-types";
+import type { ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
+import type { ModelerCapabilities } from "./capabilities";
+import type { ViewportManager } from "./viewport";
+import type { SelectionManager } from "./selection";
+
+/**
+ * The designed public TypeScript surface of the future `@miragon/bpmn-modeler`
+ * npm package (#1375, epic #1293). This file is a **type-only skeleton**: it
+ * fixes the shape of `createModeler(container, options)`, the instance handle,
+ * and the outbound event model *before* the package is extracted, so the
+ * extraction moves code into a designed API instead of freezing today's
+ * accidental facade. No runtime lives here — the current {@link BpmnModeler}
+ * satisfies the stable subset (proved in `publicApi.spec.ts`), and #1373/#1376
+ * grow the runtime up to the rest of this shape.
+ *
+ * ## Feature taxonomy
+ *
+ * Every capability the modeler exposes falls into exactly one of three
+ * categories, and each declaration below is tagged with its category so the
+ * ADR's taxonomy table has a machine-anchored home:
+ *
+ * - **[A] Engine-intrinsic** — the diagram surface itself. Always present; not
+ *   a toggle. Loading/exporting XML, the viewport, the selection, the engine.
+ * - **[B] Opinionated built-in** — on by sensible default, but turning one off
+ *   is one option away and replacing one is one override away (linting,
+ *   clipboard, theme, locale).
+ * - **[C] Host capability** — off by default; a host opts in by supplying a
+ *   port. Absent port ⇒ no UI, no dead buttons (model navigation, code link,
+ *   inline scripting).
+ *
+ * Events (the `on*` callbacks) are a fourth, cross-cutting concern: strictly
+ * outbound notifications. An event is **never** a substitute for a capability
+ * port — it cannot answer a question or resolve a target, only announce that
+ * something happened.
+ */
+
+/**
+ * [B] Theme selection for a single instance. `"automatic"` follows the host's
+ * light/dark signal; the VS Code `<body>`-class watcher moves to the host
+ * adapter (#1376/#1377), leaving the modeler with an injected mode.
+ */
+export type ThemeMode = "light" | "dark" | "automatic";
+
+/**
+ * [B] Linting configuration, adopting #1373's tier ladder verbatim:
+ *
+ * - `undefined` — linting on with the bundled default ruleset.
+ * - `false` — linting off entirely (no chip, no overlay).
+ * - `{ config }` — on, with a caller-supplied {@link BpmnlintConfig}; rules the
+ *   bundled resolver cannot resolve degrade gracefully and are reported via
+ *   {@link LintRunEvent.unresolved} rather than failing the pass.
+ * - `{ results: "external" }` — the modeler renders results the host computes
+ *   and pushes through {@link BpmnModelerHandle.applyLintResults}; no in-webview
+ *   linter runs.
+ */
+export type LintingOptions = false | { config?: BpmnlintConfig } | { results: "external" };
+
+/**
+ * [B] Clipboard override. Default (option omitted) is the native browser
+ * clipboard (#1374). A sandboxed host that cannot reach the system clipboard
+ * from the webview supplies a {@link ClipboardBridge} to route copy/paste
+ * through its extension host.
+ */
+export interface ClipboardOptions {
+    bridge: ClipboardBridge;
+}
+
+/**
+ * Outbound content notification. Debounced and owned by the package (300ms,
+ * 1000ms maxWait — the shape battle-tested in `bootstrap`), because every
+ * consumer needs exactly that debounce; raw `commandStack.changed` stays
+ * reachable through the {@link BpmnModelerHandle.getService} escape hatch for
+ * the rare consumer that wants it un-debounced.
+ */
+export interface ContentSavedEvent {
+    readonly xml: string;
+}
+
+/**
+ * Per-instance configuration for {@link createModeler}. Deliberately flat and
+ * opinionated: the required fields ([A]) are the minimum to stand up an
+ * independent modeler, and every other field either turns off / replaces a
+ * built-in ([B]) or wires a host capability ([C]).
+ */
+export interface ModelerOptions {
+    // ── [A] Engine-intrinsic ────────────────────────────────────────────────
+    /**
+     * [A] Camunda engine version. Required and known up front in the target
+     * shape (the current two-step `create(engine)` is the internal migration
+     * path; #1373/#1376 collapse it). Switching engines = `destroy()` + a new
+     * instance.
+     */
+    engine: Engine;
+
+    /**
+     * [A] The panel host. Each instance owns its own properties-panel parent so
+     * several modelers can coexist on one page (rename of today's flat
+     * `propertiesPanelParent`).
+     */
+    propertiesPanel: { parent: HTMLElement };
+
+    /**
+     * [A] Initial element templates as **data**, never a path (bpm-iq scenario
+     * 1): the host fetches the JSON and hands it in. Live updates go through
+     * {@link BpmnModelerHandle.setElementTemplates}.
+     */
+    elementTemplates?: object[];
+
+    /** [A] Initial settings (align-to-origin, transaction boundaries, favourites). */
+    settings?: Partial<BpmnModelerSetting>;
+
+    /**
+     * [A] Escape hatch: extra bpmn-js DI modules. Unstable/advanced — the
+     * supported knobs are the typed options above. Renamed from the current
+     * `extraModules` to match bpmn-js's own `additionalModules`.
+     */
+    additionalModules?: unknown[];
+
+    // ── [B] Opinionated built-ins ───────────────────────────────────────────
+    /** [B] Linting tier — see {@link LintingOptions}. Omit for the bundled default. */
+    linting?: LintingOptions;
+
+    /** [B] Clipboard override — omit for the native clipboard (#1374). */
+    clipboard?: ClipboardOptions;
+
+    /** [B] Colour theme — defaults to `"automatic"`. */
+    theme?: ThemeMode;
+
+    /** [B] UI locale (BCP-47-ish tag) — defaults to `"en"`. Absorbs the page-level `TranslateModule` + `i18n.setLanguage` wiring. */
+    locale?: string;
+
+    // ── [C] Host capabilities ───────────────────────────────────────────────
+    /**
+     * [C] Per-feature host ports. Each present port registers its feature's DI
+     * module and UI; each absent port leaves the feature off entirely. See
+     * {@link ModelerCapabilities}.
+     */
+    capabilities?: ModelerCapabilities;
+
+    // ── Events (outbound notifications) ─────────────────────────────────────
+    /** Debounced diagram content — see {@link ContentSavedEvent}. */
+    onContentSaved?: (event: ContentSavedEvent) => void;
+
+    /** One lint pass completed — findings + gracefully-degraded rules (#1373). */
+    onLintResults?: (event: LintRunEvent) => void;
+
+    /** The in-canvas lint chip was toggled on/off (absorbs today's `lintingHost`, #1373). */
+    onLintingToggled?: (enabled: boolean) => void;
+
+    /** A non-fatal warning (element-not-found, missing inline script) for the host log. */
+    onWarning?: (message: string) => void;
+
+    /** The element-templates loader reported validation errors. */
+    onElementTemplatesErrors?: (errors: unknown[]) => void;
+}
+
+/**
+ * The instance handle {@link createModeler} resolves to — the designed
+ * replacement for today's {@link BpmnModeler} class surface. Members are the
+ * union of the **stable subset** (already implemented and frozen in shape) and
+ * the **target-only** additions (`setTheme`, `applyLintResults`,
+ * `applyLintingDisabled`) that #1373/#1376 add. `publicApi.spec.ts` asserts the
+ * current facade satisfies the stable subset; the additions are documented in
+ * the ADR's rename/reshape map.
+ */
+export interface BpmnModelerHandle {
+    // ── [A] Engine-intrinsic ────────────────────────────────────────────────
+    /** [A] Load BPMN 2.0 XML, replacing any current diagram. */
+    loadDiagram(xml: string): Promise<ImportXMLResult>;
+
+    /** [A] Serialise the current diagram to formatted XML. */
+    exportDiagram(): Promise<string>;
+
+    /** [A] Replace the diagram with a new empty one. */
+    newDiagram(): Promise<ImportXMLResult>;
+
+    /** [A] Export the current diagram as SVG markup. */
+    getDiagramSvg(): Promise<string>;
+
+    /** [A] Push a new set of element templates (data, never a path). */
+    setElementTemplates(templates: object[]): void;
+
+    /** [A] Merge a partial settings update. */
+    setSettings(settings: Partial<BpmnModelerSetting>): void;
+
+    /** [A] Viewport (zoom/scroll/fit) accessor. */
+    readonly viewport: ViewportManager;
+
+    /** [A] Selection accessor. */
+    readonly selection: SelectionManager;
+
+    /** [A] Tear the instance down and free its bpmn-js DI graph and DOM. */
+    destroy(): void;
+
+    // ── [B] Opinionated built-ins ───────────────────────────────────────────
+    /** [B] Switch the colour theme live (target-only; #1376/#1377). */
+    setTheme(theme: ThemeMode): void;
+
+    /**
+     * [B] Render host-computed lint results, or clear them with `null`
+     * (target-only; #1373's `results: "external"` tier).
+     */
+    applyLintResults(results: LintResults | null): void;
+
+    /** [B] Turn off the in-webview linter and clear its overlay (target-only; #1373). */
+    applyLintingDisabled(): void;
+
+    // ── Escape hatch ────────────────────────────────────────────────────────
+    /**
+     * Unstable escape hatch: reach a bpmn-js DI service by name. Not covered by
+     * semver — plugin authors accept breakage across minor versions. Kept
+     * public deliberately (ADR decision) so advanced integrations are not
+     * blocked while the typed surface catches up.
+     *
+     * @remarks Unstable. Prefer a typed option/method; open an issue if one is missing.
+     */
+    getService<T = unknown>(name: string): T;
+}
+
+/**
+ * [A] The designed package entry point: stand up one modeler bound to
+ * `container` and resolve its {@link BpmnModelerHandle}. Async because #1373's
+ * lazy lint chunk forces a construction await anyway; a host that learns the
+ * engine late simply calls this late (today's `bootstrap` already constructs
+ * after the file handshake).
+ *
+ * Type-only in this spike — the runtime factory is still
+ * {@link createModeler} + the two-step `create(engine)`; #1376 collapses the
+ * two into this signature.
+ */
+export type CreateModeler = (
+    container: HTMLElement,
+    options: ModelerOptions,
+) => Promise<BpmnModelerHandle>;
+
+/**
+ * The stable subset of {@link BpmnModelerHandle}: the members the current
+ * {@link BpmnModeler} already implements with target-final signatures, so their
+ * shape is frozen and the extraction cannot silently reshape them.
+ * `setElementTemplates` is intentionally excluded — its param widens from
+ * `JSON[] | undefined` to `object[]` (see the ADR's reshape map), so it is not
+ * yet stable.
+ */
+export type StableModelerSurface = Pick<
+    BpmnModelerHandle,
+    | "loadDiagram"
+    | "exportDiagram"
+    | "newDiagram"
+    | "getDiagramSvg"
+    | "setSettings"
+    | "viewport"
+    | "selection"
+    | "destroy"
+    | "getService"
+>;

--- a/apps/bpmn-webview/src/app/rootElement.ts
+++ b/apps/bpmn-webview/src/app/rootElement.ts
@@ -1,4 +1,9 @@
 /**
+ * @internal Host-adapter surface — drill-down root tracking used for canvas
+ * view-state restore. Not part of the designed public API (#1375).
+ */
+
+/**
  * Function type for accessing a service from the bpmn-js DI container.
  *
  * @template T The service type to retrieve.

--- a/apps/bpmn-webview/src/app/state.ts
+++ b/apps/bpmn-webview/src/app/state.ts
@@ -1,3 +1,9 @@
+/**
+ * @internal Host-adapter surface — `WebviewStateManager` speaks the private
+ * Query/Command protocol and persists panel/canvas UI state. Not part of the
+ * designed public API (#1375); relocated out of the publishable boundary in
+ * #1377.
+ */
 import { Command, Query, HostApi } from "@miragon/bpmn-modeler-shared";
 import { isUsableViewbox } from "@miragon/bpmn-modeler-types";
 import { CanvasViewState, WebviewState } from "./webviewState";

--- a/apps/bpmn-webview/src/app/webviewState.ts
+++ b/apps/bpmn-webview/src/app/webviewState.ts
@@ -1,3 +1,8 @@
+/**
+ * @internal Host-adapter surface — persisted webview UI state shapes consumed by
+ * `WebviewStateManager`. Not part of the designed public API (#1375).
+ */
+
 export interface ViewportData {
     x: number;
     y: number;

--- a/docs/adr/0007-public-modeler-api.md
+++ b/docs/adr/0007-public-modeler-api.md
@@ -1,0 +1,222 @@
+# 0007 — Fix the public `@miragon/bpmn-modeler` API surface before extraction
+
+- Status: accepted (#1375)
+- Date: 2026-08-27
+- Category: bpmn-webview
+
+Design spike for the modeler-npm-extraction epic (#1293, see
+[ADR 0006](0006-extract-publishable-modeler-package.md)); lands the API
+skeleton that #1373 (linting tiers), #1374 (clipboard polarity), and #1376
+(package workspace) build against.
+
+## Context
+
+Epic #1293 extracts the host-free BPMN modeler composition out of
+`apps/bpmn-webview` into a publishable npm package, `@miragon/bpmn-modeler`. The
+prerequisites already landed: the public types split into `libs/modeler-types`
+(#1371), per-feature capability ports (#1370), and instance-based
+`createModeler` (#1372).
+
+The remaining risk is the API itself. The current facade
+(`app/createModeler.ts` + `app/modeler.ts`) grew to serve one caller — the VS
+Code webview `bootstrap` — so its shape is *accidental*: a two-step
+`create(engine)`, a flat `propertiesPanelParent`, an `extraModules` DI escape
+hatch carrying clipboard/i18n/theme wiring, page-level side effects
+(`initTheme`, `i18n.setLanguage`, panel resizer) done in an 836-line
+`bootstrap.ts` rather than through options, and a `lintingHost` value object
+required just to keep DI resolvable. If the extraction froze that shape, the
+first published version would bake in the accidents.
+
+This ADR fixes the complete public TypeScript surface **before** the package
+exists, so #1376 moves code into a *designed* API. The deliverable of #1375 is
+type-only: a compile-checked skeleton (`app/publicApi.ts`), a conformance +
+scenario spec (`app/publicApi.spec.ts`), an `@internal` tagging pass, and this
+record. No runtime refactor — the renames and new methods land in #1373/#1376.
+
+## Decision
+
+### Semver stance: the facade is the contract
+
+The published contract is exactly the `createModeler` options, the instance
+handle, and the outbound event model — the surface in `app/publicApi.ts`.
+Everything else is free to change without a major bump:
+
+- The **host ↔ webview `Query`/`Command` protocol** (`libs/shared`) stays
+  private and freely refactorable. It is an internal transport, not API. The
+  eslint `BND-PROTOCOL-PRIVATE` rule already forbids the publishable layers from
+  importing it.
+- The **bpmn-js DI service graph** reached through `getService` is an
+  explicitly unstable escape hatch (see below).
+- The host-capability port *forwarders* and DI *module factories*
+  (`createModelNavigationModule`, `createCodeLinkModule`,
+  `createInlineScriptingModules`) are package-internal composition wiring; a
+  consumer enables a feature by supplying its port through `capabilities`, never
+  by calling a factory.
+
+### The three-category feature taxonomy
+
+Every capability the modeler exposes belongs to exactly one category. The
+category decides its default and how a consumer changes it.
+
+| Category | Default | How to change it | Members |
+|---|---|---|---|
+| **[A] Engine-intrinsic** | Always present | n/a — it *is* the modeler | load/export/new/SVG, viewport, selection, element templates, settings, engine |
+| **[B] Opinionated built-in** | On, sensible default | One option to turn off; one option to replace | linting, clipboard, theme, locale |
+| **[C] Host capability** | Off | Supply a port through `capabilities` | model navigation, code link, inline scripting |
+
+Events (`onContentSaved`, `onLintResults`, `onLintingToggled`, `onWarning`,
+`onElementTemplatesErrors`) are a fourth, cross-cutting concern: strictly
+outbound notifications, tagged in the skeleton but not a category.
+
+### The opinionated-defaults corollary
+
+A host-less consumer that calls `createModeler(container, { engine,
+propertiesPanel })` gets a fully-featured modeler: linting on with the bundled
+ruleset, the native clipboard, automatic theming, English UI. Every built-in is
+**one option away** from off and **one override away** from replaced — `linting:
+false`, `clipboard: { bridge }`, `theme: "dark"`, `locale: "de"`. This is what
+makes the package pleasant for the demo/standalone consumers while still letting
+VS Code and IntelliJ override each built-in with their host-mediated version.
+
+### Engine in options, async factory
+
+The target factory is:
+
+```ts
+createModeler(container: HTMLElement, options: ModelerOptions): Promise<BpmnModelerHandle>
+```
+
+with a required `engine`. Two reasons the return is a `Promise`: #1373's lint
+tier lazy-loads its bpmnlint chunk, forcing a construction await anyway; and an
+async factory lets the package do first-diagram/i18n setup before resolving. A
+host that learns the engine late simply constructs late — today's `bootstrap`
+already constructs the modeler only after the file handshake. Switching engines
+is `destroy()` + a new instance, not a mutation.
+
+The current two-step `create(engine)` is documented `@internal` as the migration
+path; #1376 collapses it into the async factory.
+
+### Event model: flat typed callbacks, not one `onEvent` bus
+
+Outbound notifications are individual typed `on*` option callbacks. #1373
+already decided `onLintResults`/`onLintingToggled` as top-level callbacks; typed
+individual callbacks are more discoverable for a vanilla factory API than a
+single tagged-union `onEvent({source, event, data})` bus, and a future React
+adapter can trivially fan them into its own `onEvent`.
+
+Content-out is a package-owned **debounced** `onContentSaved({ xml })` (300 ms,
+1000 ms maxWait — the shape battle-tested in `bootstrap`, mirroring
+camunda-web-modeler's `content.saved`). Every consumer needs that debounce;
+raw `commandStack.changed` stays reachable through `getService`.
+
+**An event is never a substitute for a capability port.** A callback can only
+announce that something happened; it cannot answer a question or resolve a
+target. "Navigate to this reference" is a `ModelNavigationPort`, not an
+`onNavigateRequested` event, because the host must be able to resolve
+asynchronously and the modeler must stay ignorant of how. This is why the ports
+widen to `void | Promise<void>` (see Consequences) instead of becoming events.
+
+### `@internal` without tooling — for now
+
+`@internal` is applied as a **TSDoc documentation contract** only. There is no
+api-extractor, no `exports`-map trimming, and no lint rule enforcing it in this
+spike. Marking a symbol `@internal` states intent ("not part of the published
+API") so the extraction and reviewers have a single source of truth; mechanical
+enforcement is deferred to #1376/#1379.
+
+### `getService` stays public but unstable
+
+The DI escape hatch is kept on the public handle deliberately, so advanced
+integrations and plugin authors are not blocked while the typed surface catches
+up — but documented as unstable (not semver-covered): bpmn-js service names can
+change across minor versions. Reaching for it is a signal a typed option/method
+is missing and should be filed.
+
+## Validation
+
+Every signature was checked against the real consumers. `app/publicApi.spec.ts`
+encodes the checks as compile-time assertions.
+
+- **demo-webapp** (`demo/bpmn/main.ts`, `demo/bpmn/dual.ts`): a
+  `capabilities.modelNavigation`-only options literal type-checks; code-link and
+  scripting stay omitted, so their UI genuinely never renders. `dual.ts`'s
+  two-instance mount maps onto two independent `createModeler` calls, each with
+  its own `propertiesPanel.parent`.
+- **bpm-iq scenario 1 — data-in element templates**: `elementTemplates?:
+  object[]` accepts fetched JSON; there is no path-based variant.
+- **bpm-iq scenario 2 — async model navigation**: `ModelNavigationPort.openReference`
+  accepts an `async` implementation (GitHub-API resolution before opening a
+  tab). The widened `void | Promise<void>` return is what makes this type-check;
+  the modeler still treats the call as fire-and-forget.
+- **bpm-iq scenario 3 — graceful `{ config }` lint degradation**: a `linting: {
+  config }` literal type-checks against the structural `BpmnlintConfig` mirror;
+  unresolvable rules degrade at runtime and are reported through
+  `onLintResults({ results, unresolved })` rather than failing the pass.
+- **conformance**: the current `BpmnModeler` class is assignable to the *stable
+  subset* of `BpmnModelerHandle` (`StableModelerSurface`) — proof the extraction
+  can adopt the handle type without reshaping already-frozen members.
+
+Note: bpmn-webview has no `tsc` gate in CI (its `build` is `vite build` and its
+`test` is `vitest run`, both esbuild — types are stripped, not checked). The
+conformance spec is therefore enforced at authoring time via `tsc -p
+apps/bpmn-webview/tsconfig.spec.json`. Wiring a type-check gate is a #1376/#1379
+follow-up (see below).
+
+## Alternatives considered
+
+- **A single `onEvent({ source, event, data })` bus** (camunda-web-modeler's
+  shape). Less discoverable for a vanilla factory; a React adapter can synthesize
+  it from the typed callbacks, not the other way round.
+- **Path-based element templates** (`elementTemplates: string`). Couples the
+  package to a filesystem and a host; data-in keeps it host-free.
+- **Sync-only capability ports.** Scenario 2 needs async resolution before the
+  navigation completes; sync ports would force the host into fire-and-forget
+  hacks. Widening to `void | Promise<void>` costs nothing and unblocks it.
+- **api-extractor / `exports`-map trimming now.** Real enforcement is worth
+  doing, but it is package-workspace work (#1376/#1379), not part of fixing the
+  API shape. Adding it here would couple this spike to a build-tooling decision.
+
+## Consequences
+
+- The extraction (#1376) moves code into a designed API. The runtime deltas it
+  and #1373/#1374 must apply are captured as a **rename/reshape map**:
+
+  | Current | Target | Landing in |
+  |---|---|---|
+  | `create(engine)` second step | `engine` in options, async factory | #1376 |
+  | `propertiesPanelParent` | `propertiesPanel: { parent }` | #1376 |
+  | `extraModules` | `additionalModules` | #1376 |
+  | `lintingHost` value object | `onLintingToggled` callback | #1373 |
+  | `getService("bpmnLintConfig")` render calls | `linting` option + `applyLintResults`/`applyLintingDisabled` | #1373 |
+  | `setElementTemplates(JSON[] \| undefined)` | `setElementTemplates(object[])` | #1376 |
+  | page-level `initTheme`/`setColorThemeMode` | `theme` option + `setTheme()` | #1376/#1377 |
+  | page-level `i18n.setLanguage` + `TranslateModule` | `locale` option | #1376 |
+  | `VsCodeClipboardModule` via `extraModules` | `clipboard: { bridge }` | #1374 |
+
+- The capability ports widen to `void | Promise<void>` now (a small, real,
+  behaviour-neutral change — all callers already ignore the return value), so
+  async host implementations type-check against the frozen ports.
+- `@internal` tags mark the host-adapter-only instance methods (scripting,
+  `applyImplementationStatus`, `alignElementsToOrigin`, `rootElement`,
+  `onCommandStackChanged`, the two-step `create`), the page-level webview chrome
+  in `libs/modeler-types` (`theme`, `propertiesPanelResizer`,
+  `propertiesPanelFocus`, `canvasResize`), the `app/` host-adapter modules
+  (`host`, `state`, `webviewState`, `keyboardFocus`, `canvasFocusIndicator`,
+  `propertiesPanelClipboard`, `rootElement`), and the port module factories.
+
+
+## Follow-ups
+
+- #1373 — linting tier ladder + `onLintResults`/`onLintingToggled` runtime.
+- #1374 — clipboard polarity flip (native default, `clipboard: { bridge }`).
+- #1376 — package workspace; collapse `create(engine)` into the async factory;
+  apply the rename/reshape map; wire a `tsc` type-check gate for the package.
+- #1377 — relocate the VS Code `<body>`-class theme watcher to the host adapter;
+  inject the per-instance `theme` mode.
+- Promote the non-protocol utilities that landed in `libs/shared` by accident
+  (`processVariables`, `variableManifest`, `asyncDebounce`) to a home the
+  publishable package can import.
+- Add disposers for the manager `on*` subscriptions
+  (`onCommandStackChanged`, `onElementTemplatesErrors`) so the async handle can
+  be torn down cleanly.
+- #1379 — mechanical `@internal` enforcement (api-extractor or `exports` map).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,3 +44,4 @@ contributor-facing record, not user documentation.
 | ADR | Decision | Status |
 | --- | --- | --- |
 | [0006](0006-extract-publishable-modeler-package.md) | Extract the host-free modeler composition into a publishable npm package | accepted |
+| [0007](0007-public-modeler-api.md) | Fix the public `@miragon/bpmn-modeler` API surface before extraction | accepted |

--- a/libs/code-link/src/CodeLinkPort.ts
+++ b/libs/code-link/src/CodeLinkPort.ts
@@ -12,9 +12,13 @@ import type { ImplementationEntry } from "@miragon/bpmn-modeler-types";
  * `@miragon/bpmn-modeler-types` package (#1371).
  */
 export interface CodeLinkPort {
-    /** Open the workspace source file the reference resolves to. */
-    navigateToImplementation(reference: string, kind: ImplementationKind): void;
+    /**
+     * Open the workspace source file the reference resolves to. Widened to
+     * `void | Promise<void>` so a host may resolve the location asynchronously;
+     * the modeler treats the call as fire-and-forget and never awaits it.
+     */
+    navigateToImplementation(reference: string, kind: ImplementationKind): void | Promise<void>;
 
     /** Ship the diagram's current implementation references for status resolution. */
-    syncActivities(entries: ImplementationEntry[]): void;
+    syncActivities(entries: ImplementationEntry[]): void | Promise<void>;
 }

--- a/libs/code-link/src/index.ts
+++ b/libs/code-link/src/index.ts
@@ -35,6 +35,10 @@ export type { CodeLinkPort } from "./CodeLinkPort";
  * first in `__init__` so it is constructed (and subscribed to import/edit
  * events) before the provider that depends on it; the port rides along as a
  * `value` so both `codeLinkPort` injections resolve.
+ *
+ * @internal Package-internal composition wiring: consumers enable this feature
+ *   through the modeler's `capabilities.codeLink` port, not by calling this
+ *   factory directly (#1375).
  */
 export function createCodeLinkModule(port: CodeLinkPort) {
     return {

--- a/libs/inline-scripting/src/InlineScriptingPort.ts
+++ b/libs/inline-scripting/src/InlineScriptingPort.ts
@@ -11,9 +11,13 @@ import type { ScriptSourceChangedEvent } from "./scriptSourceWatcher";
  * `createInlineScriptingModules`).
  */
 export interface InlineScriptingPort {
-    /** A surface requested its editor tab be opened. */
-    openScriptEditor(event: OpenScriptEditorEvent): void;
+    /**
+     * A surface requested its editor tab be opened. Widened to
+     * `void | Promise<void>` so a host may open the tab asynchronously; the
+     * forwarder invokes it fire-and-forget and never awaits it.
+     */
+    openScriptEditor(event: OpenScriptEditorEvent): void | Promise<void>;
 
     /** An open script's model content diverged from its editor tab. */
-    scriptSourceChanged(event: ScriptSourceChangedEvent): void;
+    scriptSourceChanged(event: ScriptSourceChangedEvent): void | Promise<void>;
 }

--- a/libs/inline-scripting/src/index.ts
+++ b/libs/inline-scripting/src/index.ts
@@ -62,6 +62,10 @@ export type { OpenScriptEditorEvent, ScriptSourceChangedEvent, InlineScriptingPo
  * order — spread into `additionalModules`. The eighth bundle carries the
  * {@link InlineScriptingPortForwarder} together with the `inlineScriptingPort`
  * DI value, so the cluster and its host capability are registered as a unit.
+ *
+ * @internal Package-internal composition wiring: consumers enable this feature
+ *   through the modeler's `capabilities.scripting` port (C7 only), not by
+ *   calling this factory directly (#1375).
  */
 export function createInlineScriptingModules(port: InlineScriptingPort) {
     return [

--- a/libs/model-navigation/src/ModelNavigationPort.ts
+++ b/libs/model-navigation/src/ModelNavigationPort.ts
@@ -18,5 +18,12 @@ export interface ModelReference {
  * host is unrepresentable — no port, no module (see {@link createModelNavigationModule}).
  */
 export interface ModelNavigationPort {
-    openReference(reference: ModelReference): void;
+    /**
+     * Fire-and-forget from the modeler's side: the return type is widened to
+     * `void | Promise<void>` so a host can resolve the target asynchronously
+     * (e.g. a GitHub-API lookup before opening a tab) without changing the
+     * contract — the modeler never awaits it. Popup-blocker handling stays the
+     * host's problem.
+     */
+    openReference(reference: ModelReference): void | Promise<void>;
 }

--- a/libs/model-navigation/src/index.ts
+++ b/libs/model-navigation/src/index.ts
@@ -27,6 +27,10 @@ export type { ModelNavigationPort, ModelReference } from "./ModelNavigationPort"
  * Builds the DI bundle for the given host port. The port rides along as a
  * `value` so the provider's `["contextPad", "translate", "modelNavigationPort"]`
  * injection resolves.
+ *
+ * @internal Package-internal composition wiring: consumers enable this feature
+ *   through the modeler's `capabilities.modelNavigation` port, not by calling
+ *   this factory directly (#1375).
  */
 export function createModelNavigationModule(port: ModelNavigationPort) {
     return {

--- a/libs/modeler-types/src/bpmnFlowOrder.ts
+++ b/libs/modeler-types/src/bpmnFlowOrder.ts
@@ -30,9 +30,12 @@
  */
 
 /**
- * Minimal subset of a parsed bpmn-moddle element used by this module.
+ * Minimal subset of a parsed bpmn-moddle element used by this module. Exported
+ * because it appears in the signatures of the exported `buildFlowOrder` /
+ * `buildRemovedAnchors` functions — leaving it unexported forced callers to
+ * reference an anonymous, unnameable structural type at the boundary.
  */
-interface ModdleElement {
+export interface ModdleElement {
     $type: string;
     id?: string;
     [key: string]: unknown;

--- a/libs/modeler-types/src/canvasResize.ts
+++ b/libs/modeler-types/src/canvasResize.ts
@@ -1,4 +1,10 @@
 /**
+ * @internal `observeCanvasSize` and its helpers are package-internal wiring the
+ * facade installs per instance; the exported names are not part of the designed
+ * public API (#1375).
+ */
+
+/**
  * Smallest canvas box (px, both axes) worth fitting a diagram into. A host
  * that renders off-screen reports roughly one pixel rather than none, and a
  * fit against that succeeds arithmetically but scales the diagram to nothing.

--- a/libs/modeler-types/src/lint.ts
+++ b/libs/modeler-types/src/lint.ts
@@ -19,3 +19,35 @@ export interface LintReport {
  * `bpmn-js-bpmnlint`'s `Linting._formatIssues` consumes.
  */
 export type LintResults = Record<string, LintReport[]>;
+
+/**
+ * A single rule's severity in a {@link BpmnlintConfig}: bpmnlint accepts both
+ * the string form (`"error"` / `"warn"` / `"off"`) and the legacy numeric form
+ * (`2` / `1` / `0`), optionally paired with a rule-specific config object.
+ */
+export type BpmnlintRuleSeverity = "off" | "warn" | "error" | 0 | 1 | 2;
+export type BpmnlintRuleConfig = BpmnlintRuleSeverity | readonly [BpmnlintRuleSeverity, unknown];
+
+/**
+ * Structural mirror of a bpmnlint configuration (`.bpmnlintrc`) as the public
+ * `linting: { config }` option accepts it (#1373). Kept structural — not an
+ * import of bpmnlint's own types — so the published API surface does not leak a
+ * transitive bpmnlint dependency. Unresolvable `extends`/`rules` degrade
+ * gracefully at load and surface via {@link LintRunEvent.unresolved}.
+ */
+export interface BpmnlintConfig {
+    readonly extends?: string | readonly string[];
+    readonly rules?: Readonly<Record<string, BpmnlintRuleConfig>>;
+}
+
+/**
+ * Outbound notification payload for one lint pass (#1373's `onLintResults`):
+ * the findings the overlay renders plus the rule names that could not be
+ * resolved from the supplied {@link BpmnlintConfig}. `unresolved` is how the
+ * modeler reports graceful degradation instead of failing the whole run when a
+ * `{ config }` references a rule the bundled resolver does not carry.
+ */
+export interface LintRunEvent {
+    readonly results: LintResults;
+    readonly unresolved: readonly string[];
+}

--- a/libs/modeler-types/src/propertiesPanelFocus.ts
+++ b/libs/modeler-types/src/propertiesPanelFocus.ts
@@ -1,3 +1,8 @@
+/**
+ * @internal Page-level webview chrome coupled to the `js-properties-panel` DOM
+ * id and the panel shortcuts. Not part of the designed public API (#1375).
+ * `isTextEditingSurface` is the one broadly-reused helper here.
+ */
 import type { PropertiesPanelHandle } from "./propertiesPanelResizer";
 
 /**

--- a/libs/modeler-types/src/propertiesPanelResizer.ts
+++ b/libs/modeler-types/src/propertiesPanelResizer.ts
@@ -1,4 +1,10 @@
 /**
+ * @internal Page-level webview chrome bound to hard-coded DOM ids
+ * (`js-panel-resizer`, `js-properties-panel`). Not part of the designed public
+ * API (#1375); the multi-instance facade owns its own panel host instead.
+ */
+
+/**
  * Minimum width (px) the properties panel can be resized to.
  * Dragging below this threshold collapses the panel entirely.
  */

--- a/libs/modeler-types/src/theme.ts
+++ b/libs/modeler-types/src/theme.ts
@@ -7,6 +7,12 @@
  *
  * VS Code injects `vscode-dark`, `vscode-light`, or `vscode-high-contrast`
  * onto `<body>` in every webview.
+ *
+ * @internal Host-specific and module-singleton — reads VS Code `<body>` classes
+ *   and mutates a single `#theme-link`, so it is not part of the designed
+ *   public API (#1375). Follow-up (#1376/#1377): replace with an injected
+ *   per-instance `theme` mode + `setTheme()`, moving the `<body>`-class watcher
+ *   to the host adapter.
  */
 
 let currentMode: "automatic" | "light" = "automatic";


### PR DESCRIPTION
## Issue

Closes #1375

## Description

Type-only design spike for epic #1293: `publicApi.ts` fixes the target `createModeler(container, options)` surface — options (engine, locale, theme, settings, data-in `elementTemplates`, #1373's linting tier ladder, #1374's clipboard override, capability ports), the `BpmnModelerHandle` instance API, and a flat `on*` notification event model with a package-owned debounced `onContentSaved`. A conformance + scenario spec proves the current facade satisfies the frozen stable subset and that the three bpm-iq validation scenarios (fetched templates, async model-navigation port, graceful `{ config }` linting) type-check. Capability-port returns are widened to `void | Promise<void>` (zero-risk, callers never await), everything outside the designed surface gets a TSDoc `@internal` tag, and the previously unexported `ModdleElement` hole in `bpmnFlowOrder` is closed. Decisions (semver stance: the facade is the contract; the three-category feature taxonomy; opinionated-defaults corollary; rename/reshape map) are recorded in the new ADR [ADR 0007](docs/adr/0007-public-modeler-api.md). No runtime behavior change — all hosts are untouched; the refactors land in #1373/#1376.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A — type-only, no runtime change)

