### PR TITLE
feat(editor): move the default lint path in-page for hosted sessions

### DIFF
--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
@@ -188,6 +188,74 @@ describe("LintConfigService: precedence (any push wins)", () => {
     });
 });
 
+describe("LintConfigService: startInPageLinting (host handback)", () => {
+    it("switches an external instance to in-page, activating and emitting on the next run", async () => {
+        const onLintResults = vi.fn();
+        const { service, linting, canvas } = makeService({
+            tier: "external",
+            imported: true,
+            callbacks: { onLintResults },
+        });
+        expect(linting.isActive()).toBe(false);
+
+        service.startInPageLinting();
+
+        // A diagram is already imported, so it activates immediately.
+        expect(linting.isActive()).toBe(true);
+        expect(canvas.getContainer().classList.contains("bpmnlint-active")).toBe(true);
+        expect(canvas.getContainer().querySelector(".lint-off-button")).not.toBeNull();
+
+        // Now on the in-page path: a relint runs the browser linter and echoes.
+        const returned = await linting.lint();
+        expect(runMock).toHaveBeenCalled();
+        expect(onLintResults).toHaveBeenCalledWith(LINT_EVENT);
+        expect(returned).toEqual(LINT_EVENT.results);
+    });
+
+    it("defers activation to import.done when no diagram is imported yet", () => {
+        const { service, linting, bus } = makeService({ tier: "external", imported: false });
+
+        service.startInPageLinting();
+        expect(linting.isActive()).toBe(false);
+
+        bus.fire("import.done");
+        expect(linting.isActive()).toBe(true);
+    });
+
+    it("no-ops when the user has disabled linting from the canvas", async () => {
+        const { service, canvas, bus, linting } = makeService({ tier: "in-page" });
+        bus.fire("import.done");
+        clickOffButton(canvas.getContainer());
+        expect(linting.isActive()).toBe(false);
+        linting.toggle.mockClear();
+
+        // A host instruction must never silently re-enable a user-disabled linter.
+        service.startInPageLinting();
+
+        expect(linting.isActive()).toBe(false);
+        expect(linting.toggle).not.toHaveBeenCalled();
+        expect(canvas.getContainer().querySelector(".lint-disabled-chip")).not.toBeNull();
+        await expect(linting.lint()).resolves.toEqual({});
+    });
+
+    it("still lets a later external push win over the in-page handback", async () => {
+        const onLintResults = vi.fn();
+        const { service, linting } = makeService({
+            tier: "external",
+            imported: true,
+            callbacks: { onLintResults },
+        });
+        service.startInPageLinting();
+        onLintResults.mockClear();
+
+        const pushed = { "rule-y": [{ id: "B", message: "y", category: "error" }] };
+        service.applyLintResults(pushed);
+
+        await expect(linting.lint()).resolves.toEqual(pushed);
+        expect(onLintResults).not.toHaveBeenCalled();
+    });
+});
+
 describe("LintConfigService: toggle matrix", () => {
     it("in-page off-button disables optimistically and reports the toggle", async () => {
         const onLintingToggled = vi.fn();

--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
@@ -134,8 +134,18 @@ export class LintConfigService {
 
     private state: LintTierState;
 
-    // Present only in the in-page tier; undefined for external instances.
-    private readonly browserLinter?: BrowserLinter;
+    // Present once the in-page tier is live; undefined for a purely external
+    // instance. Mutable because the host can hand linting back to the webview
+    // after construction (#1373 Phase B) via {@link startInPageLinting}, which
+    // lazily builds it — the constructor only builds it for an up-front in-page tier.
+    private browserLinter?: BrowserLinter;
+
+    // Kept from `tierInit` so a later {@link startInPageLinting} can construct a
+    // BrowserLinter with the same engine (and the original explicit config when
+    // the handback carries none).
+    private readonly engine: Engine;
+
+    private readonly explicitConfig?: BpmnlintConfig;
 
     private results: LintResults = {};
 
@@ -155,25 +165,55 @@ export class LintConfigService {
         eventBus: EventBus,
     ) {
         this.state = tierInit.tier === "in-page" ? "in-page" : "external";
+        this.engine = tierInit.engine;
+        this.explicitConfig = tierInit.config;
         if (tierInit.tier === "in-page") {
-            this.browserLinter = new BrowserLinter(tierInit.engine, tierInit.config);
+            this.browserLinter = new BrowserLinter(this.engine, this.explicitConfig);
         }
 
         // One `lint` override for every tier; {@link runLint} branches on state.
         // The vendor calls it from `update()` on import.done / elements.changed.
         this.linting.lint = () => this.runLint();
 
-        // In-page linting switches itself on once a diagram is present. Guarded on
-        // the current state so a re-import never resurrects a user-disabled linter.
-        if (tierInit.tier === "in-page") {
-            eventBus.on("import.done", () => {
-                if (this.state === "in-page") {
-                    this.activateInPage();
-                }
-            });
-            if (this.bpmnjs.getDefinitions()) {
+        // Registered unconditionally so a post-handback re-import re-activates the
+        // in-page tier too (an external instance can later become in-page via
+        // {@link startInPageLinting}). Guarded on the current state so it never
+        // activates an external instance and never resurrects a user-disabled one.
+        eventBus.on("import.done", () => {
+            if (this.state === "in-page") {
                 this.activateInPage();
             }
+        });
+        if (tierInit.tier === "in-page" && this.bpmnjs.getDefinitions()) {
+            this.activateInPage();
+        }
+    }
+
+    /**
+     * Starts (or restarts) the in-page linter on host instruction — the #1373
+     * Phase B handback when the host finds no workspace `.bpmnlintrc`. Lazily
+     * builds the {@link BrowserLinter} (the constructor only builds it for an
+     * up-front in-page tier) and activates it if a diagram is already imported;
+     * otherwise the unconditional `import.done` listener activates it.
+     *
+     * No-ops when the user has disabled linting from the canvas — a host
+     * instruction must never silently re-enable a user-disabled linter; the
+     * chip's own click handler owns re-enable. Also no-ops when already in-page
+     * with no new config (a duplicate instruction). Precedence is unchanged:
+     * {@link applyLintResults}/{@link applyLintingDisabled} still hard-set
+     * `"external"`, so any host push still wins over this.
+     */
+    startInPageLinting(config?: BpmnlintConfig): void {
+        if (this.state === "in-page-disabled") {
+            return;
+        }
+        if (this.state === "in-page" && this.browserLinter && config === undefined) {
+            return;
+        }
+        this.browserLinter = new BrowserLinter(this.engine, config ?? this.explicitConfig);
+        this.state = "in-page";
+        if (this.bpmnjs.getDefinitions()) {
+            this.activateInPage();
         }
     }
 

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -11,6 +11,7 @@ import { type CodeLinkMapClient } from "@miragon/bpmn-modeler-code-link";
 import { FlowNavigationModule } from "@miragon/bpmn-modeler-flow-navigation";
 import { CreateAppendC7ElementTemplatesModule } from "@miragon/create-append-c7";
 import {
+    BpmnlintConfig,
     BpmnModelerSetting,
     Engine,
     LintResults,
@@ -290,6 +291,27 @@ export class BpmnModeler {
             return;
         }
         service.applyLintingDisabled();
+    }
+
+    /**
+     * Starts (or restarts) the in-page linter on host instruction — the #1373
+     * Phase B handback when the host finds no workspace `.bpmnlintrc`. Mirrors
+     * {@link applyLintResults}: a no-op with a warning when the instance was
+     * created with `linting: false` (no lint service). Never re-enables a
+     * user-disabled linter (the service guards that); any later host push still
+     * wins over the in-page run.
+     *
+     * @throws {NoModelerError} If the modeler has not been created yet.
+     */
+    startInPageLinting(config?: BpmnlintConfig): void {
+        const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
+        if (!service) {
+            console.warn(
+                "startInPageLinting ignored: this modeler was created with linting: false",
+            );
+            return;
+        }
+        service.startInPageLinting(config);
     }
 
     /**

--- a/apps/bpmn-webview/src/app/publicApi.ts
+++ b/apps/bpmn-webview/src/app/publicApi.ts
@@ -219,6 +219,13 @@ export interface BpmnModelerHandle {
     /** [B] Turn off the in-webview linter and clear its overlay (#1373). */
     applyLintingDisabled(): void;
 
+    /**
+     * [B] Start (or restart) the in-webview linter — the host's no-workspace-config
+     * handback (#1373 Phase B). Optional `config` overrides the engine-aware
+     * default. Never re-enables a user-disabled linter.
+     */
+    startInPageLinting(config?: BpmnlintConfig): void;
+
     // ── Escape hatch ────────────────────────────────────────────────────────
     /**
      * Unstable escape hatch: reach a bpmn-js DI service by name. Not covered by

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -39,6 +39,7 @@ import {
     SyncActivitiesCommand,
     SyncDocumentCommand,
     TextClipboardQuery,
+    UpdateLintResultsCommand,
     UpdateOpenScriptEditorsQuery,
     UpdateScriptContentQuery,
     UpdateScriptFormatQuery,
@@ -418,7 +419,15 @@ function startSession(
             extraModules,
             capabilities,
             linting: injectedLinting ?? { results: "external" },
-            onLintResults: injectedOnLintResults,
+            // A real host activates in-page linting only after it answers the
+            // GetBpmnlintConfigCommand with BpmnlintInPageQuery (no workspace
+            // config, #1373 Phase B); the webview then pushes its findings back
+            // so the host feeds its Problems panel + status bar. `??` keeps the
+            // demo's injected sink authoritative when one is supplied.
+            onLintResults:
+                injectedOnLintResults ??
+                ((e: LintRunEvent) =>
+                    host.postMessage(new UpdateLintResultsCommand(e.results, [...e.unresolved]))),
             onLintingToggled: (enabled: boolean) =>
                 host.postMessage(new SetLintingEnabledCommand(enabled)),
             applyColorThemeMode: setColorThemeMode,
@@ -678,6 +687,17 @@ function startSession(
             case queryOrCommand.type === "BpmnLintDisabledQuery": {
                 try {
                     bpmnModeler.applyLintingDisabled();
+                } catch (error: any) {
+                    host.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                }
+                break;
+            }
+            case queryOrCommand.type === "BpmnlintInPageQuery": {
+                try {
+                    // No workspace config: run our own default in-page (#1373
+                    // Phase B). onLintResults then pushes the findings back so the
+                    // host feeds its Problems panel + status bar.
+                    bpmnModeler.startInPageLinting();
                 } catch (error: any) {
                     host.postMessage(new LogErrorCommand(errorPrefix + error.message));
                 }

--- a/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
+++ b/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
@@ -6,11 +6,13 @@
  * temp filesystem, so the `BpmnLintConfigLocator` + `BpmnLintConfigService` +
  * `NodeBpmnLinter` do an actual nearest-`.bpmnlintrc` walk and run bpmnlint.
  * Covers the two branches the webview's `GetBpmnlintConfigCommand` exposes: a
- * discovered config is linted and the findings pushed as `BpmnlintResultsQuery`,
- * and no config falls back to the bundled default (#1327) rather than deactivating.
- * The temp dir has no `node_modules`, so built-in and camunda-compat rules resolve
- * from the bundled resolvers — the same path a workspace without `bpmnlint`
- * installed hits.
+ * discovered config is linted host-side and the findings pushed as
+ * `BpmnlintResultsQuery`, and no config hands linting to the webview's in-page
+ * default (#1373 Phase B) — the bridge posts a `BpmnlintInPageQuery` instead of
+ * linting host-side, then accepts the webview's own findings back through
+ * `UpdateLintResultsCommand`. The temp dir has no `node_modules`, so the
+ * workspace-config path resolves built-in and camunda-compat rules from the
+ * bundled resolvers — the same path a workspace without `bpmnlint` installed hits.
  */
 
 import { promises as fs } from "node:fs";
@@ -77,6 +79,14 @@ async function waitForFrame(
 const isLintResultsFrame = (frame: any): boolean =>
     frame.method === "editor/postMessage" && frame.params?.message?.type === "BpmnlintResultsQuery";
 
+const isInPageInstructionFrame = (frame: any): boolean =>
+    frame.method === "editor/postMessage" && frame.params?.message?.type === "BpmnlintInPageQuery";
+
+const isInPageResultsLog = (frame: any): boolean =>
+    frame.method === "notifier/log" &&
+    typeof frame.params?.message === "string" &&
+    frame.params.message.includes("in-page results");
+
 describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
     const cleanups: Array<() => Promise<void> | void> = [];
 
@@ -134,25 +144,47 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
         expect(Object.keys(results)).toContain("start-event-required");
     });
 
-    it("lints against the bundled default when no .bpmnlintrc exists", async () => {
+    it("hands linting to the webview in-page (no host lint) when no .bpmnlintrc exists", async () => {
         const { rpc, frames, editorId } = await setup();
 
         await requestConfig(rpc, editorId);
 
-        const frame = await waitForFrame(frames, isLintResultsFrame);
-        const results = frame.params.message.results;
-        expect(results).not.toBeNull();
-        expect(Object.keys(results)).toContain("start-event-required");
+        // The bridge tells the webview to run its own default rather than linting
+        // host-side, so it posts a BpmnlintInPageQuery and never a results query.
+        await waitForFrame(frames, isInPageInstructionFrame);
+        expect(frames.find(isLintResultsFrame)).toBeUndefined();
     });
 
-    it("enforces the miragon standard-size layer through the bundled default", async () => {
+    it("accepts the webview's in-page findings back over UpdateLintResultsCommand", async () => {
+        // Rule coverage for the bundled default now lives in the AC5 parity spec;
+        // here we prove the webview→host results command is wired: after the
+        // no-config in-page handback, a pushed UpdateLintResultsCommand is
+        // accepted and applied (the debug log confirms the round-trip). The
+        // bridge has no Problems panel / status bar, so the log is the only
+        // observable effect.
         const { rpc, frames, editorId } = await setup(BPMN_XML_OVERSIZED);
 
         await requestConfig(rpc, editorId);
+        await waitForFrame(frames, isInPageInstructionFrame);
 
-        const frame = await waitForFrame(frames, isLintResultsFrame);
-        const results = frame.params.message.results;
-        expect(results).not.toBeNull();
-        expect(Object.keys(results)).toContain("standard-size");
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "webview/message",
+                params: {
+                    editorId,
+                    message: {
+                        type: "UpdateLintResultsCommand",
+                        results: {
+                            "standard-size": [
+                                { id: "Task_1", message: "Task too large", category: "warn" },
+                            ],
+                        },
+                        unresolved: [],
+                    },
+                },
+            }),
+        );
+
+        await waitForFrame(frames, isInPageResultsLog);
     });
 });

--- a/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
+++ b/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
@@ -1,8 +1,7 @@
-import { Command } from "@miragon/bpmn-modeler-shared";
+import { Command, UpdateLintResultsCommand } from "@miragon/bpmn-modeler-shared";
 import {
     BpmnLintConfigLocator,
     BpmnLintConfigService,
-    DefaultBpmnlintConfigService,
     NodeBpmnLinter,
     NoopDiagnostics,
 } from "@miragon/bpmn-modeler-core";
@@ -12,16 +11,20 @@ import { RegisterParams, SessionHooks } from "./sessionHooks";
 
 /**
  * The bpmnlint feature discovers the nearest `.bpmnlintrc` for an open BPMN
- * document, runs bpmnlint in the bridge (a full Bun/Node context, so custom
- * `bpmnlint-plugin-*` rules resolve against the workspace exactly like in VS
- * Code), and pushes the findings to the webview, which only renders the in-canvas
- * markers. It reuses the host-agnostic core stack ({@link BpmnLintConfigLocator} +
+ * document. When one is found it runs bpmnlint in the bridge (a full Bun/Node
+ * context, so custom `bpmnlint-plugin-*` rules resolve against the workspace
+ * exactly like in VS Code) and pushes the findings to the webview, which only
+ * renders the in-canvas markers. When none is found it tells the webview to run
+ * its own engine-aware default in-page (#1373 Phase B) and accepts the findings
+ * back via {@link UpdateLintResultsCommand} — the same core behaviour as VS Code,
+ * arriving here structurally (Phase C formally asserts it). It reuses the
+ * host-agnostic core stack ({@link BpmnLintConfigLocator} +
  * {@link BpmnLintConfigService} + {@link NodeBpmnLinter}) over the
  * Workspace/Settings/Document/StatusBar ports the bridge already implements — the
  * bridge analogue of the VS Code `BpmnlintParticipant`. There is no Problems-panel
  * equivalent here, so {@link NoopDiagnostics} stands in.
  *
- * Webview messages: GetBpmnlintConfigCommand.
+ * Webview messages: GetBpmnlintConfigCommand, UpdateLintResultsCommand.
  * Session hooks: a per-editor `.bpmnlintrc` watcher that re-lints on change.
  */
 export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks } {
@@ -34,7 +37,6 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
         new NoopDiagnostics(),
         deps.statusBar,
         deps.notifier,
-        new DefaultBpmnlintConfigService(),
         deps.settings,
     );
 
@@ -43,6 +45,14 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
     // inside the service, so this never throws into the dispatcher.
     deps.router.on("GetBpmnlintConfigCommand", async (_message: Command, editorId: string) => {
         await lintSvc.setBpmnlintConfig(editorId);
+    });
+
+    // The webview posts its own in-page default findings back after each run
+    // (#1373 Phase B). The service ignores it once a workspace-config takeover
+    // has flipped the editor to the external path.
+    deps.router.on("UpdateLintResultsCommand", (message: Command, editorId: string) => {
+        const cmd = message as UpdateLintResultsCommand;
+        lintSvc.applyWebviewLintResults(editorId, cmd.results, cmd.unresolved);
     });
 
     // Per-editor `.bpmnlintrc` watcher so edits to the rules re-lint the open

--- a/apps/vscode-plugin/src/composition/editorFeature.ts
+++ b/apps/vscode-plugin/src/composition/editorFeature.ts
@@ -11,7 +11,6 @@ import { BpmnClipboardMediator } from "@miragon/bpmn-modeler-core";
 import { BpmnElementTemplatesService } from "@miragon/bpmn-modeler-core";
 import { BpmnLintConfigLocator } from "@miragon/bpmn-modeler-core";
 import { BpmnLintConfigService } from "@miragon/bpmn-modeler-core";
-import { DefaultBpmnlintConfigService } from "@miragon/bpmn-modeler-core";
 import { BpmnPropertiesPanelService } from "@miragon/bpmn-modeler-core";
 import { BpmnSettingsBroadcaster } from "@miragon/bpmn-modeler-core";
 import { DmnModelerService } from "@miragon/bpmn-modeler-core";
@@ -44,6 +43,7 @@ import {
     getPropertiesPanelStateHandler,
     setPropertiesPanelStateHandler,
     setLintingEnabledHandler,
+    updateLintResultsHandler,
     getClipboardHandler,
     setClipboardHandler,
     getTextClipboardHandler,
@@ -138,7 +138,6 @@ export function register(
         new VsCodeDiagnostics(FOCUS_LINT_ELEMENT_CMD),
         deps.statusBar,
         deps.notifier,
-        new DefaultBpmnlintConfigService(),
         deps.vsSettings,
     );
     const clipboardMediator = new BpmnClipboardMediator(
@@ -194,6 +193,7 @@ export function register(
         .on("GetBpmnModelerSettingCommand", getBpmnModelerSettingHandler(settingsBroadcaster))
         .on("GetBpmnModelerSettingCommand", resyncScriptTasksHandler(scriptTaskSvc))
         .on("SetLintingEnabledCommand", setLintingEnabledHandler())
+        .on("UpdateLintResultsCommand", updateLintResultsHandler(lintConfigSvc))
         .on("GetPropertiesPanelStateCommand", getPropertiesPanelStateHandler(panelSvc))
         .on("SetPropertiesPanelStateCommand", setPropertiesPanelStateHandler(panelSvc))
         .on("GetClipboardCommand", getClipboardHandler(clipboardMediator))

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.spec.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { SettingChange } from "@miragon/bpmn-modeler-core";
+import { DocumentChangeEvent, SettingChange } from "@miragon/bpmn-modeler-core";
 import { BpmnLintConfigLocator, WatcherResult } from "@miragon/bpmn-modeler-core";
 import { BpmnLintConfigService } from "@miragon/bpmn-modeler-core";
 import { VsCodeNotifier } from "../../../../shared/infrastructure/VsCodeNotifier";
@@ -13,6 +13,7 @@ const EDITOR_ID = "file:///diagram.bpmn";
 function createContext() {
     const captured: {
         settingChange?: (event: SettingChange, id: string) => void;
+        documentChange?: (event: DocumentChangeEvent) => void;
         dispose?: () => void;
         viewState?: () => void;
     } = {};
@@ -28,12 +29,21 @@ function createContext() {
     const context: EditorSessionContext = {
         editorId: EDITOR_ID,
         panel: panel as never,
-        onDocumentChange: vi.fn(),
+        onDocumentChange: (cb) => void (captured.documentChange = cb),
         onSettingChange: (cb) => void (captured.settingChange = cb),
         onDispose: (cb) => void (captured.dispose = cb),
         addDisposable,
     };
     return { context, captured, addDisposable, panel, viewStateSubscription };
+}
+
+/** A `.bpmn` content-change event for this session's document. */
+function bpmnChange(): DocumentChangeEvent {
+    return {
+        hasContentChanges: () => true,
+        documentPath: () => "/diagram.bpmn",
+        documentUriString: () => EDITOR_ID,
+    } as DocumentChangeEvent;
 }
 
 function settingChange(affected: string): SettingChange {
@@ -48,9 +58,10 @@ function createServices(watcher: WatcherResult) {
     const lintSvc = {
         setBpmnlintConfig: vi.fn(),
         clearDiagnostics: vi.fn(),
+        getLintMode: vi.fn().mockReturnValue("external"),
     } as Pick<
         BpmnLintConfigService,
-        "setBpmnlintConfig" | "clearDiagnostics"
+        "setBpmnlintConfig" | "clearDiagnostics" | "getLintMode"
     > as BpmnLintConfigService;
     const locator = {
         createWatcher: vi.fn().mockResolvedValue(watcher),
@@ -150,6 +161,48 @@ describe("BpmnlintParticipant", () => {
         captured.dispose?.();
         expect(statusBar.hideBpmnlintStatus).toHaveBeenCalledOnce();
         expect(lintSvc.clearDiagnostics).toHaveBeenCalledWith(EDITOR_ID);
+    });
+
+    describe("document-change re-lint (debounced), gated by lint mode", () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it("re-lints after the debounce when the editor is on the external path", async () => {
+            const { lintSvc, locator, statusBar, notifier } = createServices({
+                disposables: [],
+                errors: [],
+            });
+            (lintSvc.getLintMode as ReturnType<typeof vi.fn>).mockReturnValue("external");
+            const { context, captured } = createContext();
+
+            await new BpmnlintParticipant(lintSvc, locator, statusBar, notifier).onResolve(context);
+            captured.documentChange?.(bpmnChange());
+
+            // Debounced: nothing fires immediately.
+            expect(lintSvc.setBpmnlintConfig).not.toHaveBeenCalled();
+            vi.advanceTimersByTime(400);
+            expect(lintSvc.setBpmnlintConfig).toHaveBeenCalledWith(EDITOR_ID, false);
+        });
+
+        it("does not re-lint on document change when the editor is in-page", async () => {
+            const { lintSvc, locator, statusBar, notifier } = createServices({
+                disposables: [],
+                errors: [],
+            });
+            // In-page sessions lint in the webview already — a host re-lint is churn.
+            (lintSvc.getLintMode as ReturnType<typeof vi.fn>).mockReturnValue("in-page");
+            const { context, captured } = createContext();
+
+            await new BpmnlintParticipant(lintSvc, locator, statusBar, notifier).onResolve(context);
+            captured.documentChange?.(bpmnChange());
+            vi.advanceTimersByTime(400);
+
+            expect(lintSvc.setBpmnlintConfig).not.toHaveBeenCalled();
+        });
     });
 
     it("tracks editor focus: re-discovers on activate, hides on blur", async () => {

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.ts
@@ -51,11 +51,15 @@ export class BpmnlintParticipant implements EditorSessionParticipant {
         // Re-lint on edits: the custom text editor syncs webview edits into the
         // TextDocument, so the host always lints the current XML. Filter to this
         // session's `.bpmn` document so an edit elsewhere never re-lints it.
+        // In-page sessions (no workspace config, #1373 Phase B) lint in the
+        // webview on every diagram change already, so a host re-lint would be
+        // pure churn — skip it and let the webview's own push drive the chrome.
         session.onDocumentChange((event) => {
             if (
                 event.hasContentChanges() &&
                 event.documentPath().endsWith(".bpmn") &&
-                session.editorId === event.documentUriString()
+                session.editorId === event.documentUriString() &&
+                this.lintSvc.getLintMode(session.editorId) !== "in-page"
             ) {
                 this.scheduleRelint(session);
             }

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
@@ -15,6 +15,7 @@ import {
     SetPropertiesPanelStateCommand,
     SetTextClipboardCommand,
     SyncDocumentCommand,
+    UpdateLintResultsCommand,
     UpdateScriptSourceCommand,
     UpdateScriptVariablesCommand,
 } from "@miragon/bpmn-modeler-shared";
@@ -34,6 +35,7 @@ import {
     setPropertiesPanelStateHandler,
     setTextClipboardHandler,
     syncDocumentHandler,
+    updateLintResultsHandler,
     updateScriptSourceHandler,
     updateScriptVariablesHandler,
 } from "./bpmnMessageHandlers";
@@ -391,6 +393,23 @@ describe("Pattern B: a rejecting service promise propagates through the handler"
         ).rejects.toThrow(boom);
         // Language is posted before settings is awaited, so it still fires.
         expect(broadcaster.setLanguage).toHaveBeenCalledWith(EDITOR);
+    });
+});
+
+describe("updateLintResultsHandler", () => {
+    it("forwards the webview's in-page findings to applyWebviewLintResults", () => {
+        const lintSvc = { applyWebviewLintResults: vi.fn() };
+        const results = {
+            "label-required": [{ id: "Task_1", message: "needs a label", category: "warn" }],
+        };
+        const unresolved = ["some-plugin/some-rule"];
+
+        updateLintResultsHandler(lintSvc as never)(
+            new UpdateLintResultsCommand(results, unresolved),
+            EDITOR,
+        );
+
+        expect(lintSvc.applyWebviewLintResults).toHaveBeenCalledWith(EDITOR, results, unresolved);
     });
 });
 

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
@@ -10,6 +10,7 @@ import {
     SetTextClipboardCommand,
     SyncActivitiesCommand,
     SyncDocumentCommand,
+    UpdateLintResultsCommand,
     UpdateScriptSourceCommand,
     UpdateScriptVariablesCommand,
 } from "@miragon/bpmn-modeler-shared";
@@ -119,6 +120,19 @@ export function getPropertiesPanelStateHandler(
 ): MessageHandler {
     return (_message: Command, editorId: string) => {
         panelSvc.sendPropertiesPanelState(editorId);
+    };
+}
+
+/**
+ * `UpdateLintResultsCommand` → feed the host's Problems panel + status bar from
+ * findings the webview computed in its in-page default run (#1373 Phase B). The
+ * service ignores the push when the editor is no longer on the in-page path (a
+ * workspace-config takeover) or when linting is disabled.
+ */
+export function updateLintResultsHandler(lintSvc: BpmnLintConfigService): MessageHandler {
+    return (message: Command, editorId: string) => {
+        const cmd = message as UpdateLintResultsCommand;
+        lintSvc.applyWebviewLintResults(editorId, cmd.results, cmd.unresolved);
     };
 }
 

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/lintParity.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/lintParity.spec.ts
@@ -1,0 +1,91 @@
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { Engine, LintResults } from "@miragon/bpmn-modeler-types";
+
+import { DefaultBpmnlintConfigService } from "../../service/DefaultBpmnlintConfigService";
+import { NodeBpmnLinter } from "./NodeBpmnLinter";
+// Cross-package relative import (spec-only): the in-page linter lives in the
+// bpmn-webview app. modeler-core vitest runs in node and inlines the rules
+// plugin, so BrowserLinter runs here exactly as it does in the browser bundle.
+import { BrowserLinter } from "../../../../../../../apps/bpmn-webview/src/app/bpmnlint/browserLinter";
+
+/**
+ * AC5 parity: the host-side {@link NodeBpmnLinter} default run and the webview's
+ * in-page {@link BrowserLinter} default run must produce byte-identical findings
+ * for the same diagram. Phase B moves the no-config path in-page for hosted
+ * sessions, so this is the contract that a user sees the *same* lint whether the
+ * host ran it (workspace config) or the webview did (no config).
+ *
+ * Both sides lint the same moddle tree with the same engine-aware default config
+ * (`getDefaultLintConfig({ engine, preset: "modeling" })`) and must report no
+ * unresolved rules — a non-empty `unresolved` on the browser side would be a real
+ * `browserResolver` bug, not a test artefact, so it is asserted, never assumed.
+ */
+
+// A C7 diagram with a task but no start/end event (so recommended rules fire) and
+// a DI shape far from the modeler default (200×200) so the miragon `standard-size`
+// layer also fires — proving parity across both rule layers.
+const BPMN_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.20.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="Task_1" name="Do the thing" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="80" width="200" height="200" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+const PLATFORM: Engine = "c7";
+
+/** Parses XML into the moddle root the way bpmn-js hands it to `Linting.lint`. */
+async function parseModdleRoot(
+    xml: string,
+    moddleExtensions: Record<string, unknown> | undefined,
+): Promise<unknown> {
+    const mod = (await import("bpmn-moddle")) as unknown as {
+        default?: (ext?: Record<string, unknown>) => {
+            fromXML: (x: string) => Promise<{ rootElement: unknown }>;
+        };
+        BpmnModdle?: (ext?: Record<string, unknown>) => {
+            fromXML: (x: string) => Promise<{ rootElement: unknown }>;
+        };
+    };
+    const factory = mod.default ?? mod.BpmnModdle;
+    if (typeof factory !== "function") {
+        throw new Error("bpmn-moddle did not expose a factory.");
+    }
+    const { rootElement } = await factory(moddleExtensions ?? {}).fromXML(xml);
+    return rootElement;
+}
+
+describe("bpmnlint default parity: NodeBpmnLinter vs BrowserLinter", () => {
+    it("produces identical findings and no unresolved rules on either side", async () => {
+        const config = await new DefaultBpmnlintConfigService().build(PLATFORM);
+
+        // Host side: NodeBpmnLinter parses + lints the XML itself. The anchor is a
+        // resolution root only — the default references no workspace modules.
+        const anchor = resolve(__dirname, ".bpmnlintrc");
+        const nodeOut = await new NodeBpmnLinter().lint(BPMN_XML, anchor, config);
+
+        // Webview side: BrowserLinter lints the live moddle tree, so parse it here
+        // with the same embedded moddle extensions the default config carries.
+        const root = await parseModdleRoot(
+            BPMN_XML,
+            config.moddleExtensions as Record<string, unknown> | undefined,
+        );
+        const browserOut = await new BrowserLinter(PLATFORM).run(root);
+
+        // The oversized task must actually trip a rule, else "parity" is vacuous.
+        expect(Object.keys(nodeOut.results)).toContain("standard-size");
+
+        expect(browserOut.results as LintResults).toEqual(nodeOut.results);
+        expect(nodeOut.unresolved).toEqual([]);
+        expect(browserOut.unresolved).toEqual([]);
+    });
+});

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
@@ -5,10 +5,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // still resolve under vitest.
 vi.mock("vscode", () => ({}));
 
-import { BpmnLintDisabledQuery, BpmnlintResultsQuery } from "@miragon/bpmn-modeler-shared";
+import {
+    BpmnLintDisabledQuery,
+    BpmnlintInPageQuery,
+    BpmnlintResultsQuery,
+} from "@miragon/bpmn-modeler-shared";
 
 import { BpmnLintConfigService } from "./BpmnLintConfigService";
-import { DefaultBpmnlintConfigService } from "./DefaultBpmnlintConfigService";
 
 const EDITOR = "file:///work/diagram.bpmn";
 // No platform markers → detectPlatform() throws → structural-only default.
@@ -20,7 +23,10 @@ const RESULTS = {
 };
 
 function createService() {
-    const editorStore = { postMessage: vi.fn().mockResolvedValue(true) };
+    const editorStore = {
+        postMessage: vi.fn().mockResolvedValue(true),
+        getActiveEditorId: vi.fn().mockReturnValue(EDITOR),
+    };
     const vsDocument = {
         getFilePath: vi.fn().mockReturnValue(EDITOR),
         getContent: vi.fn().mockReturnValue(XML),
@@ -59,8 +65,6 @@ function createService() {
         diagnostics as never,
         statusBar as never,
         notifier as never,
-        // The real builder: the c7/c8 cases assert the exact layered config it emits.
-        new DefaultBpmnlintConfigService(),
         settings as never,
     );
 
@@ -77,11 +81,20 @@ function createService() {
     };
 }
 
+/** True when no `BpmnlintResultsQuery` was ever posted (the in-page path must not push one). */
+function noResultsQueryPosted(editorStore: {
+    postMessage: { mock: { calls: unknown[][] } };
+}): boolean {
+    return editorStore.postMessage.mock.calls.every(
+        (call) => (call[1] as { type: string }).type !== "BpmnlintResultsQuery",
+    );
+}
+
 beforeEach(() => {
     vi.clearAllMocks();
 });
 
-describe("BpmnLintConfigService.setBpmnlintConfig", () => {
+describe("BpmnLintConfigService.setBpmnlintConfig — workspace config (external)", () => {
     it("lints the document and posts the results with the active status when a config is found", async () => {
         const { service, editorStore, locator, lintRunner, diagnostics, statusBar, notifier } =
             createService();
@@ -100,37 +113,10 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         expect(statusBar.showBpmnlintActive).toHaveBeenCalledWith("/work/.bpmnlintrc");
         expect(statusBar.showBpmnlintUnresolved).not.toHaveBeenCalled();
         expect(notifier.logInfo).toHaveBeenCalledWith("bpmnlint applied from /work/.bpmnlintrc");
+        expect(service.getLintMode(EDITOR)).toBe("external");
         const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintResultsQuery;
         expect(msg.type).toBe("BpmnlintResultsQuery");
         expect(msg.results).toEqual(RESULTS);
-    });
-
-    it("skips linting and pushes the disabled state when linting is turned off", async () => {
-        const { service, editorStore, locator, lintRunner, diagnostics, statusBar, settings } =
-            createService();
-        settings.getLintingEnabled.mockReturnValue(false);
-
-        const result = await service.setBpmnlintConfig(EDITOR);
-
-        expect(result).toBe(true);
-        // The gate short-circuits before any config discovery or lint run.
-        expect(locator.findNearestConfig).not.toHaveBeenCalled();
-        expect(lintRunner.lint).not.toHaveBeenCalled();
-        expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
-        expect(statusBar.showBpmnlintDisabled).toHaveBeenCalledOnce();
-        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnLintDisabledQuery;
-        expect(msg.type).toBe("BpmnLintDisabledQuery");
-    });
-
-    it("leaves the status bar untouched when disabled and reflectInStatusBar is false", async () => {
-        const { service, editorStore, statusBar, settings } = createService();
-        settings.getLintingEnabled.mockReturnValue(false);
-
-        await service.setBpmnlintConfig(EDITOR, false);
-
-        expect(statusBar.showBpmnlintDisabled).not.toHaveBeenCalled();
-        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnLintDisabledQuery;
-        expect(msg.type).toBe("BpmnLintDisabledQuery");
     });
 
     it("shows the unresolved status and warns when rules could not be resolved", async () => {
@@ -146,62 +132,6 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         ]);
         expect(statusBar.showBpmnlintActive).not.toHaveBeenCalled();
         expect(notifier.logWarning).toHaveBeenCalledWith(expect.stringContaining("custom/x"));
-    });
-
-    it("lints against the bundled default (structural only) for a platform-less file when no config is found", async () => {
-        const { service, editorStore, locator, lintRunner, diagnostics, statusBar } =
-            createService();
-        locator.findNearestConfig.mockResolvedValue(undefined);
-
-        const result = await service.setBpmnlintConfig(EDITOR);
-
-        expect(result).toBe(true);
-        expect(lintRunner.lint).toHaveBeenCalledWith(XML, EDITOR, {
-            extends: ["bpmnlint:recommended", "plugin:@miragon/rules/recommended-for-modeling"],
-        });
-        expect(diagnostics.publish).toHaveBeenCalledWith(EDITOR, XML, RESULTS);
-        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith(undefined);
-        expect(statusBar.showBpmnlintNoConfig).not.toHaveBeenCalled();
-        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintResultsQuery;
-        expect(msg.results).toEqual(RESULTS);
-    });
-
-    it("adds the C7 engine layer to the default when the document targets Camunda 7", async () => {
-        const { service, locator, lintRunner, statusBar, vsDocument } = createService();
-        locator.findNearestConfig.mockResolvedValue(undefined);
-        vsDocument.getContent.mockReturnValue(XML_C7);
-
-        await service.setBpmnlintConfig(EDITOR);
-
-        const [xml, anchor, config] = lintRunner.lint.mock.calls[0];
-        expect(xml).toBe(XML_C7);
-        expect(anchor).toBe(EDITOR);
-        expect((config as { extends: string[] }).extends).toEqual([
-            "bpmnlint:recommended",
-            "plugin:@miragon/rules/recommended-for-modeling",
-            "plugin:camunda-compat/camunda-platform-7-24",
-        ]);
-        expect((config as { moddleExtensions: Record<string, unknown> }).moddleExtensions).toEqual({
-            camunda: expect.anything(),
-        });
-        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith("c7");
-    });
-
-    it("adds the C8 engine layer to the default when the document targets Camunda 8", async () => {
-        const { service, locator, lintRunner, statusBar, vsDocument } = createService();
-        locator.findNearestConfig.mockResolvedValue(undefined);
-        vsDocument.getContent.mockReturnValue(XML_C8);
-
-        await service.setBpmnlintConfig(EDITOR);
-
-        const [, , config] = lintRunner.lint.mock.calls[0];
-        expect((config as { extends: string[] }).extends).toContain(
-            "plugin:camunda-compat/camunda-cloud-8-10",
-        );
-        expect((config as { moddleExtensions: Record<string, unknown> }).moddleExtensions).toEqual({
-            zeebe: expect.anything(),
-        });
-        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith("c8");
     });
 
     it("still posts results but leaves the status bar untouched when reflectInStatusBar is false", async () => {
@@ -229,6 +159,7 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         expect(notifier.logError).toHaveBeenCalledOnce();
         expect(statusBar.showBpmnlintNoConfig).toHaveBeenCalledOnce();
         expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
+        expect(service.getLintMode(EDITOR)).toBe("external");
         const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintResultsQuery;
         expect(msg.results).toBeNull();
     });
@@ -250,5 +181,198 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         // The lint succeeded — the transport failure must not be logged as one.
         expect(notifier.logError).not.toHaveBeenCalled();
         expect(editorStore.postMessage).toHaveBeenCalledOnce();
+    });
+});
+
+describe("BpmnLintConfigService.setBpmnlintConfig — no config (in-page handback)", () => {
+    it("instructs the webview to run in-page, does not lint host-side, and posts no results query", async () => {
+        const { service, editorStore, locator, lintRunner, diagnostics, statusBar } =
+            createService();
+        locator.findNearestConfig.mockResolvedValue(undefined);
+
+        const result = await service.setBpmnlintConfig(EDITOR);
+
+        expect(result).toBe(true);
+        expect(lintRunner.lint).not.toHaveBeenCalled();
+        expect(service.getLintMode(EDITOR)).toBe("in-page");
+        // Provisional: clear stale diagnostics + a default status while the
+        // webview's first run is in flight (no cached event yet).
+        expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
+        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith(undefined);
+        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintInPageQuery;
+        expect(msg.type).toBe("BpmnlintInPageQuery");
+        expect(noResultsQueryPosted(editorStore)).toBe(true);
+    });
+
+    it("reflects the detected platform in the provisional status (C7)", async () => {
+        const { service, locator, statusBar, vsDocument } = createService();
+        locator.findNearestConfig.mockResolvedValue(undefined);
+        vsDocument.getContent.mockReturnValue(XML_C7);
+
+        await service.setBpmnlintConfig(EDITOR);
+
+        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith("c7");
+    });
+
+    it("reflects the detected platform in the provisional status (C8)", async () => {
+        const { service, locator, statusBar, vsDocument } = createService();
+        locator.findNearestConfig.mockResolvedValue(undefined);
+        vsDocument.getContent.mockReturnValue(XML_C8);
+
+        await service.setBpmnlintConfig(EDITOR);
+
+        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith("c8");
+    });
+
+    it("leaves the status bar untouched when reflectInStatusBar is false", async () => {
+        const { service, editorStore, locator, statusBar } = createService();
+        locator.findNearestConfig.mockResolvedValue(undefined);
+
+        await service.setBpmnlintConfig(EDITOR, false);
+
+        expect(statusBar.showBpmnlintDefault).not.toHaveBeenCalled();
+        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintInPageQuery;
+        expect(msg.type).toBe("BpmnlintInPageQuery");
+    });
+
+    it("replays the last cached in-page event on re-instruct (panel re-activation)", async () => {
+        const { service, locator, diagnostics, statusBar, vsDocument } = createService();
+        locator.findNearestConfig.mockResolvedValue(undefined);
+
+        await service.setBpmnlintConfig(EDITOR); // in-page, no cache yet
+        service.applyWebviewLintResults(EDITOR, RESULTS, []); // caches the event
+        vi.clearAllMocks();
+        vsDocument.getContent.mockReturnValue(XML);
+        locator.findNearestConfig.mockResolvedValue(undefined);
+
+        await service.setBpmnlintConfig(EDITOR); // re-instruct
+
+        // Cached findings are restored instead of a blank provisional state.
+        expect(diagnostics.publish).toHaveBeenCalledWith(EDITOR, XML, RESULTS);
+        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith(undefined);
+    });
+});
+
+describe("BpmnLintConfigService.applyWebviewLintResults", () => {
+    async function inPageService() {
+        const ctx = createService();
+        ctx.locator.findNearestConfig.mockResolvedValue(undefined);
+        await ctx.service.setBpmnlintConfig(EDITOR); // flip to in-page
+        vi.clearAllMocks();
+        ctx.editorStore.getActiveEditorId.mockReturnValue(EDITOR);
+        ctx.settings.getLintingEnabled.mockReturnValue(true);
+        ctx.vsDocument.getContent.mockReturnValue(XML);
+        return ctx;
+    }
+
+    it("publishes diagnostics, shows the default status, warns on unresolved, and caches", async () => {
+        const { service, diagnostics, statusBar, notifier } = await inPageService();
+
+        service.applyWebviewLintResults(EDITOR, RESULTS, ["some-plugin/some-rule"]);
+
+        expect(diagnostics.publish).toHaveBeenCalledWith(EDITOR, XML, RESULTS);
+        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith(undefined);
+        expect(notifier.logWarning).toHaveBeenCalledWith(
+            expect.stringContaining("some-plugin/some-rule"),
+        );
+    });
+
+    it("publishes diagnostics but skips the status bar when the editor is not active", async () => {
+        const { service, editorStore, diagnostics, statusBar } = await inPageService();
+        editorStore.getActiveEditorId.mockReturnValue("file:///other.bpmn");
+
+        service.applyWebviewLintResults(EDITOR, RESULTS, []);
+
+        // The Problems panel is global, so diagnostics always publish...
+        expect(diagnostics.publish).toHaveBeenCalledWith(EDITOR, XML, RESULTS);
+        // ...but a background editor's push must not steal the visible status.
+        expect(statusBar.showBpmnlintDefault).not.toHaveBeenCalled();
+    });
+
+    it("ignores a push when the editor is on the external path (default)", () => {
+        const { service, diagnostics } = createService();
+
+        service.applyWebviewLintResults(EDITOR, RESULTS, []);
+
+        expect(diagnostics.publish).not.toHaveBeenCalled();
+    });
+
+    it("ignores a push when linting is disabled", async () => {
+        const { service, diagnostics, settings } = await inPageService();
+        settings.getLintingEnabled.mockReturnValue(false);
+
+        service.applyWebviewLintResults(EDITOR, RESULTS, []);
+
+        expect(diagnostics.publish).not.toHaveBeenCalled();
+    });
+
+    it("ignores a stale in-page push after a workspace-config takeover", async () => {
+        const { service, locator, diagnostics } = createService();
+        locator.findNearestConfig.mockResolvedValue(undefined);
+        await service.setBpmnlintConfig(EDITOR); // in-page
+
+        // Config appears — the mode flips to external before the takeover push.
+        locator.findNearestConfig.mockResolvedValue("/work/.bpmnlintrc");
+        locator.readConfig.mockResolvedValue(JSON.stringify({ extends: "bpmnlint:recommended" }));
+        await service.setBpmnlintConfig(EDITOR);
+        expect(service.getLintMode(EDITOR)).toBe("external");
+        diagnostics.publish.mockClear();
+
+        // A webview push already in flight arrives late — it must be dropped.
+        service.applyWebviewLintResults(EDITOR, RESULTS, []);
+        expect(diagnostics.publish).not.toHaveBeenCalled();
+    });
+});
+
+describe("BpmnLintConfigService.setBpmnlintConfig — disabled", () => {
+    it("skips linting and pushes the disabled state when linting is turned off", async () => {
+        const { service, editorStore, locator, lintRunner, diagnostics, statusBar, settings } =
+            createService();
+        settings.getLintingEnabled.mockReturnValue(false);
+
+        const result = await service.setBpmnlintConfig(EDITOR);
+
+        expect(result).toBe(true);
+        // The gate short-circuits before any config discovery or lint run.
+        expect(locator.findNearestConfig).not.toHaveBeenCalled();
+        expect(lintRunner.lint).not.toHaveBeenCalled();
+        expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
+        expect(statusBar.showBpmnlintDisabled).toHaveBeenCalledOnce();
+        expect(service.getLintMode(EDITOR)).toBe("external");
+        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnLintDisabledQuery;
+        expect(msg.type).toBe("BpmnLintDisabledQuery");
+    });
+
+    it("leaves the status bar untouched when disabled and reflectInStatusBar is false", async () => {
+        const { service, editorStore, statusBar, settings } = createService();
+        settings.getLintingEnabled.mockReturnValue(false);
+
+        await service.setBpmnlintConfig(EDITOR, false);
+
+        expect(statusBar.showBpmnlintDisabled).not.toHaveBeenCalled();
+        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnLintDisabledQuery;
+        expect(msg.type).toBe("BpmnLintDisabledQuery");
+    });
+
+    it("clears the cached in-page event so a re-instruct does not replay stale findings", async () => {
+        const { service, locator, diagnostics, statusBar, settings } = createService();
+        locator.findNearestConfig.mockResolvedValue(undefined);
+        await service.setBpmnlintConfig(EDITOR); // in-page
+        service.applyWebviewLintResults(EDITOR, RESULTS, []); // cache an event
+
+        // User disables linting — the cache is dropped (external mode).
+        settings.getLintingEnabled.mockReturnValue(false);
+        await service.setBpmnlintConfig(EDITOR);
+
+        // Re-enable + no config → in-page again, but with no cached event to
+        // replay: back to the provisional (blank) state.
+        settings.getLintingEnabled.mockReturnValue(true);
+        vi.clearAllMocks();
+        locator.findNearestConfig.mockResolvedValue(undefined);
+        await service.setBpmnlintConfig(EDITOR);
+
+        expect(diagnostics.publish).not.toHaveBeenCalled();
+        expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
+        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith(undefined);
     });
 });

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
@@ -1,6 +1,10 @@
 import { posix } from "path";
 
-import { BpmnLintDisabledQuery, BpmnlintResultsQuery } from "@miragon/bpmn-modeler-shared";
+import {
+    BpmnLintDisabledQuery,
+    BpmnlintInPageQuery,
+    BpmnlintResultsQuery,
+} from "@miragon/bpmn-modeler-shared";
 import { Engine, LintResults } from "@miragon/bpmn-modeler-types";
 
 import { BpmnDocument } from "../../../shared/domain/BpmnDocument";
@@ -18,23 +22,67 @@ import {
     BpmnLintConfigLocator,
     BpmnlintChangeTarget,
 } from "../../../shared/service/BpmnLintConfigLocator";
-import { DefaultBpmnlintConfigService } from "./DefaultBpmnlintConfigService";
 
 /**
- * Discovers the nearest `.bpmnlintrc` for an open BPMN document, runs bpmnlint
- * in the extension host, and pushes the resulting findings to the webview, which
- * only renders overlays. Running in the host (a full Node context) is what lets
- * custom `bpmnlint-plugin-*` rules and `plugin:<pkg>/recommended` configs resolve
- * against the workspace `node_modules` — the browser webview only ever saw the
- * built-in rules bundled into it.
+ * Where a set of findings came from, so {@link BpmnLintConfigService.applyFindings}
+ * can pick the right status-bar indicator and log line. `"workspace"` is a
+ * host-side run against a discovered `.bpmnlintrc`; `"in-page"` is the webview's
+ * own default run (#1373 Phase B), reflected with the same `showBpmnlintDefault`
+ * indicator the old host-side default used (same ruleset, different execution site).
+ */
+type LintFindingsSource =
+    | { kind: "workspace"; configPath: string }
+    | { kind: "in-page"; platform: Engine | undefined };
+
+/**
+ * The last in-page lint event received from the webview for one editor, cached
+ * so a panel re-activation (`setBpmnlintConfig` from the panel-active hook) can
+ * restore the Problems panel + status bar instead of going blank until the next
+ * edit re-runs the webview linter.
+ */
+interface CachedInPageEvent {
+    readonly xml: string;
+    readonly results: LintResults;
+    readonly unresolved: readonly string[];
+    readonly platform: Engine | undefined;
+}
+
+/**
+ * Decides *where* an open BPMN document is linted and routes the resulting
+ * findings to the host's chrome (Problems panel, status bar) and the webview.
  *
- * The same findings are also published as host diagnostics (Problems panel) and
- * summarised in the status bar. Filesystem discovery / reading / watching lives
- * in {@link BpmnLintConfigLocator}; the actual lint run is a {@link LintRunnerPort}.
- * Implements {@link BpmnlintChangeTarget} so the locator's watcher — and the
+ * Two paths, chosen per document by whether a workspace `.bpmnlintrc` exists:
+ *
+ *  - **Workspace config** — the host runs bpmnlint in a full Node context
+ *    ({@link LintRunnerPort}) so custom `bpmnlint-plugin-*` rules and
+ *    `plugin:<pkg>/recommended` configs resolve against the workspace
+ *    `node_modules`, then pushes the findings to the webview (which only paints
+ *    overlays). This is the external tier — any push wins on the webview side.
+ *  - **No config** (#1373 Phase B) — the host tells the webview to run its own
+ *    engine-aware default in-page ({@link BpmnlintInPageQuery}); the webview
+ *    pushes its findings back through {@link applyWebviewLintResults}, which
+ *    feeds the very same host chrome. The host does not lint in this case, so a
+ *    non-workspace diagram no longer pays for a host-side re-lint on every edit.
+ *
+ * A per-editor {@link lintModes} map tracks which path is live so the VS Code
+ * participant can skip its debounced re-lint for in-page sessions, and so a
+ * stale webview push arriving after a workspace-config takeover is ignored (the
+ * mode flips to `"external"` *before* the takeover push — ordering matters).
+ *
+ * Filesystem discovery / reading / watching lives in {@link BpmnLintConfigLocator};
+ * the actual host lint run is a {@link LintRunnerPort}. Implements
+ * {@link BpmnlintChangeTarget} so the locator's watcher — and the
  * document-change trigger — can re-lint when the file or diagram changes.
  */
 export class BpmnLintConfigService implements BpmnlintChangeTarget {
+    /**
+     * Per-editor lint path. Defaults to `"external"` for an untracked editor so
+     * the participant only skips its re-lint once in-page is explicitly active.
+     */
+    private readonly lintModes = new Map<string, "external" | "in-page">();
+
+    private readonly lastInPageEvents = new Map<string, CachedInPageEvent>();
+
     constructor(
         private readonly editorStore: EditorSessionStore,
         private readonly vsDocument: DocumentPort,
@@ -43,32 +91,68 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
         private readonly diagnostics: DiagnosticsPort,
         private readonly statusBar: StatusBarPort,
         private readonly notifier: NotifierPort,
-        private readonly defaultConfig: DefaultBpmnlintConfigService,
         private readonly settings: SettingsPort,
     ) {}
 
     /**
-     * Re-lints the document and pushes the result to the webview. Named
-     * {@link BpmnlintChangeTarget.setBpmnlintConfig} so the locator's watcher and
-     * the participant's document-change hook can call it uniformly.
+     * Re-evaluates the lint path for the document and drives it (host run + push,
+     * or in-page instruction). Named {@link BpmnlintChangeTarget.setBpmnlintConfig}
+     * so the locator's watcher and the participant's hooks can call it uniformly.
      */
     setBpmnlintConfig(editorId: string, reflectInStatusBar = true): Promise<boolean> {
         return this.lintAndPush(editorId, reflectInStatusBar);
     }
 
-    /** Drops the published diagnostics for a closing editor so the Problems panel
-     * does not retain findings for a document that is no longer open. */
+    /** The live lint path for an editor — `"external"` unless in-page is active. */
+    getLintMode(editorId: string): "external" | "in-page" {
+        return this.lintModes.get(editorId) ?? "external";
+    }
+
+    /** Drops the published diagnostics and the per-editor lint bookkeeping for a
+     * closing editor so neither the Problems panel nor the mode/cache maps retain
+     * state for a document that is no longer open. */
     clearDiagnostics(editorId: string): void {
         this.diagnostics.clear(editorId);
+        this.lintModes.delete(editorId);
+        this.lastInPageEvents.delete(editorId);
     }
 
     /**
-     * Resolves the nearest `.bpmnlintrc`, lints the current document XML against
-     * it, then pushes the findings to the webview and publishes them as
-     * diagnostics. When none is found, lints against a bundled default selected
-     * per execution platform instead of staying dormant (#1327). A read/parse/lint
-     * failure — including a malformed `.bpmnlintrc` — degrades to the no-config
-     * state rather than crashing the editor or silently swapping in the default.
+     * Applies findings the webview computed in its own in-page default run
+     * (#1373 Phase B) to the host's chrome. Guarded so a push that arrives after
+     * a workspace-config takeover — or while linting is disabled — is ignored:
+     * the mode flips to `"external"` *before* the takeover push, so a late
+     * in-page push finds the wrong mode and is dropped.
+     *
+     * The event is cached so a later panel re-activation can restore it. The
+     * Problems panel is global, so diagnostics always publish; the status bar
+     * reflects an async push only for the active editor (a background editor's
+     * push must not steal the visible indicator).
+     */
+    applyWebviewLintResults(
+        editorId: string,
+        results: LintResults,
+        unresolved: readonly string[],
+    ): void {
+        if (this.getLintMode(editorId) !== "in-page" || !this.settings.getLintingEnabled()) {
+            return;
+        }
+        const xml = this.vsDocument.getContent(editorId);
+        const platform = this.detectPlatform(xml);
+        this.lastInPageEvents.set(editorId, { xml, results, unresolved, platform });
+        this.applyFindings(editorId, xml, results, unresolved, this.isActiveEditor(editorId), {
+            kind: "in-page",
+            platform,
+        });
+    }
+
+    /**
+     * Resolves the nearest `.bpmnlintrc`. When one is found, lints the document
+     * host-side against it and pushes the findings (external tier). When none is
+     * found, hands linting to the webview's in-page default instead of linting
+     * host-side (#1373 Phase B). A read/parse/lint failure — including a malformed
+     * `.bpmnlintrc` — degrades to the no-config-*failure* state (linting off in
+     * the webview) rather than crashing the editor.
      */
     private async lintAndPush(editorId: string, reflectInStatusBar: boolean): Promise<boolean> {
         // User opted out of linting entirely: skip the run and clear every
@@ -76,6 +160,7 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
         // shown automation rules. Distinct from the no-config state — nothing
         // failed — so the webview can offer a re-enable affordance.
         if (!this.settings.getLintingEnabled()) {
+            this.setExternalMode(editorId);
             if (reflectInStatusBar) {
                 this.statusBar.showBpmnlintDisabled();
             }
@@ -83,100 +168,131 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
             return this.pushDisabled(editorId);
         }
 
-        let results: LintResults | null;
         try {
             const dir = posix.dirname(this.vsDocument.getFilePath(editorId));
             const configPath = await this.locator.findNearestConfig(dir);
 
             if (!configPath) {
-                results = await this.lintWithBundledDefault(editorId, reflectInStatusBar);
-            } else {
-                const config = JSON.parse(await this.locator.readConfig(configPath)) as Record<
-                    string,
-                    unknown
-                >;
-                const xml = this.vsDocument.getContent(editorId);
-                const { results: lintResults, unresolved } = await this.lintRunner.lint(
-                    xml,
-                    configPath,
-                    config,
-                );
-
-                this.diagnostics.publish(editorId, xml, lintResults);
-                if (reflectInStatusBar) {
-                    if (unresolved.length > 0) {
-                        this.statusBar.showBpmnlintUnresolved(configPath, unresolved);
-                    } else {
-                        this.statusBar.showBpmnlintActive(configPath);
-                    }
-                }
-                if (unresolved.length > 0) {
-                    // The finding was previously buried in the output channel while
-                    // the status bar still showed a green tick — surface it plainly.
-                    this.notifier.logWarning(
-                        `bpmnlint: ${unresolved.length} rule(s)/config(s) could not be resolved and were skipped: ${unresolved.join(
-                            ", ",
-                        )}`,
-                    );
-                }
-                this.notifier.logInfo(`bpmnlint applied from ${configPath}`);
-                results = lintResults;
+                // Early return — must NOT fall through to a results push: a
+                // trailing BpmnlintResultsQuery(null) would immediately deactivate
+                // the in-page tier this instruction just started.
+                return this.instructInPage(editorId, reflectInStatusBar);
             }
+
+            const config = JSON.parse(await this.locator.readConfig(configPath)) as Record<
+                string,
+                unknown
+            >;
+            const xml = this.vsDocument.getContent(editorId);
+            const { results, unresolved } = await this.lintRunner.lint(xml, configPath, config);
+
+            // Flip the mode *before* the takeover push so a stale in-page push
+            // already in flight is ignored by applyWebviewLintResults.
+            this.setExternalMode(editorId);
+            this.applyFindings(editorId, xml, results, unresolved, reflectInStatusBar, {
+                kind: "workspace",
+                configPath,
+            });
+            return this.pushResults(editorId, results);
         } catch (error) {
             // A malformed .bpmnlintrc or a linter blow-up must not crash the
-            // editor — warn, fall back to the no-config state, and tell the
-            // webview to deactivate linting.
+            // editor — warn, fall back to the no-config-failure state, and tell
+            // the webview to deactivate linting.
             this.notifier.logError(
                 new Error(`Failed to lint against .bpmnlintrc: ${(error as Error).message}`),
             );
+            this.setExternalMode(editorId);
             if (reflectInStatusBar) {
                 this.statusBar.showBpmnlintNoConfig();
             }
             this.diagnostics.clear(editorId);
-            results = null;
+            return this.pushResults(editorId, null);
         }
-
-        return this.pushResults(editorId, results);
     }
 
     /**
-     * Lints against the host-bundled default when the workspace has no
-     * `.bpmnlintrc`. The engine layer is chosen from the document's detected
-     * execution platform (re-detected here so a mid-edit platform change is
-     * reflected); a platform-less document gets the structural base only.
+     * Switches the editor to the in-page path and tells the webview to run its
+     * own engine-aware default. Replays the last cached in-page event if one
+     * exists (panel re-activation), so the Problems panel + status bar are
+     * restored instead of blanking until the next webview push; otherwise clears
+     * diagnostics and shows a provisional default indicator while the webview's
+     * first run is in flight.
      */
-    private async lintWithBundledDefault(
-        editorId: string,
-        reflectInStatusBar: boolean,
-    ): Promise<LintResults> {
-        const xml = this.vsDocument.getContent(editorId);
-        const platform = this.detectPlatform(xml);
-        const config = await this.defaultConfig.build(platform);
+    private instructInPage(editorId: string, reflectInStatusBar: boolean): Promise<boolean> {
+        this.lintModes.set(editorId, "in-page");
 
-        // The default references only host-bundled rules, so the path is a mere
-        // resolution anchor — the document's own path keeps it valid.
-        const anchorPath = this.vsDocument.getFilePath(editorId);
-        const { results, unresolved } = await this.lintRunner.lint(xml, anchorPath, config);
-
-        this.diagnostics.publish(editorId, xml, results);
-        if (reflectInStatusBar) {
-            this.statusBar.showBpmnlintDefault(platform);
+        const cached = this.lastInPageEvents.get(editorId);
+        if (cached) {
+            this.applyFindings(
+                editorId,
+                cached.xml,
+                cached.results,
+                cached.unresolved,
+                reflectInStatusBar,
+                { kind: "in-page", platform: cached.platform },
+            );
+        } else {
+            this.diagnostics.clear(editorId);
+            if (reflectInStatusBar) {
+                const platform = this.detectPlatform(this.vsDocument.getContent(editorId));
+                this.statusBar.showBpmnlintDefault(platform);
+            }
         }
+
+        return this.postInPageInstruction(editorId);
+    }
+
+    /**
+     * The single results→chrome mapping shared by the workspace-config run and
+     * the in-page webview push, so both feed the Problems panel, status bar, and
+     * unresolved warning identically (AC5 parity is structural). The status bar
+     * is only touched when `reflectInStatusBar`; diagnostics always publish.
+     */
+    private applyFindings(
+        editorId: string,
+        xml: string,
+        results: LintResults,
+        unresolved: readonly string[],
+        reflectInStatusBar: boolean,
+        source: LintFindingsSource,
+    ): void {
+        this.diagnostics.publish(editorId, xml, results);
+
+        if (reflectInStatusBar) {
+            if (source.kind === "workspace") {
+                if (unresolved.length > 0) {
+                    this.statusBar.showBpmnlintUnresolved(source.configPath, [...unresolved]);
+                } else {
+                    this.statusBar.showBpmnlintActive(source.configPath);
+                }
+            } else {
+                this.statusBar.showBpmnlintDefault(source.platform);
+            }
+        }
+
         if (unresolved.length > 0) {
-            // The bundled default should resolve entirely from the host; anything
-            // unresolved is a packaging bug, not a workspace one — flag it loudly.
+            // Surface skipped rules plainly rather than burying them in the
+            // output channel while the status bar shows a green tick.
             this.notifier.logWarning(
-                `bpmnlint default: ${unresolved.length} bundled rule(s)/config(s) unresolved: ${unresolved.join(
-                    ", ",
-                )}`,
+                source.kind === "workspace"
+                    ? `bpmnlint: ${unresolved.length} rule(s)/config(s) could not be resolved and were skipped: ${unresolved.join(
+                          ", ",
+                      )}`
+                    : `bpmnlint (in-page default): ${unresolved.length} rule(s)/config(s) unresolved: ${unresolved.join(
+                          ", ",
+                      )}`,
             );
         }
-        // Debug-level: this fires on every re-lint (each edit), so it belongs with
-        // the other high-frequency lifecycle noise, not the always-on info log.
-        this.notifier.logDebug(
-            `bpmnlint applied bundled default (platform: ${platform ?? "generic"})`,
-        );
-        return results;
+
+        if (source.kind === "workspace") {
+            this.notifier.logInfo(`bpmnlint applied from ${source.configPath}`);
+        } else {
+            // Debug-level: fires on every webview push (each edit), so it belongs
+            // with the other high-frequency lifecycle noise.
+            this.notifier.logDebug(
+                `bpmnlint applied in-page results (platform: ${source.platform ?? "generic"})`,
+            );
+        }
     }
 
     /**
@@ -195,6 +311,22 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
         }
     }
 
+    /** Marks the editor external and drops any cached in-page event so a later
+     * panel re-activation cannot replay stale in-page findings over a host run. */
+    private setExternalMode(editorId: string): void {
+        this.lintModes.set(editorId, "external");
+        this.lastInPageEvents.delete(editorId);
+    }
+
+    private isActiveEditor(editorId: string): boolean {
+        try {
+            return this.editorStore.getActiveEditorId() === editorId;
+        } catch {
+            // No active editor (e.g. all panels hidden) — treat as not active.
+            return false;
+        }
+    }
+
     /**
      * Posts the results to the webview, the sole results transport.
      *
@@ -209,6 +341,22 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
         } catch (error) {
             this.notifier.logWarning(
                 `[bpmnlint] results push skipped: ${(error as Error).message}`,
+            );
+            return false;
+        }
+    }
+
+    /**
+     * Tells the webview to run its in-page default (#1373 Phase B). Same
+     * recoverable-drop handling as {@link pushResults}: a hidden panel makes the
+     * post reject, and the webview re-requests on reload.
+     */
+    private async postInPageInstruction(editorId: string): Promise<boolean> {
+        try {
+            return await this.editorStore.postMessage(editorId, new BpmnlintInPageQuery());
+        } catch (error) {
+            this.notifier.logWarning(
+                `[bpmnlint] in-page instruction skipped: ${(error as Error).message}`,
             );
             return false;
         }

--- a/libs/shared/src/lib/modeler.ts
+++ b/libs/shared/src/lib/modeler.ts
@@ -9,6 +9,7 @@
  * - {@link DmnFileQuery}                  — deliver DMN XML for rendering
  * - {@link ElementTemplatesQuery}         — deliver the resolved element-template list
  * - {@link BpmnlintResultsQuery}          — deliver host-computed bpmnlint results (or null to deactivate)
+ * - {@link BpmnlintInPageQuery}           — tell the webview to run its in-page default linter (no workspace config)
  * - {@link BpmnModelerSettingQuery}       — deliver modeler settings (e.g. alignToOrigin)
  * - {@link DmnModelerSettingQuery}         — deliver DMN modeler settings (colorTheme only)
  * - {@link PropertiesPanelStateQuery}     — deliver the global default visibility of the properties panel
@@ -26,6 +27,7 @@
  * - {@link GetDmnModelerSettingCommand}       — request current DMN modeler settings
  * - {@link GetPropertiesPanelStateCommand}    — request the global properties-panel visibility default
  * - {@link SetPropertiesPanelStateCommand}    — report a user toggle so the host can update the global default
+ * - {@link UpdateLintResultsCommand}          — push the webview's own in-page lint findings back to the host
  * - {@link GetClipboardCommand}               — request clipboard text from the host
  * - {@link SetClipboardCommand}               — ask the host to write text to the clipboard
  * - {@link GetDiagramAsSVGCommand}            — request an SVG export of the current diagram
@@ -132,6 +134,26 @@ export class BpmnlintResultsQuery extends Query {
 export class BpmnLintDisabledQuery extends Query {
     constructor() {
         super("BpmnLintDisabledQuery");
+    }
+}
+
+/**
+ * Tells the webview to run its **own in-page default** linter because the host
+ * found no workspace `.bpmnlintrc` (#1373 Phase B). Carries no payload: the
+ * webview's {@link BrowserLinter} derives the engine-aware zero-config default
+ * from the live modeler itself, so nothing has to travel. The webview then
+ * pushes its findings back through {@link UpdateLintResultsCommand}.
+ *
+ * This replaces the previous no-config behaviour where the host lint against a
+ * bundled default and pushed a {@link BpmnlintResultsQuery}. A workspace-config
+ * session still lints host-side and pushes results, and any such push wins:
+ * {@link BpmnlintResultsQuery} / {@link BpmnLintDisabledQuery} switch the webview
+ * back to the external tier and supersede an in-page run. A later refinement
+ * (#1384) may add an optional `config` here to escalate the in-page ruleset.
+ */
+export class BpmnlintInPageQuery extends Query {
+    constructor() {
+        super("BpmnlintInPageQuery");
     }
 }
 
@@ -417,6 +439,28 @@ export class SetLintingEnabledCommand extends Command {
     constructor(enabled: boolean) {
         super("SetLintingEnabledCommand");
         this.enabled = enabled;
+    }
+}
+
+/**
+ * Sent by the BPMN webview after every **in-page** lint pass (the #1373 Phase B
+ * default path) so the host can feed its own chrome — the VS Code Problems panel
+ * and status bar — from results the webview computed. Only fired when the host
+ * activated in-page linting via {@link BpmnlintInPageQuery}; a workspace-config
+ * session lints host-side instead and never receives this. `unresolved` carries
+ * the rules the browser resolver could not honour (informational, never fatal).
+ * Hosts without a Problems surface (the IntelliJ bridge) accept it and update
+ * whatever chrome they have.
+ */
+export class UpdateLintResultsCommand extends Command {
+    public readonly results: LintResults;
+
+    public readonly unresolved: readonly string[];
+
+    constructor(results: LintResults, unresolved: readonly string[]) {
+        super("UpdateLintResultsCommand");
+        this.results = results;
+        this.unresolved = unresolved;
     }
 }
 


### PR DESCRIPTION
## Issue

Part of #1373 (Phase B — protocol + core policy + VS Code adapter; Phase C follows).

## Description

When the host finds no workspace `.bpmnlintrc`, it now answers `GetBpmnlintConfigCommand` with the new `BpmnlintInPageQuery` instead of linting in Node — the webview runs its engine-aware default linter on the live moddle tree (new `startInPageLinting` handback on the facade) and pushes findings back via the new `UpdateLintResultsCommand`, which feeds the VS Code Problems panel and status bar through `BpmnLintConfigService.applyWebviewLintResults`. Workspace configs keep today's `NodeBpmnLinter` external flow entirely; per-editor mode tracking skips the host's 400 ms doc-change re-lint for in-page sessions, and `lintWithBundledDefault` (now dead) is removed along with the `DefaultBpmnlintConfigService` constructor arg. The bridge composes the same core service, so IntelliJ inherits the in-page default structurally (asserted in Phase C); its e2e spec covers both branches. A new AC5 parity spec pins `NodeBpmnLinter` and the webview `BrowserLinter` to identical results for the default config.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A — tier design recorded with #1373/Phase A; protocol is internal)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
