### PR TITLE
feat(editor): run workspace .bpmnlintrc in-page, escalate on unresolved rules

### DIFF
--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
@@ -272,6 +272,62 @@ describe("LintConfigService: startInPageLinting (host handback)", () => {
     });
 });
 
+describe("LintConfigService: covered-config re-enable (token dedup)", () => {
+    const CONFIG = { extends: "bpmnlint:recommended" };
+    const TOKEN = "cfg-v1";
+
+    it("re-activates after a host disabled push when the same token is re-sent", async () => {
+        // Regression for the covered `.bpmnlintrc` re-enable no-op: disable hard-sets
+        // the tier to `external`, so the next covered instruction must not be dedup'd
+        // away even though the token is unchanged from the pre-disable run.
+        const onLintResults = vi.fn();
+        const { service, linting, canvas } = makeService({
+            tier: "external",
+            imported: true,
+            callbacks: { onLintResults },
+        });
+        service.startInPageLinting(CONFIG, TOKEN);
+        expect(linting.isActive()).toBe(true);
+
+        // Host's user-disabled push (chip off → SetLintingEnabledCommand → pushDisabled).
+        service.applyLintingDisabled();
+        expect(linting.isActive()).toBe(false);
+        linting.toggle.mockClear();
+
+        // Host re-enables and re-sends the covered query with the SAME token.
+        service.startInPageLinting(CONFIG, TOKEN);
+
+        expect(linting.toggle).toHaveBeenCalledWith(true);
+        expect(linting.isActive()).toBe(true);
+        expect(canvas.getContainer().querySelector(".lint-off-button")).not.toBeNull();
+        await expect(linting.lint()).resolves.toEqual(LINT_EVENT.results);
+    });
+
+    it("dedups a repeat covered instruction with the same token while in-page-active", () => {
+        const { service, linting } = makeService({ tier: "external", imported: true });
+        service.startInPageLinting(CONFIG, TOKEN);
+        ctorMock.mockClear();
+        linting.toggle.mockClear();
+
+        // Host re-sends on panel re-activation; the live run must not churn.
+        service.startInPageLinting(CONFIG, TOKEN);
+
+        expect(ctorMock).not.toHaveBeenCalled();
+        expect(linting.toggle).not.toHaveBeenCalled();
+    });
+
+    it("rebuilds when a new token arrives while in-page-active (config version change)", () => {
+        const { service } = makeService({ tier: "external", imported: true });
+        service.startInPageLinting(CONFIG, TOKEN);
+        ctorMock.mockClear();
+
+        const nextConfig = { extends: "bpmnlint:all" };
+        service.startInPageLinting(nextConfig, "cfg-v2");
+
+        expect(ctorMock).toHaveBeenLastCalledWith("c7", nextConfig);
+    });
+});
+
 describe("LintConfigService: toggle matrix", () => {
     it("in-page off-button disables optimistically and reports the toggle", async () => {
         const onLintingToggled = vi.fn();

--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.spec.ts
@@ -3,10 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // The tier state machine is the unit under test; the actual browser lint run is
 // mocked so these tests never spin up bpmnlint. `runMock` is hoisted so the
 // `vi.mock` factory (itself hoisted) can close over it.
-const { runMock } = vi.hoisted(() => ({ runMock: vi.fn() }));
+const { runMock, ctorMock } = vi.hoisted(() => ({ runMock: vi.fn(), ctorMock: vi.fn() }));
 vi.mock("./browserLinter", () => ({
-    // A class (not an arrow) so `new BrowserLinter()` constructs.
+    // A class (not an arrow) so `new BrowserLinter()` constructs. `ctorMock`
+    // records the (engine, config) args so a test can assert the handed-back
+    // config reaches the linter (#1384).
     BrowserLinter: class {
+        constructor(...args: unknown[]) {
+            ctorMock(...args);
+        }
         run = runMock;
     },
 }));
@@ -210,6 +215,17 @@ describe("LintConfigService: startInPageLinting (host handback)", () => {
         expect(runMock).toHaveBeenCalled();
         expect(onLintResults).toHaveBeenCalledWith(LINT_EVENT);
         expect(returned).toEqual(LINT_EVENT.results);
+    });
+
+    it("builds the browser linter with the handed-back workspace config (#1384)", () => {
+        ctorMock.mockClear();
+        const { service } = makeService({ tier: "external", imported: true });
+        const config = { extends: "bpmnlint:recommended" };
+
+        service.startInPageLinting(config);
+
+        // The covered workspace config the host pushed is linted, not the default.
+        expect(ctorMock).toHaveBeenLastCalledWith("c7", config);
     });
 
     it("defers activation to import.done when no diagram is imported yet", () => {

--- a/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/LintConfigService.ts
@@ -147,6 +147,12 @@ export class LintConfigService {
 
     private readonly explicitConfig?: BpmnlintConfig;
 
+    // The config-version token of the last in-page instruction (#1384). Used to
+    // dedup a repeat covered instruction, but only while actually `"in-page"`:
+    // any disabled/external push in between leaves this stale, and the state
+    // guard below stops that stale token from dropping a genuine re-enable.
+    private lastConfigToken?: string;
+
     private results: LintResults = {};
 
     private toolbar?: HTMLElement;
@@ -199,17 +205,27 @@ export class LintConfigService {
      * No-ops when the user has disabled linting from the canvas — a host
      * instruction must never silently re-enable a user-disabled linter; the
      * chip's own click handler owns re-enable. Also no-ops when already in-page
-     * with no new config (a duplicate instruction). Precedence is unchanged:
-     * {@link applyLintResults}/{@link applyLintingDisabled} still hard-set
-     * `"external"`, so any host push still wins over this.
+     * with a duplicate instruction (no new config, or the same `configToken` as
+     * the live run — the host re-sends on panel re-activation and rebuilding the
+     * {@link BrowserLinter} would churn the lint chrome for nothing). The dedup
+     * is gated on `state === "in-page"` so a token left stale by an intervening
+     * disabled/external push can never drop a genuine re-enable. Precedence is
+     * unchanged: {@link applyLintResults}/{@link applyLintingDisabled} still
+     * hard-set `"external"`, so any host push still wins over this.
      */
-    startInPageLinting(config?: BpmnlintConfig): void {
+    startInPageLinting(config?: BpmnlintConfig, configToken?: string): void {
         if (this.state === "in-page-disabled") {
             return;
         }
-        if (this.state === "in-page" && this.browserLinter && config === undefined) {
-            return;
+        if (this.state === "in-page" && this.browserLinter) {
+            if (config === undefined) {
+                return;
+            }
+            if (configToken !== undefined && configToken === this.lastConfigToken) {
+                return;
+            }
         }
+        this.lastConfigToken = configToken;
         this.browserLinter = new BrowserLinter(this.engine, config ?? this.explicitConfig);
         this.state = "in-page";
         if (this.bpmnjs.getDefinitions()) {

--- a/apps/bpmn-webview/src/app/bpmnlint/browserResolver.ts
+++ b/apps/bpmn-webview/src/app/bpmnlint/browserResolver.ts
@@ -1,5 +1,10 @@
-import type { BpmnlintConfig } from "@miragon/bpmn-modeler-types";
+import { staticUnresolvedModdleExtensions } from "@miragon/bpmn-modeler-types";
 import { createBundledResolver, type Resolver } from "@miragon/bpmnlint-plugin-rules";
+
+// Re-exported so `browserLinter.ts` and `browserResolver.spec.ts` keep importing
+// it from here; the implementation moved to modeler-types so the host's
+// escalation pre-check shares the exact same logic (#1384).
+export { staticUnresolvedModdleExtensions };
 
 /**
  * A bpmnlint rule that reports nothing. Substituted for a rule/config the bundled
@@ -13,15 +18,6 @@ const NOOP_RULE = () => ({ check: () => undefined });
 
 /** An empty shareable config — the `resolveConfig` fallback for a missing plugin config. */
 const NOOP_CONFIG = { rules: {} };
-
-/**
- * The moddle prefixes the live bpmn-js tree already registers. The webview lints
- * the in-memory definitions (not re-parsed XML), so any `moddleExtensions` entry
- * targeting one of these is already satisfied — the typed properties the rules
- * inspect are present on the tree. Everything else cannot be honoured in a
- * browser (no `require`), so it is reported, never loaded.
- */
-const LIVE_MODDLE_PREFIXES = new Set(["bpmn", "bpmndi", "dc", "di", "camunda", "zeebe", "modeler"]);
 
 /**
  * Wraps `@miragon/bpmnlint-plugin-rules`' bundled resolver (bpmnlint built-ins +
@@ -76,28 +72,4 @@ export class RecordingBrowserResolver implements Resolver {
             return undefined;
         }
     }
-}
-
-/**
- * The `moddleExtensions` a browser lint run cannot honour, in the same
- * `moddleExtension:<prefix>` form the Node linter reports. A string value is a
- * module path only Node can `require`; an object value is only usable when its
- * prefix is one the live tree already registers (otherwise its typed properties
- * were never parsed onto the model). Everything unhonourable is returned so it
- * can be merged into the run's `unresolved` list — informational, never fatal.
- */
-export function staticUnresolvedModdleExtensions(config: BpmnlintConfig): string[] {
-    const declared = config.moddleExtensions;
-    if (!declared || typeof declared !== "object") {
-        return [];
-    }
-    const unresolved: string[] = [];
-    for (const [prefix, value] of Object.entries(declared)) {
-        const honoured =
-            value != null && typeof value === "object" && LIVE_MODDLE_PREFIXES.has(prefix);
-        if (!honoured) {
-            unresolved.push(`moddleExtension:${prefix}`);
-        }
-    }
-    return unresolved;
 }

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -303,7 +303,7 @@ export class BpmnModeler {
      *
      * @throws {NoModelerError} If the modeler has not been created yet.
      */
-    startInPageLinting(config?: BpmnlintConfig): void {
+    startInPageLinting(config?: BpmnlintConfig, configToken?: string): void {
         const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
         if (!service) {
             console.warn(
@@ -311,7 +311,7 @@ export class BpmnModeler {
             );
             return;
         }
-        service.startInPageLinting(config);
+        service.startInPageLinting(config, configToken);
     }
 
     /**

--- a/apps/bpmn-webview/src/app/publicApi.ts
+++ b/apps/bpmn-webview/src/app/publicApi.ts
@@ -222,9 +222,11 @@ export interface BpmnModelerHandle {
     /**
      * [B] Start (or restart) the in-webview linter — the host's no-workspace-config
      * handback (#1373 Phase B). Optional `config` overrides the engine-aware
-     * default. Never re-enables a user-disabled linter.
+     * default; optional `configToken` (#1384) lets a repeat instruction with the
+     * same version dedup while linting is live. Never re-enables a user-disabled
+     * linter.
      */
-    startInPageLinting(config?: BpmnlintConfig): void;
+    startInPageLinting(config?: BpmnlintConfig, configToken?: string): void;
 
     // ── Escape hatch ────────────────────────────────────────────────────────
     /**

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -714,24 +714,16 @@ function startSession(
             case queryOrCommand.type === "BpmnlintInPageQuery": {
                 try {
                     const q = message.data as BpmnlintInPageQuery;
-                    // Dedup a repeat covered instruction (same config version): the
-                    // host re-sends on panel re-activation, and rebuilding the
-                    // BrowserLinter would churn the lint chrome for nothing. A
-                    // payload-free default (token undefined) always resets and
-                    // re-runs so a config→no-config transition takes effect.
-                    if (
-                        q.config &&
-                        q.configToken !== undefined &&
-                        q.configToken === currentLintConfigToken
-                    ) {
-                        break;
-                    }
+                    // The token stays current for the onLintResults echo. Dedup of
+                    // a repeat covered instruction now lives in LintConfigService,
+                    // where the tier state is known — a stale token from an
+                    // intervening disabled push can no longer drop a re-enable.
                     currentLintConfigToken = q.configToken;
                     // No workspace config → engine-aware default (#1373 Phase B);
                     // a covered config (#1384) → lint it in-page. Either way
                     // onLintResults pushes the findings back so the host feeds its
                     // Problems panel + status bar.
-                    bpmnModeler.startInPageLinting(q.config);
+                    bpmnModeler.startInPageLinting(q.config, q.configToken);
                 } catch (error: any) {
                     host.postMessage(new LogErrorCommand(errorPrefix + error.message));
                 }

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -15,6 +15,7 @@ import {
     FlushDocumentQuery,
     FocusElementQuery,
     GetBpmnFileCommand,
+    BpmnlintInPageQuery,
     GetBpmnlintConfigCommand,
     GetBpmnModelerSettingCommand,
     GetClipboardCommand,
@@ -136,6 +137,18 @@ function startSession(
     // A FocusElementQuery can arrive before the import finishes (host opens the
     // editor and focuses in one tick); apply it once the modeler is ready.
     let pendingFocusId: string | undefined;
+
+    // The opaque config-version token from the host's last BpmnlintInPageQuery
+    // (#1384), echoed back on every UpdateLintResultsCommand so the host can pair
+    // a run with the config version it linted and drop a stale run. `undefined`
+    // for the payload-free #1373 default tier (and reset to it on config→no-config).
+    //
+    // Pairing is race-free without any per-run plumbing: BrowserLinter.run is a
+    // pure microtask chain (bpmnlint over the in-memory tree, no I/O), so it
+    // drains to its onLintResults synchronously-after-await, before the next host
+    // message can be delivered as a fresh macrotask and swap this closure. So the
+    // token read here always belongs to the config that drove this very run.
+    let currentLintConfigToken: string | undefined;
 
     // Separate resolvers for element clipboard and text (label) clipboard.
     let elementClipboardResolver = createResolver<ClipboardQuery>();
@@ -427,7 +440,13 @@ function startSession(
             onLintResults:
                 injectedOnLintResults ??
                 ((e: LintRunEvent) =>
-                    host.postMessage(new UpdateLintResultsCommand(e.results, [...e.unresolved]))),
+                    host.postMessage(
+                        new UpdateLintResultsCommand(
+                            e.results,
+                            [...e.unresolved],
+                            currentLintConfigToken,
+                        ),
+                    )),
             onLintingToggled: (enabled: boolean) =>
                 host.postMessage(new SetLintingEnabledCommand(enabled)),
             applyColorThemeMode: setColorThemeMode,
@@ -694,10 +713,25 @@ function startSession(
             }
             case queryOrCommand.type === "BpmnlintInPageQuery": {
                 try {
-                    // No workspace config: run our own default in-page (#1373
-                    // Phase B). onLintResults then pushes the findings back so the
-                    // host feeds its Problems panel + status bar.
-                    bpmnModeler.startInPageLinting();
+                    const q = message.data as BpmnlintInPageQuery;
+                    // Dedup a repeat covered instruction (same config version): the
+                    // host re-sends on panel re-activation, and rebuilding the
+                    // BrowserLinter would churn the lint chrome for nothing. A
+                    // payload-free default (token undefined) always resets and
+                    // re-runs so a config→no-config transition takes effect.
+                    if (
+                        q.config &&
+                        q.configToken !== undefined &&
+                        q.configToken === currentLintConfigToken
+                    ) {
+                        break;
+                    }
+                    currentLintConfigToken = q.configToken;
+                    // No workspace config → engine-aware default (#1373 Phase B);
+                    // a covered config (#1384) → lint it in-page. Either way
+                    // onLintResults pushes the findings back so the host feeds its
+                    // Problems panel + status bar.
+                    bpmnModeler.startInPageLinting(q.config);
                 } catch (error: any) {
                     host.postMessage(new LogErrorCommand(errorPrefix + error.message));
                 }

--- a/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
+++ b/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
@@ -5,14 +5,16 @@
  * (`createBridge`) runs against a fake transport (a frames array) over a real
  * temp filesystem, so the `BpmnLintConfigLocator` + `BpmnLintConfigService` +
  * `NodeBpmnLinter` do an actual nearest-`.bpmnlintrc` walk and run bpmnlint.
- * Covers the two branches the webview's `GetBpmnlintConfigCommand` exposes: a
- * discovered config is linted host-side and the findings pushed as
- * `BpmnlintResultsQuery`, and no config hands linting to the webview's in-page
- * default (#1373 Phase B) — the bridge posts a `BpmnlintInPageQuery` instead of
- * linting host-side, then accepts the webview's own findings back through
- * `UpdateLintResultsCommand`. The temp dir has no `node_modules`, so the
- * workspace-config path resolves built-in and camunda-compat rules from the
- * bundled resolvers — the same path a workspace without `bpmnlint` installed hits.
+ * Covers the three tiers the webview's `GetBpmnlintConfigCommand` exposes: no
+ * config hands linting to the webview's in-page default (#1373 Phase B); a
+ * *covered* config is pushed down for the webview to lint in-page (#1384, a
+ * config-carrying `BpmnlintInPageQuery`, no host lint) and escalates to a host
+ * `BpmnlintResultsQuery` only once the webview reports it cannot cover a rule; an
+ * *escalating* config (a Node-only string moddleExtension) is linted host-side
+ * straight away. The temp dir has no `node_modules`, so the host path resolves
+ * built-in and camunda-compat rules from the bundled resolvers — the same path a
+ * workspace without `bpmnlint` installed hits, and an unresolvable string
+ * moddleExtension is recorded (never fatal), so the lint still produces findings.
  *
  * Phase C additionally asserts the mid-session transitions the `.bpmnlintrc`
  * watcher drives: a config that *appears* takes the editor over to the host
@@ -96,6 +98,11 @@ const isLintResultsFrame = (frame: any): boolean =>
 const isInPageInstructionFrame = (frame: any): boolean =>
     frame.method === "editor/postMessage" && frame.params?.message?.type === "BpmnlintInPageQuery";
 
+// A #1384 covered-config instruction: an in-page instruction that carries the
+// workspace config + version token (vs. the payload-free zero-config default).
+const isInPageConfigInstructionFrame = (frame: any): boolean =>
+    isInPageInstructionFrame(frame) && frame.params?.message?.config != null;
+
 const isInPageResultsLog = (frame: any): boolean =>
     frame.method === "notifier/log" &&
     typeof frame.params?.message === "string" &&
@@ -141,7 +148,7 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
         );
     }
 
-    it("lints against the nearest .bpmnlintrc and pushes the findings to the webview", async () => {
+    it("lints a covered .bpmnlintrc in-page — pushes the config, not host findings (#1384)", async () => {
         const { rpc, frames, root, editorId } = await setup();
         await fs.writeFile(
             join(root, ".bpmnlintrc"),
@@ -151,11 +158,65 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
 
         await requestConfig(rpc, editorId);
 
-        const frame = await waitForFrame(frames, isLintResultsFrame);
-        const results = frame.params.message.results;
-        expect(results).not.toBeNull();
-        // recommended flags the missing start event on the process containing Task_1.
-        expect(Object.keys(results)).toContain("start-event-required");
+        // The bundled resolver covers `bpmnlint:recommended`, so the bridge pushes
+        // the config down for the webview to lint in-page instead of running the
+        // Node linter — a config-carrying instruction, never a results frame.
+        const frame = await waitForFrame(frames, isInPageConfigInstructionFrame);
+        expect(frame.params.message.config).toEqual({ extends: "bpmnlint:recommended" });
+        expect(typeof frame.params.message.configToken).toBe("string");
+        expect(frames.find(isLintResultsFrame)).toBeUndefined();
+    });
+
+    it("escalates a covered config to a host lint when the webview reports unresolved (#1384)", async () => {
+        const { rpc, frames, root, editorId } = await setup();
+        await fs.writeFile(
+            join(root, ".bpmnlintrc"),
+            JSON.stringify({ extends: "bpmnlint:recommended" }),
+            "utf8",
+        );
+
+        await requestConfig(rpc, editorId);
+        const instruction = await waitForFrame(frames, isInPageConfigInstructionFrame);
+        const token = instruction.params.message.configToken;
+
+        // The webview reports a rule the bundled resolver could not cover, so the
+        // bridge escalates that session to a host-side Node lint (results frame).
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "webview/message",
+                params: {
+                    editorId,
+                    message: {
+                        type: "UpdateLintResultsCommand",
+                        results: {},
+                        unresolved: ["bpmnlint-plugin-acme/foo"],
+                        configToken: token,
+                    },
+                },
+            }),
+        );
+        const resultsFrame = await waitForFrame(frames, isLintResultsFrame);
+        expect(Object.keys(resultsFrame.params.message.results)).toContain("start-event-required");
+
+        // The session is now escalated, so a later clean same-token in-page event
+        // is stale and must be dropped — no "in-page results" debug log follows.
+        const baseline = frames.length;
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "webview/message",
+                params: {
+                    editorId,
+                    message: {
+                        type: "UpdateLintResultsCommand",
+                        results: {},
+                        unresolved: [],
+                        configToken: token,
+                    },
+                },
+            }),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        expect(frames.slice(baseline).find(isInPageResultsLog)).toBeUndefined();
     });
 
     it("hands linting to the webview in-page (no host lint) when no .bpmnlintrc exists", async () => {
@@ -208,13 +269,18 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
         await requestConfig(rpc, editorId);
         await waitForFrame(frames, isInPageInstructionFrame);
 
-        // The watcher re-lints host-side the moment the config lands. fsevents
-        // can drop the first `add` after a fresh watch, so re-write inside the
-        // wait loop until the host results frame arrives.
+        // An *escalating* config (a Node-only string moddleExtension) so the
+        // watcher takes the editor host-side and emits a results frame — a covered
+        // config would only push an in-page instruction. The watcher re-lints the
+        // moment the config lands; fsevents can drop the first `add` after a fresh
+        // watch, so re-write inside the wait loop until the host results frame arrives.
         const writeConfig = () =>
             fs.writeFile(
                 join(root, ".bpmnlintrc"),
-                JSON.stringify({ extends: "bpmnlint:recommended" }),
+                JSON.stringify({
+                    extends: "bpmnlint:recommended",
+                    moddleExtensions: { acme: "./acme.json" },
+                }),
                 "utf8",
             );
         await writeConfig();
@@ -248,7 +314,16 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
     it("hands linting back to the webview in-page when the .bpmnlintrc is deleted mid-session", async () => {
         const { rpc, frames, root, editorId } = await setup();
         const configPath = join(root, ".bpmnlintrc");
-        await fs.writeFile(configPath, JSON.stringify({ extends: "bpmnlint:recommended" }), "utf8");
+        // Escalating config so the initial request lints host-side (results frame);
+        // deleting it must then hand linting back to the in-page default.
+        await fs.writeFile(
+            configPath,
+            JSON.stringify({
+                extends: "bpmnlint:recommended",
+                moddleExtensions: { acme: "./acme.json" },
+            }),
+            "utf8",
+        );
 
         await requestConfig(rpc, editorId);
         await waitForFrame(frames, isLintResultsFrame);

--- a/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
+++ b/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
@@ -11,13 +11,15 @@ import { RegisterParams, SessionHooks } from "./sessionHooks";
 
 /**
  * The bpmnlint feature discovers the nearest `.bpmnlintrc` for an open BPMN
- * document. When one is found it runs bpmnlint in the bridge (a full Bun/Node
- * context, so custom `bpmnlint-plugin-*` rules resolve against the workspace
- * exactly like in VS Code) and pushes the findings to the webview, which only
- * renders the in-canvas markers. When none is found it tells the webview to run
- * its own engine-aware default in-page (#1373 Phase B) and accepts the findings
- * back via {@link UpdateLintResultsCommand} — the same core behaviour as VS Code,
- * arriving here structurally. It reuses the
+ * document and drives the shared three-tier policy in {@link BpmnLintConfigService}:
+ * no config → the webview's engine-aware default in-page (#1373 Phase B); a
+ * config the bundled resolver covers → the webview lints it in-page against the
+ * pushed config (#1384); a config it cannot cover → the bridge runs bpmnlint in
+ * a full Bun/Node context (so custom `bpmnlint-plugin-*` rules resolve against
+ * the workspace exactly like in VS Code) and pushes the findings to the webview,
+ * which only renders the in-canvas markers. In-page runs come back via
+ * {@link UpdateLintResultsCommand} — the same core behaviour as VS Code, arriving
+ * here structurally. It reuses the
  * host-agnostic core stack ({@link BpmnLintConfigLocator} +
  * {@link BpmnLintConfigService} + {@link NodeBpmnLinter}) over the
  * Workspace/Settings/Document/StatusBar ports the bridge already implements — the
@@ -52,7 +54,7 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
     // has flipped the editor to the external path.
     deps.router.on("UpdateLintResultsCommand", (message: Command, editorId: string) => {
         const cmd = message as UpdateLintResultsCommand;
-        lintSvc.applyWebviewLintResults(editorId, cmd.results, cmd.unresolved);
+        lintSvc.applyWebviewLintResults(editorId, cmd.results, cmd.unresolved, cmd.configToken);
     });
 
     // Per-editor `.bpmnlintrc` watcher so edits to the rules re-lint the open
@@ -74,6 +76,10 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
             onSessionDisposed: (editorId: string) => {
                 watchers.get(editorId)?.forEach((disposable) => disposable.dispose());
                 watchers.delete(editorId);
+                // Also frees the service's per-editor mode/cache/negotiation maps
+                // (a pre-existing leak — nothing evicted them before) alongside
+                // the watcher.
+                lintSvc.clearDiagnostics(editorId);
                 deps.statusBar.hideBpmnlintStatus();
             },
         },

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
@@ -409,7 +409,29 @@ describe("updateLintResultsHandler", () => {
             EDITOR,
         );
 
-        expect(lintSvc.applyWebviewLintResults).toHaveBeenCalledWith(EDITOR, results, unresolved);
+        expect(lintSvc.applyWebviewLintResults).toHaveBeenCalledWith(
+            EDITOR,
+            results,
+            unresolved,
+            undefined,
+        );
+    });
+
+    it("forwards the config token so the service can pair the run with its config version (#1384)", () => {
+        const lintSvc = { applyWebviewLintResults: vi.fn() };
+        const results = {};
+
+        updateLintResultsHandler(lintSvc as never)(
+            new UpdateLintResultsCommand(results, [], "lint-cfg-7"),
+            EDITOR,
+        );
+
+        expect(lintSvc.applyWebviewLintResults).toHaveBeenCalledWith(
+            EDITOR,
+            results,
+            [],
+            "lint-cfg-7",
+        );
     });
 });
 

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
@@ -132,7 +132,7 @@ export function getPropertiesPanelStateHandler(
 export function updateLintResultsHandler(lintSvc: BpmnLintConfigService): MessageHandler {
     return (message: Command, editorId: string) => {
         const cmd = message as UpdateLintResultsCommand;
-        lintSvc.applyWebviewLintResults(editorId, cmd.results, cmd.unresolved);
+        lintSvc.applyWebviewLintResults(editorId, cmd.results, cmd.unresolved, cmd.configToken);
     };
 }
 

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/lintParity.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/lintParity.spec.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { Engine, LintResults } from "@miragon/bpmn-modeler-types";
+import { BpmnlintConfig, Engine, LintResults } from "@miragon/bpmn-modeler-types";
 
 import { DefaultBpmnlintConfigService } from "../../service/DefaultBpmnlintConfigService";
 import { NodeBpmnLinter } from "./NodeBpmnLinter";
@@ -83,6 +83,30 @@ describe("bpmnlint default parity: NodeBpmnLinter vs BrowserLinter", () => {
 
         // The oversized task must actually trip a rule, else "parity" is vacuous.
         expect(Object.keys(nodeOut.results)).toContain("standard-size");
+
+        expect(browserOut.results as LintResults).toEqual(nodeOut.results);
+        expect(nodeOut.unresolved).toEqual([]);
+        expect(browserOut.unresolved).toEqual([]);
+    });
+
+    // #1384: a covered *workspace* config (a real `.bpmnlintrc`, not the
+    // zero-config default) that the bundled resolver can fully honour must lint
+    // identically host-side and in-page — so a user who edits `bpmnlint:recommended`
+    // into their config sees the exact same findings the host would have produced.
+    it("produces identical findings and no unresolved rules for a covered workspace config", async () => {
+        const config: BpmnlintConfig = { extends: "bpmnlint:recommended" };
+
+        const anchor = resolve(__dirname, ".bpmnlintrc");
+        const nodeOut = await new NodeBpmnLinter().lint(BPMN_XML, anchor, config);
+
+        const root = await parseModdleRoot(
+            BPMN_XML,
+            config.moddleExtensions as Record<string, unknown> | undefined,
+        );
+        const browserOut = await new BrowserLinter(PLATFORM, config).run(root);
+
+        // recommended flags the missing start event — else "parity" is vacuous.
+        expect(Object.keys(nodeOut.results)).toContain("start-event-required");
 
         expect(browserOut.results as LintResults).toEqual(nodeOut.results);
         expect(nodeOut.unresolved).toEqual([]);

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
@@ -14,6 +14,7 @@ import {
 import { BpmnLintConfigService } from "./BpmnLintConfigService";
 
 const EDITOR = "file:///work/diagram.bpmn";
+const CONFIG_PATH = "/work/.bpmnlintrc";
 // No platform markers → detectPlatform() throws → structural-only default.
 const XML = "<xml/>";
 const XML_C7 = '<definitions modeler:executionPlatformVersion="7.20.0" />';
@@ -21,6 +22,20 @@ const XML_C8 = '<definitions modeler:executionPlatformVersion="8.6.0" />';
 const RESULTS = {
     "label-required": [{ id: "Task_1", message: "Element requires a label", category: "warn" }],
 };
+
+// The bundled resolver covers this (no moddleExtensions) → linted in-page (#1384).
+const COVERED_CONFIG = { extends: "bpmnlint:recommended" };
+const COVERED_RAW = JSON.stringify(COVERED_CONFIG);
+// A string moddleExtension is a Node-only module path → the static pre-check
+// escalates immediately (today's host-side behaviour).
+const ESCALATING_CONFIG = {
+    extends: "bpmnlint:recommended",
+    moddleExtensions: { acme: "./acme.json" },
+};
+const ESCALATING_RAW = JSON.stringify(ESCALATING_CONFIG);
+
+/** Lets a fire-and-forget `runWorkspaceLint` settle before assertions. */
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
 
 function createService() {
     const editorStore = {
@@ -81,76 +96,106 @@ function createService() {
     };
 }
 
+type Store = { postMessage: { mock: { calls: unknown[][] } } };
+
+/** Every posted message of the given `type`, in post order. */
+function postedOfType<T extends { type: string } = { type: string }>(
+    editorStore: Store,
+    type: string,
+): T[] {
+    return editorStore.postMessage.mock.calls
+        .map((call) => call[1] as { type: string })
+        .filter((message) => message.type === type) as T[];
+}
+
 /** True when no `BpmnlintResultsQuery` was ever posted (the in-page path must not push one). */
-function noResultsQueryPosted(editorStore: {
-    postMessage: { mock: { calls: unknown[][] } };
-}): boolean {
-    return editorStore.postMessage.mock.calls.every(
-        (call) => (call[1] as { type: string }).type !== "BpmnlintResultsQuery",
-    );
+function noResultsQueryPosted(editorStore: Store): boolean {
+    return postedOfType(editorStore, "BpmnlintResultsQuery").length === 0;
+}
+
+/** Arranges a live covered (#1384 in-page) session and returns its instruction token. */
+async function coveredSession(): Promise<ReturnType<typeof createService> & { token: string }> {
+    const ctx = createService();
+    ctx.locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+    ctx.locator.readConfig.mockResolvedValue(COVERED_RAW);
+    await ctx.service.setBpmnlintConfig(EDITOR);
+    const [instruction] = postedOfType<BpmnlintInPageQuery>(ctx.editorStore, "BpmnlintInPageQuery");
+    return { ...ctx, token: instruction.configToken as string };
 }
 
 beforeEach(() => {
     vi.clearAllMocks();
 });
 
-describe("BpmnLintConfigService.setBpmnlintConfig — workspace config (external)", () => {
-    it("lints the document and posts the results with the active status when a config is found", async () => {
+describe("BpmnLintConfigService.setBpmnlintConfig — escalated workspace config (Node run)", () => {
+    it("lints host-side and posts the results with the active status when the config needs the Node resolver", async () => {
         const { service, editorStore, locator, lintRunner, diagnostics, statusBar, notifier } =
             createService();
-        locator.findNearestConfig.mockResolvedValue("/work/.bpmnlintrc");
-        locator.readConfig.mockResolvedValue(JSON.stringify({ extends: "bpmnlint:recommended" }));
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+        locator.readConfig.mockResolvedValue(ESCALATING_RAW);
 
         const result = await service.setBpmnlintConfig(EDITOR);
 
         expect(result).toBe(true);
         // Discovery walks from the document's directory, not the file itself.
         expect(locator.findNearestConfig).toHaveBeenCalledWith("file:///work");
-        expect(lintRunner.lint).toHaveBeenCalledWith(XML, "/work/.bpmnlintrc", {
-            extends: "bpmnlint:recommended",
-        });
+        expect(lintRunner.lint).toHaveBeenCalledWith(XML, CONFIG_PATH, ESCALATING_CONFIG);
         expect(diagnostics.publish).toHaveBeenCalledWith(EDITOR, XML, RESULTS);
-        expect(statusBar.showBpmnlintActive).toHaveBeenCalledWith("/work/.bpmnlintrc");
+        expect(statusBar.showBpmnlintActive).toHaveBeenCalledWith(CONFIG_PATH);
         expect(statusBar.showBpmnlintUnresolved).not.toHaveBeenCalled();
-        expect(notifier.logInfo).toHaveBeenCalledWith("bpmnlint applied from /work/.bpmnlintrc");
+        expect(notifier.logInfo).toHaveBeenCalledWith(`bpmnlint applied from ${CONFIG_PATH}`);
         expect(service.getLintMode(EDITOR)).toBe("external");
-        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintResultsQuery;
-        expect(msg.type).toBe("BpmnlintResultsQuery");
+        // Escalation runs host-side — no in-page instruction is ever posted.
+        expect(postedOfType(editorStore, "BpmnlintInPageQuery")).toHaveLength(0);
+        const [msg] = postedOfType<BpmnlintResultsQuery>(editorStore, "BpmnlintResultsQuery");
         expect(msg.results).toEqual(RESULTS);
     });
 
     it("shows the unresolved status and warns when rules could not be resolved", async () => {
         const { service, locator, lintRunner, statusBar, notifier } = createService();
-        locator.findNearestConfig.mockResolvedValue("/work/.bpmnlintrc");
-        locator.readConfig.mockResolvedValue(JSON.stringify({ rules: { "custom/x": "error" } }));
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+        locator.readConfig.mockResolvedValue(ESCALATING_RAW);
         lintRunner.lint.mockResolvedValue({ results: {}, unresolved: ["custom/x"] });
 
         await service.setBpmnlintConfig(EDITOR);
 
-        expect(statusBar.showBpmnlintUnresolved).toHaveBeenCalledWith("/work/.bpmnlintrc", [
-            "custom/x",
-        ]);
+        expect(statusBar.showBpmnlintUnresolved).toHaveBeenCalledWith(CONFIG_PATH, ["custom/x"]);
         expect(statusBar.showBpmnlintActive).not.toHaveBeenCalled();
         expect(notifier.logWarning).toHaveBeenCalledWith(expect.stringContaining("custom/x"));
     });
 
     it("still posts results but leaves the status bar untouched when reflectInStatusBar is false", async () => {
         const { service, editorStore, locator, statusBar } = createService();
-        locator.findNearestConfig.mockResolvedValue("/work/.bpmnlintrc");
-        locator.readConfig.mockResolvedValue(JSON.stringify({ extends: "bpmnlint:recommended" }));
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+        locator.readConfig.mockResolvedValue(ESCALATING_RAW);
 
         const result = await service.setBpmnlintConfig(EDITOR, false);
 
         expect(result).toBe(true);
         expect(statusBar.showBpmnlintActive).not.toHaveBeenCalled();
         expect(statusBar.showBpmnlintNoConfig).not.toHaveBeenCalled();
-        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintResultsQuery;
+        const [msg] = postedOfType<BpmnlintResultsQuery>(editorStore, "BpmnlintResultsQuery");
         expect(msg.results).toEqual(RESULTS);
+    });
+
+    it("re-lints via the Node path on a cache-hit re-run and posts no new in-page instruction", async () => {
+        const { service, editorStore, locator, lintRunner } = createService();
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+        locator.readConfig.mockResolvedValue(ESCALATING_RAW);
+        await service.setBpmnlintConfig(EDITOR);
+        expect(lintRunner.lint).toHaveBeenCalledTimes(1);
+
+        await service.setBpmnlintConfig(EDITOR);
+
+        // The document may have changed, so it re-lints — but the version is
+        // unchanged, so it does not re-negotiate or post a fresh instruction.
+        expect(lintRunner.lint).toHaveBeenCalledTimes(2);
+        expect(postedOfType(editorStore, "BpmnlintInPageQuery")).toHaveLength(0);
     });
 
     it("logs and falls back to null without throwing on malformed JSON", async () => {
         const { service, editorStore, locator, diagnostics, statusBar, notifier } = createService();
-        locator.findNearestConfig.mockResolvedValue("/work/.bpmnlintrc");
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
         locator.readConfig.mockResolvedValue("{ not json");
 
         const result = await service.setBpmnlintConfig(EDITOR);
@@ -160,14 +205,14 @@ describe("BpmnLintConfigService.setBpmnlintConfig — workspace config (external
         expect(statusBar.showBpmnlintNoConfig).toHaveBeenCalledOnce();
         expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
         expect(service.getLintMode(EDITOR)).toBe("external");
-        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintResultsQuery;
+        const [msg] = postedOfType<BpmnlintResultsQuery>(editorStore, "BpmnlintResultsQuery");
         expect(msg.results).toBeNull();
     });
 
     it("swallows a hidden-panel post rejection as a warning without misreporting it as a read failure", async () => {
         const { service, editorStore, locator, notifier } = createService();
-        locator.findNearestConfig.mockResolvedValue("/work/.bpmnlintrc");
-        locator.readConfig.mockResolvedValue(JSON.stringify({ extends: "bpmnlint:recommended" }));
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+        locator.readConfig.mockResolvedValue(ESCALATING_RAW);
         // The watcher fires while the diagram panel is hidden, so the post rejects.
         editorStore.postMessage.mockRejectedValue(new Error("The active editor is hidden."));
 
@@ -184,7 +229,98 @@ describe("BpmnLintConfigService.setBpmnlintConfig — workspace config (external
     });
 });
 
-describe("BpmnLintConfigService.setBpmnlintConfig — no config (in-page handback)", () => {
+describe("BpmnLintConfigService.setBpmnlintConfig — covered workspace config (#1384 in-page)", () => {
+    it("instructs the webview to lint the config in-page with a token, and never lints host-side", async () => {
+        const { service, editorStore, locator, lintRunner, diagnostics, statusBar } =
+            createService();
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+        locator.readConfig.mockResolvedValue(COVERED_RAW);
+
+        const result = await service.setBpmnlintConfig(EDITOR);
+
+        expect(result).toBe(true);
+        expect(lintRunner.lint).not.toHaveBeenCalled();
+        expect(service.getLintMode(EDITOR)).toBe("in-page");
+        // Provisional Active (not the zero-config default) while the first webview
+        // run is in flight.
+        expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
+        expect(statusBar.showBpmnlintActive).toHaveBeenCalledWith(CONFIG_PATH);
+        expect(statusBar.showBpmnlintDefault).not.toHaveBeenCalled();
+        const [msg] = postedOfType<BpmnlintInPageQuery>(editorStore, "BpmnlintInPageQuery");
+        expect(msg.config).toEqual(COVERED_CONFIG);
+        expect(typeof msg.configToken).toBe("string");
+        expect(noResultsQueryPosted(editorStore)).toBe(true);
+    });
+
+    it("applies a matching-token clean in-page event as Active", async () => {
+        const { service, diagnostics, statusBar, token } = await coveredSession();
+        vi.clearAllMocks();
+
+        service.applyWebviewLintResults(EDITOR, RESULTS, [], token);
+
+        expect(diagnostics.publish).toHaveBeenCalledWith(EDITOR, XML, RESULTS);
+        expect(statusBar.showBpmnlintActive).toHaveBeenCalledWith(CONFIG_PATH);
+        expect(statusBar.showBpmnlintDefault).not.toHaveBeenCalled();
+    });
+
+    it("replays the cached covered event as Active on a cache-hit re-instruct", async () => {
+        const { service, editorStore, diagnostics, statusBar, token } = await coveredSession();
+        service.applyWebviewLintResults(EDITOR, RESULTS, [], token); // cache it
+        vi.clearAllMocks();
+
+        await service.setBpmnlintConfig(EDITOR); // same version → cache hit
+
+        expect(diagnostics.publish).toHaveBeenCalledWith(EDITOR, XML, RESULTS);
+        expect(statusBar.showBpmnlintActive).toHaveBeenCalledWith(CONFIG_PATH);
+        // Re-sends the instruction carrying the same token (webview dedups on it).
+        const [msg] = postedOfType<BpmnlintInPageQuery>(editorStore, "BpmnlintInPageQuery");
+        expect(msg.configToken).toBe(token);
+    });
+});
+
+describe("BpmnLintConfigService — escalation from a covered in-page run", () => {
+    it("escalates to the Node linter on a non-empty unresolved and does not apply the partial in-page findings", async () => {
+        const { service, locator, lintRunner, diagnostics, token } = await coveredSession();
+        locator.readConfig.mockResolvedValue(COVERED_RAW);
+        lintRunner.lint.mockResolvedValue({ results: RESULTS, unresolved: [] });
+        vi.clearAllMocks();
+
+        const partial = { "x/y": [{ id: "T", message: "partial", category: "warn" }] };
+        service.applyWebviewLintResults(EDITOR, partial, ["some-plugin/some-rule"], token);
+        await flush();
+
+        // The Node run happened against the covered config…
+        expect(lintRunner.lint).toHaveBeenCalledWith(XML, CONFIG_PATH, COVERED_CONFIG);
+        // …publishing the Node results, never the partial in-page findings.
+        expect(diagnostics.publish).toHaveBeenCalledWith(EDITOR, XML, RESULTS);
+        expect(diagnostics.publish).not.toHaveBeenCalledWith(EDITOR, XML, partial);
+        expect(service.getLintMode(EDITOR)).toBe("external");
+    });
+
+    it("drops a second same-token in-page event while the escalation Node run is in flight", async () => {
+        const { service, locator, lintRunner, diagnostics, token } = await coveredSession();
+        locator.readConfig.mockResolvedValue(COVERED_RAW);
+        // Node lint hangs, so the mode is still "in-page" — the decision flip is
+        // the only guard against a second event re-escalating.
+        let release: (() => void) | undefined;
+        lintRunner.lint.mockReturnValue(
+            new Promise((resolve) => {
+                release = () => resolve({ results: {}, unresolved: [] });
+            }),
+        );
+        service.applyWebviewLintResults(EDITOR, RESULTS, ["p/r"], token); // triggers escalation
+        diagnostics.publish.mockClear();
+
+        service.applyWebviewLintResults(EDITOR, RESULTS, [], token); // second, same token
+
+        expect(diagnostics.publish).not.toHaveBeenCalled();
+        expect(lintRunner.lint).toHaveBeenCalledTimes(1);
+        release?.();
+        await flush();
+    });
+});
+
+describe("BpmnLintConfigService.setBpmnlintConfig — no config (in-page default)", () => {
     it("instructs the webview to run in-page, does not lint host-side, and posts no results query", async () => {
         const { service, editorStore, locator, lintRunner, diagnostics, statusBar } =
             createService();
@@ -199,8 +335,10 @@ describe("BpmnLintConfigService.setBpmnlintConfig — no config (in-page handbac
         // webview's first run is in flight (no cached event yet).
         expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
         expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith(undefined);
-        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintInPageQuery;
-        expect(msg.type).toBe("BpmnlintInPageQuery");
+        const [msg] = postedOfType<BpmnlintInPageQuery>(editorStore, "BpmnlintInPageQuery");
+        // Payload-free: no config and no token travel for the zero-config tier.
+        expect(msg.config).toBeUndefined();
+        expect(msg.configToken).toBeUndefined();
         expect(noResultsQueryPosted(editorStore)).toBe(true);
     });
 
@@ -231,8 +369,7 @@ describe("BpmnLintConfigService.setBpmnlintConfig — no config (in-page handbac
         await service.setBpmnlintConfig(EDITOR, false);
 
         expect(statusBar.showBpmnlintDefault).not.toHaveBeenCalled();
-        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintInPageQuery;
-        expect(msg.type).toBe("BpmnlintInPageQuery");
+        expect(postedOfType(editorStore, "BpmnlintInPageQuery")).toHaveLength(1);
     });
 
     it("replays the last cached in-page event on re-instruct (panel re-activation)", async () => {
@@ -306,21 +443,133 @@ describe("BpmnLintConfigService.applyWebviewLintResults", () => {
         expect(diagnostics.publish).not.toHaveBeenCalled();
     });
 
-    it("ignores a stale in-page push after a workspace-config takeover", async () => {
+    it("drops a default-tier push that carries a token (a deleted-config era)", async () => {
+        const { service, diagnostics, notifier } = await inPageService();
+
+        service.applyWebviewLintResults(EDITOR, RESULTS, [], "stale-token");
+
+        expect(diagnostics.publish).not.toHaveBeenCalled();
+        expect(notifier.logDebug).toHaveBeenCalledWith(expect.stringContaining("superseded"));
+    });
+
+    it("ignores a stale in-page push after an escalating workspace-config takeover", async () => {
         const { service, locator, diagnostics } = createService();
         locator.findNearestConfig.mockResolvedValue(undefined);
-        await service.setBpmnlintConfig(EDITOR); // in-page
+        await service.setBpmnlintConfig(EDITOR); // in-page default
 
-        // Config appears — the mode flips to external before the takeover push.
-        locator.findNearestConfig.mockResolvedValue("/work/.bpmnlintrc");
-        locator.readConfig.mockResolvedValue(JSON.stringify({ extends: "bpmnlint:recommended" }));
+        // An escalating config appears — the mode flips to external before the push.
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+        locator.readConfig.mockResolvedValue(ESCALATING_RAW);
         await service.setBpmnlintConfig(EDITOR);
         expect(service.getLintMode(EDITOR)).toBe("external");
         diagnostics.publish.mockClear();
 
-        // A webview push already in flight arrives late — it must be dropped.
+        // A default-tier webview push already in flight arrives late — dropped.
         service.applyWebviewLintResults(EDITOR, RESULTS, []);
         expect(diagnostics.publish).not.toHaveBeenCalled();
+    });
+});
+
+describe("BpmnLintConfigService — re-negotiation (both directions + race)", () => {
+    it("mints a new-token in-page instruction when an escalated config becomes covered", async () => {
+        const { service, editorStore, locator, lintRunner } = createService();
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+        locator.readConfig.mockResolvedValue(ESCALATING_RAW);
+        await service.setBpmnlintConfig(EDITOR); // escalated (external)
+        expect(service.getLintMode(EDITOR)).toBe("external");
+        vi.clearAllMocks();
+
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+        locator.readConfig.mockResolvedValue(COVERED_RAW);
+        await service.setBpmnlintConfig(EDITOR); // edited → covered
+
+        expect(lintRunner.lint).not.toHaveBeenCalled();
+        expect(service.getLintMode(EDITOR)).toBe("in-page");
+        const [msg] = postedOfType<BpmnlintInPageQuery>(editorStore, "BpmnlintInPageQuery");
+        expect(msg.config).toEqual(COVERED_CONFIG);
+        expect(typeof msg.configToken).toBe("string");
+    });
+
+    it("escalates when a covered config becomes uncovered", async () => {
+        const { service, locator, lintRunner } = await coveredSession();
+        vi.clearAllMocks();
+
+        locator.readConfig.mockResolvedValue(ESCALATING_RAW);
+        await service.setBpmnlintConfig(EDITOR); // edited → needs the Node resolver
+
+        expect(lintRunner.lint).toHaveBeenCalledWith(XML, CONFIG_PATH, ESCALATING_CONFIG);
+        expect(service.getLintMode(EDITOR)).toBe("external");
+    });
+
+    it("hands back to the payload-free default and forgets the negotiation when the config is deleted", async () => {
+        const { service, editorStore, locator, statusBar } = await coveredSession();
+        vi.clearAllMocks();
+
+        locator.findNearestConfig.mockResolvedValue(undefined); // config deleted
+        await service.setBpmnlintConfig(EDITOR);
+
+        expect(service.getLintMode(EDITOR)).toBe("in-page");
+        expect(statusBar.showBpmnlintDefault).toHaveBeenCalledWith(undefined);
+        const [msg] = postedOfType<BpmnlintInPageQuery>(editorStore, "BpmnlintInPageQuery");
+        expect(msg.config).toBeUndefined();
+        expect(msg.configToken).toBeUndefined();
+
+        // Negotiation gone: a default-tier event with the old token is now dropped.
+        service.applyWebviewLintResults(EDITOR, RESULTS, [], "old-token");
+        expect((editorStore.postMessage.mock.calls as unknown[][]).length).toBeGreaterThanOrEqual(
+            1,
+        );
+    });
+
+    it("drops a stale-token event without escalating when the config was edited mid-flight", async () => {
+        const { service, editorStore, locator, lintRunner, diagnostics, token } =
+            await coveredSession();
+
+        // Config edited V1 → V2 (still covered) before V1's in-page run returns.
+        locator.readConfig.mockResolvedValue(JSON.stringify({ ...COVERED_CONFIG, rules: {} }));
+        await service.setBpmnlintConfig(EDITOR);
+        const instructions = postedOfType<BpmnlintInPageQuery>(editorStore, "BpmnlintInPageQuery");
+        const token2 = instructions[instructions.length - 1].configToken;
+        expect(token2).not.toBe(token);
+        vi.clearAllMocks();
+
+        // A late V1 run (old token) reports it could not cover a rule.
+        service.applyWebviewLintResults(EDITOR, RESULTS, ["p/r"], token);
+
+        // Dropped as stale — it must not escalate the current V2 (still in-page).
+        expect(lintRunner.lint).not.toHaveBeenCalled();
+        expect(diagnostics.publish).not.toHaveBeenCalled();
+        expect(service.getLintMode(EDITOR)).toBe("in-page");
+    });
+
+    it("reuses the settled decision (same token) across disable → re-enable", async () => {
+        const { service, editorStore, locator, settings, token } = await coveredSession();
+
+        settings.getLintingEnabled.mockReturnValue(false);
+        await service.setBpmnlintConfig(EDITOR); // disabled — negotiation retained
+        vi.clearAllMocks();
+
+        settings.getLintingEnabled.mockReturnValue(true);
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+        locator.readConfig.mockResolvedValue(COVERED_RAW);
+        await service.setBpmnlintConfig(EDITOR); // re-enabled — same version
+
+        const [msg] = postedOfType<BpmnlintInPageQuery>(editorStore, "BpmnlintInPageQuery");
+        expect(msg.configToken).toBe(token); // reused, not re-minted
+    });
+
+    it("forgets the negotiation on clearDiagnostics so a re-open re-negotiates a fresh token", async () => {
+        const { service, editorStore, locator, token } = await coveredSession();
+
+        service.clearDiagnostics(EDITOR);
+        vi.clearAllMocks();
+
+        locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
+        locator.readConfig.mockResolvedValue(COVERED_RAW);
+        await service.setBpmnlintConfig(EDITOR);
+
+        const [msg] = postedOfType<BpmnlintInPageQuery>(editorStore, "BpmnlintInPageQuery");
+        expect(msg.configToken).not.toBe(token);
     });
 });
 
@@ -339,7 +588,7 @@ describe("BpmnLintConfigService.setBpmnlintConfig — disabled", () => {
         expect(diagnostics.clear).toHaveBeenCalledWith(EDITOR);
         expect(statusBar.showBpmnlintDisabled).toHaveBeenCalledOnce();
         expect(service.getLintMode(EDITOR)).toBe("external");
-        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnLintDisabledQuery;
+        const [msg] = postedOfType<BpmnLintDisabledQuery>(editorStore, "BpmnLintDisabledQuery");
         expect(msg.type).toBe("BpmnLintDisabledQuery");
     });
 
@@ -350,8 +599,7 @@ describe("BpmnLintConfigService.setBpmnlintConfig — disabled", () => {
         await service.setBpmnlintConfig(EDITOR, false);
 
         expect(statusBar.showBpmnlintDisabled).not.toHaveBeenCalled();
-        const msg = editorStore.postMessage.mock.calls[0][1] as BpmnLintDisabledQuery;
-        expect(msg.type).toBe("BpmnLintDisabledQuery");
+        expect(postedOfType(editorStore, "BpmnLintDisabledQuery")).toHaveLength(1);
     });
 
     it("clears the cached in-page event so a re-instruct does not replay stale findings", async () => {

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
@@ -5,7 +5,12 @@ import {
     BpmnlintInPageQuery,
     BpmnlintResultsQuery,
 } from "@miragon/bpmn-modeler-shared";
-import { Engine, LintResults } from "@miragon/bpmn-modeler-types";
+import {
+    BpmnlintConfig,
+    Engine,
+    LintResults,
+    staticUnresolvedModdleExtensions,
+} from "@miragon/bpmn-modeler-types";
 
 import { BpmnDocument } from "../../../shared/domain/BpmnDocument";
 import { ExecutionPlatformNotDetectedError } from "../../../shared/domain/errors";
@@ -26,48 +31,81 @@ import {
 /**
  * Where a set of findings came from, so {@link BpmnLintConfigService.applyFindings}
  * can pick the right status-bar indicator and log line. `"workspace"` is a
- * host-side run against a discovered `.bpmnlintrc`; `"in-page"` is the webview's
- * own default run (#1373 Phase B), reflected with the same `showBpmnlintDefault`
- * indicator the old host-side default used (same ruleset, different execution site).
+ * host-side (escalated) Node run against a discovered `.bpmnlintrc`; `"in-page"`
+ * is a webview run — either the zero-config default (#1373 Phase B, no
+ * `configPath`) or the #1384 covered workspace tier (`configPath` set, so it
+ * shows the `showBpmnlintActive` indicator rather than `showBpmnlintDefault`).
  */
 type LintFindingsSource =
     | { kind: "workspace"; configPath: string }
-    | { kind: "in-page"; platform: Engine | undefined };
+    | { kind: "in-page"; platform: Engine | undefined; configPath?: string };
 
 /**
  * The last in-page lint event received from the webview for one editor, cached
  * so a panel re-activation (`setBpmnlintConfig` from the panel-active hook) can
  * restore the Problems panel + status bar instead of going blank until the next
- * edit re-runs the webview linter.
+ * edit re-runs the webview linter. `configPath` records which tier produced it
+ * (set = #1384 covered workspace config; undefined = #1373 zero-config default)
+ * so a replay restores the right status-bar indicator.
  */
 interface CachedInPageEvent {
     readonly xml: string;
     readonly results: LintResults;
     readonly unresolved: readonly string[];
     readonly platform: Engine | undefined;
+    readonly configPath?: string;
+}
+
+/**
+ * The per-(editor × config-version) escalation decision for a workspace
+ * `.bpmnlintrc` (#1384). Version identity is `configPath` + `rawConfig` (the
+ * exact bytes read from disk): editing either mints a fresh decision. `decision`
+ * starts `"in-page"` (the webview lints the covered config itself) and only ever
+ * flips forward to `"escalated"` — when the static pre-check, or the webview's
+ * reported `unresolved`, proves the bundled resolver cannot cover the config, so
+ * the host takes over with the Node linter. It never de-escalates within one
+ * version. `token` is the opaque stamp carried on {@link BpmnlintInPageQuery} and
+ * echoed on {@link UpdateLintResultsCommand}: a stale in-page run against a
+ * superseded version echoes an old token and is dropped, so it can never
+ * (de-)escalate the current version.
+ */
+interface LintNegotiation {
+    readonly configPath: string;
+    readonly rawConfig: string;
+    readonly token: string;
+    decision: "in-page" | "escalated";
 }
 
 /**
  * Decides *where* an open BPMN document is linted and routes the resulting
  * findings to the host's chrome (Problems panel, status bar) and the webview.
  *
- * Two paths, chosen per document by whether a workspace `.bpmnlintrc` exists:
+ * Three tiers, chosen per document:
  *
- *  - **Workspace config** — the host runs bpmnlint in a full Node context
- *    ({@link LintRunnerPort}) so custom `bpmnlint-plugin-*` rules and
- *    `plugin:<pkg>/recommended` configs resolve against the workspace
- *    `node_modules`, then pushes the findings to the webview (which only paints
- *    overlays). This is the external tier — any push wins on the webview side.
- *  - **No config** (#1373 Phase B) — the host tells the webview to run its own
- *    engine-aware default in-page ({@link BpmnlintInPageQuery}); the webview
- *    pushes its findings back through {@link applyWebviewLintResults}, which
- *    feeds the very same host chrome. The host does not lint in this case, so a
- *    non-workspace diagram no longer pays for a host-side re-lint on every edit.
+ *  - **No config** (#1373 Phase B) — no workspace `.bpmnlintrc`: the host tells
+ *    the webview to run its own engine-aware default in-page (payload-free
+ *    {@link BpmnlintInPageQuery}); the webview pushes findings back through
+ *    {@link applyWebviewLintResults}. The host does not lint, so a non-workspace
+ *    diagram never pays for a host-side re-lint.
+ *  - **Covered workspace config** (#1384) — a `.bpmnlintrc` exists and the
+ *    bundled resolver can cover it: the host pushes the config down
+ *    ({@link BpmnlintInPageQuery} carrying `config`) and the webview lints it
+ *    in-page, so a covered config also skips the host re-lint per edit. A static
+ *    pre-check ({@link staticUnresolvedModdleExtensions}) escalates immediately;
+ *    otherwise the webview's reported `unresolved` triggers escalation.
+ *  - **Escalated workspace config** — the config references rules/moddle
+ *    extensions the bundled resolver cannot cover: the host runs bpmnlint in a
+ *    full Node context ({@link LintRunnerPort}) so custom `bpmnlint-plugin-*`
+ *    rules resolve against the workspace `node_modules`, then pushes the findings
+ *    to the webview (which only paints overlays). Any such push wins.
  *
- * A per-editor {@link lintModes} map tracks which path is live so the VS Code
- * participant can skip its debounced re-lint for in-page sessions, and so a
- * stale webview push arriving after a workspace-config takeover is ignored (the
- * mode flips to `"external"` *before* the takeover push — ordering matters).
+ * The escalation decision per (editor × config version) lives in the
+ * {@link negotiations} map so VS Code and the modeler-bridge inherit it
+ * identically. A per-editor {@link lintModes} map tracks whether the live tier is
+ * in-page or external so the VS Code participant can skip its debounced re-lint
+ * for in-page sessions, and so a stale webview push arriving after an escalation
+ * or takeover is ignored (the mode flips to `"external"` *before* the takeover
+ * push — ordering matters).
  *
  * Filesystem discovery / reading / watching lives in {@link BpmnLintConfigLocator};
  * the actual host lint run is a {@link LintRunnerPort}. Implements
@@ -82,6 +120,12 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
     private readonly lintModes = new Map<string, "external" | "in-page">();
 
     private readonly lastInPageEvents = new Map<string, CachedInPageEvent>();
+
+    /** The settled escalation decision per editor for its current config version. */
+    private readonly negotiations = new Map<string, LintNegotiation>();
+
+    /** Monotonic source for opaque config-version tokens; never reset. */
+    private tokenCounter = 0;
 
     constructor(
         private readonly editorStore: EditorSessionStore,
@@ -109,34 +153,101 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
     }
 
     /** Drops the published diagnostics and the per-editor lint bookkeeping for a
-     * closing editor so neither the Problems panel nor the mode/cache maps retain
-     * state for a document that is no longer open. */
+     * closing editor so neither the Problems panel nor the mode/cache/negotiation
+     * maps retain state for a document that is no longer open. The single teardown
+     * entry point, so it is also where the escalation decision is forgotten. */
     clearDiagnostics(editorId: string): void {
         this.diagnostics.clear(editorId);
         this.lintModes.delete(editorId);
         this.lastInPageEvents.delete(editorId);
+        this.negotiations.delete(editorId);
     }
 
     /**
-     * Applies findings the webview computed in its own in-page default run
-     * (#1373 Phase B) to the host's chrome. Guarded so a push that arrives after
-     * a workspace-config takeover — or while linting is disabled — is ignored:
-     * the mode flips to `"external"` *before* the takeover push, so a late
-     * in-page push finds the wrong mode and is dropped.
+     * Applies findings the webview computed in an in-page run (the #1373 default
+     * tier or the #1384 covered workspace tier) to the host's chrome. Guarded so
+     * a push that arrives after an escalation or a workspace-config takeover — or
+     * while linting is disabled — is ignored: the mode flips to `"external"`
+     * *before* the takeover push, so a late in-page push finds the wrong mode.
      *
-     * The event is cached so a later panel re-activation can restore it. The
-     * Problems panel is global, so diagnostics always publish; the status bar
-     * reflects an async push only for the active editor (a background editor's
+     * For a workspace-config session, `configToken` pairs the run with a config
+     * version: a run echoing a superseded token is dropped, and a non-empty
+     * `unresolved` escalates the session to the Node linter (the webview proved
+     * the bundled resolver cannot cover this config). The decision flips
+     * *synchronously* so a second event for the same token is dropped, and the
+     * partial in-page findings are **not** applied — the escalated Node run is
+     * the authority.
+     *
+     * A clean covered run is cached so a later panel re-activation can restore
+     * it. The Problems panel is global, so diagnostics always publish; the status
+     * bar reflects an async push only for the active editor (a background editor's
      * push must not steal the visible indicator).
      */
     applyWebviewLintResults(
         editorId: string,
         results: LintResults,
         unresolved: readonly string[],
+        configToken?: string,
     ): void {
         if (this.getLintMode(editorId) !== "in-page" || !this.settings.getLintingEnabled()) {
             return;
         }
+
+        const negotiation = this.negotiations.get(editorId);
+        if (negotiation) {
+            // Workspace-config in-page tier (#1384). Drop a run paired with a
+            // superseded config version, or one arriving after this version
+            // already escalated (the synchronous double-event guard).
+            if (configToken !== negotiation.token) {
+                this.notifier.logDebug(
+                    "[bpmnlint] dropping in-page results for a superseded config version",
+                );
+                return;
+            }
+            if (negotiation.decision === "escalated") {
+                return;
+            }
+            if (unresolved.length > 0) {
+                // The bundled resolver could not cover the config — escalate to
+                // the Node linter. Flip *before* the async lint so a second
+                // same-token event is dropped above; the partial in-page findings
+                // are discarded. runWorkspaceLint owns its own catch, so this
+                // fire-and-forget never leaks an unhandled rejection.
+                negotiation.decision = "escalated";
+                void this.runWorkspaceLint(
+                    editorId,
+                    negotiation.configPath,
+                    JSON.parse(negotiation.rawConfig) as Record<string, unknown>,
+                    this.isActiveEditor(editorId),
+                );
+                return;
+            }
+            const xml = this.vsDocument.getContent(editorId);
+            const platform = this.detectPlatform(xml);
+            this.lastInPageEvents.set(editorId, {
+                xml,
+                results,
+                unresolved,
+                platform,
+                configPath: negotiation.configPath,
+            });
+            this.applyFindings(editorId, xml, results, unresolved, this.isActiveEditor(editorId), {
+                kind: "in-page",
+                platform,
+                configPath: negotiation.configPath,
+            });
+            return;
+        }
+
+        // No negotiation: the #1373 payload-free default tier. A token here means
+        // the run belongs to a since-deleted config era — drop it.
+        if (configToken !== undefined) {
+            this.notifier.logDebug(
+                "[bpmnlint] dropping in-page results from a superseded config era",
+            );
+            return;
+        }
+
         const xml = this.vsDocument.getContent(editorId);
         const platform = this.detectPlatform(xml);
         this.lastInPageEvents.set(editorId, { xml, results, unresolved, platform });
@@ -147,12 +258,16 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
     }
 
     /**
-     * Resolves the nearest `.bpmnlintrc`. When one is found, lints the document
-     * host-side against it and pushes the findings (external tier). When none is
-     * found, hands linting to the webview's in-page default instead of linting
-     * host-side (#1373 Phase B). A read/parse/lint failure — including a malformed
-     * `.bpmnlintrc` — degrades to the no-config-*failure* state (linting off in
-     * the webview) rather than crashing the editor.
+     * Resolves the nearest `.bpmnlintrc` and drives the right tier. No config →
+     * the webview's in-page default (#1373 Phase B). A config → consult the
+     * per-editor negotiation: a cached decision re-lints in its settled tier
+     * (in-page instruction or Node run); a new/changed version re-negotiates,
+     * escalating immediately when the static pre-check proves the bundled
+     * resolver cannot cover it, otherwise lints it in-page (#1384). A
+     * read/parse/lint failure — including a malformed `.bpmnlintrc` — degrades to
+     * the no-config-*failure* state (linting off in the webview) rather than
+     * crashing the editor, and forgets the negotiation so a later valid edit
+     * re-negotiates cleanly.
      */
     private async lintAndPush(editorId: string, reflectInStatusBar: boolean): Promise<boolean> {
         // User opted out of linting entirely: skip the run and clear every
@@ -179,29 +294,71 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
                 return this.instructInPage(editorId, reflectInStatusBar);
             }
 
-            const config = JSON.parse(await this.locator.readConfig(configPath)) as Record<
-                string,
-                unknown
-            >;
-            const xml = this.vsDocument.getContent(editorId);
-            const { results, unresolved } = await this.lintRunner.lint(xml, configPath, config);
+            const rawConfig = await this.locator.readConfig(configPath);
+            // Parse up-front: a cache-hit rawConfig always parses (a negotiation is
+            // only stored after a successful parse), so a throw here is always a
+            // new/malformed version and belongs in the catch.
+            const config = JSON.parse(rawConfig) as Record<string, unknown>;
+            const existing = this.negotiations.get(editorId);
 
-            // Flip the mode *before* the takeover push so a stale in-page push
-            // already in flight is ignored by applyWebviewLintResults.
-            this.setExternalMode(editorId);
-            this.applyFindings(editorId, xml, results, unresolved, reflectInStatusBar, {
-                kind: "workspace",
+            // Cache hit — same config version: reuse the settled decision and
+            // re-lint (the document may have changed) without re-negotiating.
+            if (
+                existing &&
+                existing.configPath === configPath &&
+                existing.rawConfig === rawConfig
+            ) {
+                if (existing.decision === "escalated") {
+                    return this.runWorkspaceLint(editorId, configPath, config, reflectInStatusBar);
+                }
+                return this.reinstructCoveredInPage(
+                    editorId,
+                    configPath,
+                    config as BpmnlintConfig,
+                    existing.token,
+                    reflectInStatusBar,
+                );
+            }
+
+            // New or changed version: mint a fresh negotiation and drop any cached
+            // in-page event from the prior version.
+            const token = this.mintToken();
+            this.negotiations.set(editorId, {
                 configPath,
+                rawConfig,
+                token,
+                decision: "in-page",
             });
-            return this.pushResults(editorId, results);
+            this.lastInPageEvents.delete(editorId);
+
+            // Static pre-check: escalate immediately (no webview round trip) when
+            // the bundled resolver provably cannot cover the config — a Node-only
+            // string moddleExtension, or an object one under an unregistered prefix.
+            if (staticUnresolvedModdleExtensions(config as BpmnlintConfig).length > 0) {
+                const negotiation = this.negotiations.get(editorId);
+                if (negotiation) {
+                    negotiation.decision = "escalated";
+                }
+                return this.runWorkspaceLint(editorId, configPath, config, reflectInStatusBar);
+            }
+
+            // Covered: the webview lints the workspace config in-page. Provisional
+            // Active indicator while its first run is in flight (no cache yet).
+            this.lintModes.set(editorId, "in-page");
+            this.diagnostics.clear(editorId);
+            if (reflectInStatusBar) {
+                this.statusBar.showBpmnlintActive(configPath);
+            }
+            return this.postInPageInstruction(editorId, config as BpmnlintConfig, token);
         } catch (error) {
             // A malformed .bpmnlintrc or a linter blow-up must not crash the
-            // editor — warn, fall back to the no-config-failure state, and tell
-            // the webview to deactivate linting.
+            // editor — warn, fall back to the no-config-failure state, forget the
+            // negotiation, and tell the webview to deactivate linting.
             this.notifier.logError(
                 new Error(`Failed to lint against .bpmnlintrc: ${(error as Error).message}`),
             );
             this.setExternalMode(editorId);
+            this.negotiations.delete(editorId);
             if (reflectInStatusBar) {
                 this.statusBar.showBpmnlintNoConfig();
             }
@@ -211,18 +368,100 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
     }
 
     /**
-     * Switches the editor to the in-page path and tells the webview to run its
-     * own engine-aware default. Replays the last cached in-page event if one
-     * exists (panel re-activation), so the Problems panel + status bar are
-     * restored instead of blanking until the next webview push; otherwise clears
-     * diagnostics and shows a provisional default indicator while the webview's
-     * first run is in flight.
+     * Runs bpmnlint host-side against a discovered `.bpmnlintrc` and pushes the
+     * findings (the escalated tier). Flips the mode to `"external"` *before* the
+     * push so a stale in-page run already in flight is dropped by
+     * {@link applyWebviewLintResults} — the no-duplicate-markers invariant.
+     *
+     * Owns its own catch so escalation callers can fire-and-forget it without
+     * leaking an unhandled rejection: a failure degrades to the no-config-failure
+     * state and forgets the negotiation so a later valid edit re-negotiates.
+     */
+    private async runWorkspaceLint(
+        editorId: string,
+        configPath: string,
+        config: Record<string, unknown>,
+        reflectInStatusBar: boolean,
+    ): Promise<boolean> {
+        try {
+            const xml = this.vsDocument.getContent(editorId);
+            const { results, unresolved } = await this.lintRunner.lint(xml, configPath, config);
+
+            this.setExternalMode(editorId);
+            this.applyFindings(editorId, xml, results, unresolved, reflectInStatusBar, {
+                kind: "workspace",
+                configPath,
+            });
+            return this.pushResults(editorId, results);
+        } catch (error) {
+            this.notifier.logError(
+                new Error(`Failed to lint against .bpmnlintrc: ${(error as Error).message}`),
+            );
+            this.setExternalMode(editorId);
+            this.negotiations.delete(editorId);
+            if (reflectInStatusBar) {
+                this.statusBar.showBpmnlintNoConfig();
+            }
+            this.diagnostics.clear(editorId);
+            return this.pushResults(editorId, null);
+        }
+    }
+
+    /**
+     * Cache-hit covered branch: the config version is unchanged and its settled
+     * decision is in-page, so re-assert the in-page mode and replay the last
+     * cached event (panel re-activation) — or clear + a provisional Active
+     * indicator when there is none — then re-send the instruction carrying the
+     * *same* token (the webview dedups on it; a freshly reloaded webview applies).
+     */
+    private reinstructCoveredInPage(
+        editorId: string,
+        configPath: string,
+        config: BpmnlintConfig,
+        token: string,
+        reflectInStatusBar: boolean,
+    ): Promise<boolean> {
+        this.lintModes.set(editorId, "in-page");
+        const cached = this.lastInPageEvents.get(editorId);
+        if (cached) {
+            this.applyFindings(
+                editorId,
+                cached.xml,
+                cached.results,
+                cached.unresolved,
+                reflectInStatusBar,
+                { kind: "in-page", platform: cached.platform, configPath: cached.configPath },
+            );
+        } else {
+            this.diagnostics.clear(editorId);
+            if (reflectInStatusBar) {
+                this.statusBar.showBpmnlintActive(configPath);
+            }
+        }
+        return this.postInPageInstruction(editorId, config, token);
+    }
+
+    /** Mints the next opaque config-version token. */
+    private mintToken(): string {
+        return `lint-cfg-${++this.tokenCounter}`;
+    }
+
+    /**
+     * Switches the editor to the in-page **default** path (no workspace config)
+     * and tells the webview to run its own engine-aware default. Forgets any
+     * negotiation — this is the de-escalation direction (config deleted / never
+     * present). Replays the last cached default event if one exists (panel
+     * re-activation) so the Problems panel + status bar are restored instead of
+     * blanking; a cached *covered* event (from a since-deleted config) is stale
+     * for the default tier, so it is dropped in favour of a provisional default
+     * indicator while the webview's first default run is in flight.
      */
     private instructInPage(editorId: string, reflectInStatusBar: boolean): Promise<boolean> {
         this.lintModes.set(editorId, "in-page");
+        this.negotiations.delete(editorId);
 
         const cached = this.lastInPageEvents.get(editorId);
-        if (cached) {
+        if (cached && cached.configPath === undefined) {
             this.applyFindings(
                 editorId,
                 cached.xml,
@@ -232,6 +471,7 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
                 { kind: "in-page", platform: cached.platform },
             );
         } else {
+            this.lastInPageEvents.delete(editorId);
             this.diagnostics.clear(editorId);
             if (reflectInStatusBar) {
                 const platform = this.detectPlatform(this.vsDocument.getContent(editorId));
@@ -265,6 +505,10 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
                 } else {
                     this.statusBar.showBpmnlintActive(source.configPath);
                 }
+            } else if (source.configPath !== undefined) {
+                // #1384 covered workspace tier: linted in-page, but against a real
+                // .bpmnlintrc — surface it as Active, not the zero-config default.
+                this.statusBar.showBpmnlintActive(source.configPath);
             } else {
                 this.statusBar.showBpmnlintDefault(source.platform);
             }
@@ -347,13 +591,23 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
     }
 
     /**
-     * Tells the webview to run its in-page default (#1373 Phase B). Same
+     * Tells the webview to run its in-page linter. Payload-free = the #1373
+     * engine-aware default (no workspace config); with `config` + `configToken` =
+     * the #1384 covered workspace tier, the config to lint plus the version stamp
+     * the webview echoes back on {@link UpdateLintResultsCommand}. Same
      * recoverable-drop handling as {@link pushResults}: a hidden panel makes the
      * post reject, and the webview re-requests on reload.
      */
-    private async postInPageInstruction(editorId: string): Promise<boolean> {
+    private async postInPageInstruction(
+        editorId: string,
+        config?: BpmnlintConfig,
+        configToken?: string,
+    ): Promise<boolean> {
         try {
-            return await this.editorStore.postMessage(editorId, new BpmnlintInPageQuery());
+            return await this.editorStore.postMessage(
+                editorId,
+                new BpmnlintInPageQuery(config, configToken),
+            );
         } catch (error) {
             this.notifier.logWarning(
                 `[bpmnlint] in-page instruction skipped: ${(error as Error).message}`,

--- a/libs/modeler-types/src/lint.ts
+++ b/libs/modeler-types/src/lint.ts
@@ -34,14 +34,56 @@ export type BpmnlintRuleConfig = BpmnlintRuleSeverity | readonly [BpmnlintRuleSe
  * import of bpmnlint's own types — so the published API surface does not leak a
  * transitive bpmnlint dependency. Unresolvable `extends`/`rules` degrade
  * gracefully at load and surface via {@link LintRunEvent.unresolved}.
- * Serializable when `moddleExtensions` is omitted or carries only string module
- * paths — so it can cross the webview↔host protocol as a plain data value; a
- * browser lint run reports unhonourable entries as `moddleExtension:<prefix>`.
+ * Serializable across the webview↔host protocol when `moddleExtensions` is
+ * omitted or carries only object-valued entries decoded from JSON — a
+ * string-valued entry is a Node-only module path, so it never crosses the wire:
+ * it makes {@link staticUnresolvedModdleExtensions} non-empty and escalates the
+ * session to the host linter before any config would be pushed. A browser lint
+ * run reports unhonourable entries as `moddleExtension:<prefix>`.
  */
 export interface BpmnlintConfig {
     readonly extends?: string | readonly string[];
     readonly rules?: Readonly<Record<string, BpmnlintRuleConfig>>;
     readonly moddleExtensions?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * The moddle prefixes the live bpmn-js tree already registers. The webview lints
+ * the in-memory definitions (not re-parsed XML), so any `moddleExtensions` entry
+ * targeting one of these is already satisfied — the typed properties the rules
+ * inspect are present on the tree. Everything else cannot be honoured in a
+ * browser (no `require`), so it is reported, never loaded.
+ */
+const LIVE_MODDLE_PREFIXES = new Set(["bpmn", "bpmndi", "dc", "di", "camunda", "zeebe", "modeler"]);
+
+/**
+ * The `moddleExtensions` a browser lint run cannot honour, in the same
+ * `moddleExtension:<prefix>` form the Node linter reports. A string value is a
+ * module path only Node can `require`; an object value is only usable when its
+ * prefix is one the live tree already registers (otherwise its typed properties
+ * were never parsed onto the model). Everything unhonourable is returned so it
+ * can be merged into the run's `unresolved` list — informational, never fatal.
+ *
+ * Shared verbatim by the webview (merged into every in-page run's `unresolved`)
+ * and the host ({@link BpmnLintConfigService} escalates to the Node linter
+ * without a round trip whenever this returns non-empty). Identical logic on both
+ * sides *is* the parity guarantee — the engine-blind `zeebe`/`camunda` and
+ * possibly-unregistered `modeler` caveats are intentional and must stay in sync.
+ */
+export function staticUnresolvedModdleExtensions(config: BpmnlintConfig): string[] {
+    const declared = config.moddleExtensions;
+    if (!declared || typeof declared !== "object") {
+        return [];
+    }
+    const unresolved: string[] = [];
+    for (const [prefix, value] of Object.entries(declared)) {
+        const honoured =
+            value != null && typeof value === "object" && LIVE_MODDLE_PREFIXES.has(prefix);
+        if (!honoured) {
+            unresolved.push(`moddleExtension:${prefix}`);
+        }
+    }
+    return unresolved;
 }
 
 /**

--- a/libs/shared/src/lib/modeler.ts
+++ b/libs/shared/src/lib/modeler.ts
@@ -9,7 +9,7 @@
  * - {@link DmnFileQuery}                  — deliver DMN XML for rendering
  * - {@link ElementTemplatesQuery}         — deliver the resolved element-template list
  * - {@link BpmnlintResultsQuery}          — deliver host-computed bpmnlint results (or null to deactivate)
- * - {@link BpmnlintInPageQuery}           — tell the webview to run its in-page default linter (no workspace config)
+ * - {@link BpmnlintInPageQuery}           — tell the webview to run its in-page linter (zero-config default, or a covered workspace config)
  * - {@link BpmnModelerSettingQuery}       — deliver modeler settings (e.g. alignToOrigin)
  * - {@link DmnModelerSettingQuery}         — deliver DMN modeler settings (colorTheme only)
  * - {@link PropertiesPanelStateQuery}     — deliver the global default visibility of the properties panel
@@ -42,6 +42,7 @@
 import { Command, Query } from "./messages";
 import { VariableDef } from "./processVariables";
 import type {
+    BpmnlintConfig,
     BpmnModelerSetting,
     BpmnViewerMode,
     DiffCounts,
@@ -138,22 +139,40 @@ export class BpmnLintDisabledQuery extends Query {
 }
 
 /**
- * Tells the webview to run its **own in-page default** linter because the host
- * found no workspace `.bpmnlintrc` (#1373 Phase B). Carries no payload: the
- * webview's {@link BrowserLinter} derives the engine-aware zero-config default
- * from the live modeler itself, so nothing has to travel. The webview then
- * pushes its findings back through {@link UpdateLintResultsCommand}.
+ * Tells the webview to run its **own in-page** linter. Two tiers travel on this
+ * one message:
  *
- * This replaces the previous no-config behaviour where the host lint against a
- * bundled default and pushed a {@link BpmnlintResultsQuery}. A workspace-config
- * session still lints host-side and pushes results, and any such push wins:
- * {@link BpmnlintResultsQuery} / {@link BpmnLintDisabledQuery} switch the webview
- * back to the external tier and supersede an in-page run. A later refinement
- * (#1384) may add an optional `config` here to escalate the in-page ruleset.
+ *  - **Payload-free** (#1373 Phase B) — no workspace `.bpmnlintrc`: the webview's
+ *    {@link BrowserLinter} derives the engine-aware zero-config default from the
+ *    live modeler itself, so nothing has to travel.
+ *  - **With `config`** (#1384) — a workspace `.bpmnlintrc` exists and the host's
+ *    escalation pre-check ({@link staticUnresolvedModdleExtensions}) proved the
+ *    bundled resolver can cover it: the host lints it in-page against the
+ *    supplied `config` instead of running the Node linter on every edit. If the
+ *    webview then reports non-empty `unresolved`, the host escalates that session
+ *    to the Node linter and supersedes the in-page run.
+ *
+ * `configToken` is an opaque per-session version stamp echoed back on
+ * {@link UpdateLintResultsCommand} so a stale in-page run against config V1 can
+ * never (de-)escalate a freshly edited V2 (the host mints a new token per config
+ * version). The webview treats it as an opaque value — store and echo, never
+ * interpret. Both fields are absent for the payload-free tier.
+ *
+ * The webview then pushes its findings back through {@link UpdateLintResultsCommand}.
+ * A workspace-config session that the host lints host-side (escalated tier)
+ * pushes results instead, and any such push wins: {@link BpmnlintResultsQuery} /
+ * {@link BpmnLintDisabledQuery} switch the webview back to the external tier and
+ * supersede an in-page run.
  */
 export class BpmnlintInPageQuery extends Query {
-    constructor() {
+    public readonly config?: BpmnlintConfig;
+
+    public readonly configToken?: string;
+
+    constructor(config?: BpmnlintConfig, configToken?: string) {
         super("BpmnlintInPageQuery");
+        this.config = config;
+        this.configToken = configToken;
     }
 }
 
@@ -443,24 +462,33 @@ export class SetLintingEnabledCommand extends Command {
 }
 
 /**
- * Sent by the BPMN webview after every **in-page** lint pass (the #1373 Phase B
- * default path) so the host can feed its own chrome — the VS Code Problems panel
- * and status bar — from results the webview computed. Only fired when the host
- * activated in-page linting via {@link BpmnlintInPageQuery}; a workspace-config
- * session lints host-side instead and never receives this. `unresolved` carries
- * the rules the browser resolver could not honour (informational, never fatal).
- * Hosts without a Problems surface (the IntelliJ bridge) accept it and update
- * whatever chrome they have.
+ * Sent by the BPMN webview after every **in-page** lint pass so the host can
+ * feed its own chrome — the VS Code Problems panel and status bar — from results
+ * the webview computed. Fired whenever the host activated in-page linting via
+ * {@link BpmnlintInPageQuery}, in either tier: the payload-free #1373 default or
+ * the #1384 workspace-config in-page run. An escalated workspace session lints
+ * host-side instead and never receives this. `unresolved` carries the rules the
+ * browser resolver could not honour (informational for the default tier; the
+ * escalation trigger for the #1384 workspace tier — a non-empty list flips the
+ * session to the Node linter). Hosts without a Problems surface (the IntelliJ
+ * bridge) accept it and update whatever chrome they have.
+ *
+ * `configToken` echoes the token the driving {@link BpmnlintInPageQuery} carried
+ * (absent for the payload-free default tier) so the host can pair a run with the
+ * config version it linted and drop a stale run against a superseded config.
  */
 export class UpdateLintResultsCommand extends Command {
     public readonly results: LintResults;
 
     public readonly unresolved: readonly string[];
 
-    constructor(results: LintResults, unresolved: readonly string[]) {
+    public readonly configToken?: string;
+
+    constructor(results: LintResults, unresolved: readonly string[], configToken?: string) {
         super("UpdateLintResultsCommand");
         this.results = results;
         this.unresolved = unresolved;
+        this.configToken = configToken;
     }
 }
 


### PR DESCRIPTION
## Issue

Closes #1384
Fixes #1383 

## Description

A workspace `.bpmnlintrc` the bundled resolver can cover is now pushed to the webview (`BpmnlintInPageQuery` gained an optional `config`) and linted in-page against the live moddle tree, instead of the host reparsing the XML and running `NodeBpmnLinter` on every debounced edit. The host escalates to the Node linter only when the config provably needs it — a static `moddleExtensions` pre-check (hoisted verbatim from the webview into `@miragon/bpmn-modeler-types` so both sides share the exact logic) or a non-empty `unresolved` reported by the webview's recording resolver — and caches one escalation decision per editor × config version, with `.bpmnlintrc` edits re-negotiating in both directions. An opaque config token echoed on `UpdateLintResultsCommand` drops stale in-page runs so a mid-flight config edit can never stick a clean session in the escalated tier. The policy lives in `BpmnLintConfigService`, so VS Code and the modeler-bridge inherit it identically; the bridge additionally frees the service's per-editor maps on session dispose (pre-existing leak). Covered-in-page sessions keep the `Active(configPath)` status-bar indicator, and the new parity test asserts a covered workspace config produces byte-identical findings host-side and in-page.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A — the Query/Command protocol is private per ADR 0007; no public API change)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (unit + bridge e2e coverage; no manual host run yet — IntelliJ needs the usual bundled-webview sync)