### PR TITLE
feat(bpmn-webview): make native clipboard the default, host bridge the override

### DIFF
--- a/.agent/skills/bpmn-js/SKILL.md
+++ b/.agent/skills/bpmn-js/SKILL.md
@@ -70,30 +70,36 @@ Services are accessed via `modeler.get('serviceName')`. Key services used:
 bpmn-js events use a priority system. Higher priority listeners fire first and can prevent lower-priority listeners from executing by returning `false` or calling `event.stopPropagation()`.
 
 - Default priority: `1000`
-- The element-clipboard interceptor in `VsCodeClipboardModule` uses priority
+- The element-clipboard interceptor in `BridgedClipboardModule` uses priority
   **`2051`** — intentionally above bpmn-js's `NativeCopyPaste` (priority `2050`)
   to intercept `copyPaste.elementsCopied` / `copyPaste.pasteElements` before the
   default handler runs
 
 ## Copy-Paste Architecture (Three Layers)
 
-Copy-paste in this project operates at three distinct layers. The first two are
-**bpmn-js DI modules** extracted into the shared `libs/bpmn-clipboard` package
-(`@miragon/bpmn-modeler-clipboard`) and installed as `additionalModules` in
-`apps/bpmn-webview/src/main.ts`; the third is a webview-local polyfill. The two
-DI modules receive their host bridges through didi value injection —
-`elementClipboardBridge` (element JSON) and `textClipboardBridge` (plain text),
-each a `{ requestClipboard, writeClipboard }` pair wired in `main.ts` to the
-host clipboard commands. Because bpmn-js's own `NativeCopyPaste` still handles
-the canvas natively in a plain browser, the interception only matters inside the
-sandboxed VS Code / IntelliJ webview, where the iframe has no clipboard access.
+Copy-paste in this project operates at three distinct layers. The **default is
+the native browser clipboard** — camunda-bpmn-js always registers bpmn-js's
+`NativeCopyPaste`, so a plain browser (the demo, `serve`) needs nothing extra
+(#1374). The first two layers below are the **host-bridge override**: bpmn-js DI
+modules in the shared `libs/bpmn-clipboard` package
+(`@miragon/bpmn-modeler-clipboard`), built by its `createClipboardModules({
+element, text? })` factory and registered only when the webview can't reach the
+system clipboard; the third is a webview-local polyfill. `apps/bpmn-webview/src/bootstrap.ts`
+selects between them (native for dev / `clipboard: "native"`, otherwise the
+protocol bridge). The two DI modules receive their host bridges through didi
+value injection — `elementClipboardBridge` (element JSON) and
+`textClipboardBridge` (plain text), each a `{ requestClipboard, writeClipboard }`
+pair the factory binds; `text` defaults to `element`. When registered, the
+override disables `NativeCopyPaste` (`nativeCopyPaste.toggle(false)`) and takes
+over inside the sandboxed VS Code / IntelliJ webview, where the iframe has no
+clipboard access.
 
 > Two separate host round-trips: **element** clipboard uses
 > `GetClipboardCommand` / `SetClipboardCommand` → `ClipboardQuery`; **text**
 > clipboard (labels, FEEL editor) uses `GetTextClipboardCommand` /
 > `SetTextClipboardCommand` → `TextClipboardQuery`.
 
-### Layer 1: Diagram Elements (`VsCodeClipboardModule`)
+### Layer 1: Diagram Elements (`BridgedClipboardModule`)
 
 Handles copying/pasting of BPMN shapes and connections on the canvas.
 
@@ -165,7 +171,7 @@ Theme detection uses `document.body.classList` — checking for `vscode-dark` or
 
 - **Modeler wrapper**: `apps/bpmn-webview/src/app/modeler.ts`
 - **Webview entry** (installs the clipboard modules): `apps/bpmn-webview/src/main.ts`
-- **Element clipboard module** (priority 2051, `createReviver`): `libs/bpmn-clipboard/src/VsCodeClipboardModule.ts`
+- **Element clipboard module** (priority 2051, `createReviver`): `libs/bpmn-clipboard/src/BridgedClipboardModule.ts` (built via `createClipboardModules`)
 - **Label overlay clipboard module**: `libs/bpmn-clipboard/src/LabelClipboardModule.ts`
 - **FEEL editor + Ctrl+A polyfill**: `apps/bpmn-webview/src/app/propertiesPanelClipboard.ts`
 - **Barrel exports**: `apps/bpmn-webview/src/app/index.ts`

--- a/.agent/skills/vscode-ux-guidelines/SKILL.md
+++ b/.agent/skills/vscode-ux-guidelines/SKILL.md
@@ -127,8 +127,8 @@ its host bridge through didi value injection — a `{ requestClipboard,
 writeClipboard }` pair — rather than the old `installClipboardInterceptor(...)`
 call, which no longer exists.
 
-**1. Diagram element copy/paste** (`VsCodeClipboardModule`,
-`libs/bpmn-clipboard/src/VsCodeClipboardModule.ts`, injected
+**1. Diagram element copy/paste** (`BridgedClipboardModule`,
+`libs/bpmn-clipboard/src/BridgedClipboardModule.ts`, injected
 `elementClipboardBridge`):
 
 Intercepts bpmn-js `copyPaste.elementsCopied` / `copyPaste.pasteElements` at
@@ -151,33 +151,35 @@ calls `stopPropagation()`.
 See the `/bpmn-js` skill for the full three-layer copy-paste architecture (the
 third layer is a webview-local FEEL-editor polyfill).
 
-### Wiring (Production Only)
+### Wiring (bridge override only)
 
-The bridges are wired in `apps/bpmn-webview/src/main.ts` using a promise-based
-resolver pattern, then injected as `value` providers:
+The native browser clipboard is the default (#1374); the bridge modules are only
+built when the webview can't reach the system clipboard. `apps/bpmn-webview/src/bootstrap.ts`
+wires the bridges with a promise-based resolver pattern and hands them to
+`createClipboardModules`, which returns the two DI modules + their `value`
+bindings:
 
 ```typescript
 const requestElementClipboard = async (): Promise<string> => {
-    clipboardResolver = createResolver<ClipboardQuery>();
+    elementClipboardResolver = createResolver<ClipboardQuery>();
     host.postMessage(new GetClipboardCommand());
-    return (await clipboardResolver.wait())?.text ?? "";
+    return (await elementClipboardResolver.wait())?.text ?? "";
 };
 const writeElementClipboard = (text: string): void => {
     host.postMessage(new SetClipboardCommand(text));
 };
 // (text bridge mirrors this with the *Text* commands / TextClipboardQuery)
 
-clipboardModules = [
-    VsCodeClipboardModule,
-    LabelClipboardModule,
-    {
-        elementClipboardBridge: ["value", { requestClipboard: requestElementClipboard, writeClipboard: writeElementClipboard }],
-        textClipboardBridge: ["value", { requestClipboard: requestTextClipboard, writeClipboard: writeTextClipboard }],
-    },
-];
+clipboardModules = createClipboardModules({
+    element: { requestClipboard: requestElementClipboard, writeClipboard: writeElementClipboard },
+    text: { requestClipboard: requestTextClipboard, writeClipboard: writeTextClipboard },
+});
 ```
 
-These modules are only added in production (not development) because in dev mode the webview runs in a regular browser with native clipboard access.
+bootstrap selects the native path (no modules) for dev builds and for a
+`clipboard: "native"` consumer (the demo); a real host gets the protocol bridge
+above. The single-bridge public override (`clipboard: { bridge }`) maps onto both
+channels because `createClipboardModules` defaults `text` to `element`.
 
 ## Webview Theming
 

--- a/apps/bpmn-webview/package.json
+++ b/apps/bpmn-webview/package.json
@@ -47,6 +47,8 @@
     "devDependencies": {
         "@types/vscode-webview": "1.57.5",
         "@vitest/coverage-v8": "4.1.9",
+        "bpmn-js-native-copy-paste": "0.3.0",
+        "didi": "11.0.0",
         "jsdom": "30.0.1",
         "typescript": "6.0.3",
         "vite": "8.1.0",

--- a/apps/bpmn-webview/src/app/bridgedClipboard.spec.ts
+++ b/apps/bpmn-webview/src/app/bridgedClipboard.spec.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Injector } from "didi";
+import { BpmnModdle } from "bpmn-moddle";
+import { createClipboardModules, type ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
+
+/**
+ * Behavioural spec for the bridge-path clipboard module (`BridgedClipboard`,
+ * #1374). The class is private to the lib, so it is exercised through the same
+ * DI wiring the webview uses: `createClipboardModules` yields the module, and a
+ * didi injector instantiates it against fake bpmn-js services + a real
+ * `bpmn-moddle` (the reviver needs genuine type descriptors).
+ *
+ * The prefixed-JSON payload asserted here is byte-identical to upstream
+ * `bpmn-js-native-copy-paste` — that wire compatibility is the point of #1374.
+ */
+
+const CLIP_PREFIX = "bpmn-js-clip----";
+
+/** A fake EventBus that records handlers and lets a test fire them synchronously. */
+class FakeEventBus {
+    private readonly handlers = new Map<string, ((context: unknown) => unknown)[]>();
+
+    on(
+        event: string,
+        priorityOrHandler: unknown,
+        maybeHandler?: (context: unknown) => unknown,
+    ): void {
+        const handler = (maybeHandler ?? priorityOrHandler) as (context: unknown) => unknown;
+        const list = this.handlers.get(event) ?? [];
+        list.push(handler);
+        this.handlers.set(event, list);
+    }
+
+    fire(event: string, context: unknown): unknown {
+        let result: unknown;
+        for (const handler of this.handlers.get(event) ?? []) {
+            result = handler(context);
+        }
+        return result;
+    }
+}
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+function bridgeSpies(clipboardText: string): {
+    bridge: ClipboardBridge;
+    requestClipboard: ReturnType<typeof vi.fn>;
+    writeClipboard: ReturnType<typeof vi.fn>;
+} {
+    const requestClipboard = vi.fn<() => Promise<string>>().mockResolvedValue(clipboardText);
+    const writeClipboard = vi.fn<(text: string) => void>();
+    return { bridge: { requestClipboard, writeClipboard }, requestClipboard, writeClipboard };
+}
+
+function instantiate(bridge: ClipboardBridge): {
+    eventBus: FakeEventBus;
+    copyPaste: { paste: ReturnType<typeof vi.fn> };
+    nativeCopyPaste: { toggle: ReturnType<typeof vi.fn> };
+} {
+    const eventBus = new FakeEventBus();
+    const copyPaste = { paste: vi.fn() };
+    const nativeCopyPaste = { toggle: vi.fn() };
+    const canvas = { focus: vi.fn() };
+    const moddle = BpmnModdle();
+
+    const [BridgedClipboardModule] = createClipboardModules({ element: bridge });
+
+    const injector = new Injector([
+        BridgedClipboardModule,
+        {
+            elementClipboardBridge: ["value", bridge],
+            eventBus: ["value", eventBus],
+            copyPaste: ["value", copyPaste],
+            moddle: ["value", moddle],
+            nativeCopyPaste: ["value", nativeCopyPaste],
+            canvas: ["value", canvas],
+        },
+    ] as never);
+    injector.init();
+
+    return { eventBus, copyPaste, nativeCopyPaste };
+}
+
+/** A minimal but real copyTree: one bpmn:Task descriptor at depth 0. */
+const TREE = {
+    "0": [{ businessObject: { $type: "bpmn:Task", id: "Task_1", name: "Do work" } }],
+};
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+});
+
+describe("BridgedClipboard", () => {
+    it("disables the native copy-paste layer on construction", () => {
+        const { nativeCopyPaste } = instantiate(bridgeSpies("").bridge);
+        expect(nativeCopyPaste.toggle).toHaveBeenCalledWith(false);
+    });
+
+    it("writes prefixed JSON and marks the copy handled on elementsCopied", () => {
+        const { bridge, writeClipboard } = bridgeSpies("");
+        const { eventBus } = instantiate(bridge);
+
+        const context: { tree: unknown; hints: { clip?: boolean } } = { tree: TREE, hints: {} };
+        eventBus.fire("copyPaste.elementsCopied", context);
+
+        expect(writeClipboard).toHaveBeenCalledWith(CLIP_PREFIX + JSON.stringify(TREE));
+        expect(context.hints.clip).toBe(false);
+    });
+
+    it("revives prefixed clipboard JSON into copyPaste.paste with the snapshotted context", async () => {
+        const { bridge } = bridgeSpies(CLIP_PREFIX + JSON.stringify(TREE));
+        const { eventBus, copyPaste } = instantiate(bridge);
+
+        const result = eventBus.fire("copyPaste.pasteElements", { point: { x: 1, y: 2 } });
+        expect(result).toBe(false);
+
+        await flush();
+
+        expect(copyPaste.paste).toHaveBeenCalledTimes(1);
+        const pasted = copyPaste.paste.mock.calls[0][0] as {
+            point: unknown;
+            tree: Record<string, { businessObject: { $type: string; set?: unknown } }[]>;
+        };
+        expect(pasted.point).toEqual({ x: 1, y: 2 });
+        // The revived node is a real moddle instance, not the raw descriptor.
+        const revived = pasted.tree["0"][0].businessObject;
+        expect(revived.$type).toBe("bpmn:Task");
+        expect(typeof revived.set).toBe("function");
+    });
+
+    it("does nothing when the clipboard text lacks the prefix", async () => {
+        const { bridge } = bridgeSpies("just some plain text");
+        const { eventBus, copyPaste } = instantiate(bridge);
+
+        eventBus.fire("copyPaste.pasteElements", {});
+        await flush();
+
+        expect(copyPaste.paste).not.toHaveBeenCalled();
+    });
+
+    it("fails soft on a prefixed but unparseable payload — logs, never throws", async () => {
+        const { bridge } = bridgeSpies(CLIP_PREFIX + "not-valid-json{");
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+        const { eventBus, copyPaste } = instantiate(bridge);
+
+        expect(() => eventBus.fire("copyPaste.pasteElements", {})).not.toThrow();
+        await flush();
+
+        expect(errorSpy).toHaveBeenCalled();
+        expect(copyPaste.paste).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when the paste context already carries a tree (re-triggered paste)", () => {
+        const { bridge, requestClipboard } = bridgeSpies(CLIP_PREFIX + JSON.stringify(TREE));
+        const { eventBus, copyPaste } = instantiate(bridge);
+
+        const result = eventBus.fire("copyPaste.pasteElements", { tree: TREE });
+
+        expect(result).toBeUndefined();
+        expect(requestClipboard).not.toHaveBeenCalled();
+        expect(copyPaste.paste).not.toHaveBeenCalled();
+    });
+});

--- a/apps/bpmn-webview/src/app/clipboardModules.spec.ts
+++ b/apps/bpmn-webview/src/app/clipboardModules.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { createClipboardModules, type ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
+
+/**
+ * Contract of the clipboard-override factory (#1374). The two DI modules and
+ * the value bindings are the whole surface bootstrap/createModeler rely on; the
+ * `text ?? element` default is what lets the frozen single-bridge public API map
+ * onto the two protocol channels a webview host actually needs.
+ */
+
+function fakeBridge(): ClipboardBridge {
+    return { requestClipboard: () => Promise.resolve(""), writeClipboard: () => undefined };
+}
+
+describe("createClipboardModules", () => {
+    it("returns the two DI modules plus one value binding", () => {
+        const modules = createClipboardModules({ element: fakeBridge() }) as Record<
+            string,
+            unknown
+        >[];
+
+        expect(modules).toHaveLength(3);
+        expect(modules[0]).toHaveProperty("bridgedClipboard");
+        expect(modules[1]).toHaveProperty("labelClipboard");
+        expect(modules[2]).toHaveProperty("elementClipboardBridge");
+        expect(modules[2]).toHaveProperty("textClipboardBridge");
+    });
+
+    it("binds the element bridge to the element clipboard value", () => {
+        const element = fakeBridge();
+
+        const [, , values] = createClipboardModules({ element }) as Record<string, unknown[]>[];
+
+        expect(values.elementClipboardBridge).toEqual(["value", element]);
+    });
+
+    it("defaults the text bridge to the element bridge when `text` is omitted", () => {
+        const element = fakeBridge();
+
+        const [, , values] = createClipboardModules({ element }) as Record<string, unknown[]>[];
+
+        expect(values.textClipboardBridge).toEqual(["value", element]);
+        expect(values.textClipboardBridge[1]).toBe(element);
+    });
+
+    it("binds distinct bridges when both element and text are supplied", () => {
+        const element = fakeBridge();
+        const text = fakeBridge();
+
+        const [, , values] = createClipboardModules({ element, text }) as Record<
+            string,
+            unknown[]
+        >[];
+
+        expect(values.elementClipboardBridge[1]).toBe(element);
+        expect(values.textClipboardBridge[1]).toBe(text);
+    });
+});

--- a/apps/bpmn-webview/src/app/clipboardWireFormat.spec.ts
+++ b/apps/bpmn-webview/src/app/clipboardWireFormat.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { BpmnModdle } from "bpmn-moddle";
+import { createReviver } from "bpmn-js-native-copy-paste/lib/PasteUtil.js";
+import camundaModdle from "camunda-bpmn-moddle/resources/camunda.json";
+import zeebeModdle from "zeebe-bpmn-moddle/resources/zeebe.json";
+
+/**
+ * Executable statement of the cross-engine clipboard policy (#1374): unsupported,
+ * fails soft. The wire format is engine-agnostic — a Camunda-7 element pasted
+ * into a Camunda-8 modeler revives its shared bpmn: base, and the reviver
+ * silently drops every extension node whose `$type` the target moddle does not
+ * know (`camunda:*` in a C8 moddle), replacing it with `null` rather than
+ * throwing. This spec is the policy; the README describes what it proves.
+ *
+ * The fixture is a real moddle serialisation, not a hand-written string: a C7
+ * service task with `camunda:class` and a `camunda:Properties` extension,
+ * serialised exactly as `NativeCopyPaste`/`BridgedClipboard` do
+ * (`JSON.stringify(copyTree)`).
+ */
+
+const c7Moddle = (): ReturnType<typeof BpmnModdle> => BpmnModdle({ camunda: camundaModdle });
+const c8Moddle = (): ReturnType<typeof BpmnModdle> => BpmnModdle({ zeebe: zeebeModdle });
+
+/** Builds the copyTree a C7 service-task copy produces, then serialises it. */
+function c7ServiceTaskPayload(): string {
+    const moddle = c7Moddle();
+    const property = moddle.create("camunda:Property", { name: "foo", value: "bar" });
+    const properties = moddle.create("camunda:Properties", { values: [property] });
+    const extensionElements = moddle.create("bpmn:ExtensionElements", { values: [properties] });
+    const businessObject = moddle.create("bpmn:ServiceTask", {
+        id: "ServiceTask_1",
+        name: "Call",
+        class: "com.acme.Handler",
+        extensionElements,
+    });
+    const tree = { "0": [{ businessObject, id: "ServiceTask_1", name: "Call" }] };
+    return JSON.stringify(tree);
+}
+
+type RevivedTree = Record<string, { businessObject: Record<string, any> }[]>;
+
+describe("clipboard wire format — cross-engine paste policy", () => {
+    it("serialises a copyTree the reviver can read back (round-trip is the wire contract)", () => {
+        const json = c7ServiceTaskPayload();
+        expect(json).toContain('"$type":"bpmn:ServiceTask"');
+        expect(json).toContain('"$type":"camunda:Properties"');
+    });
+
+    it("C7 → C7: keeps the camunda extension untouched", () => {
+        const revived = JSON.parse(
+            c7ServiceTaskPayload(),
+            createReviver(c7Moddle()),
+        ) as RevivedTree;
+        const bo = revived["0"][0].businessObject;
+
+        expect(bo.$type).toBe("bpmn:ServiceTask");
+        expect(bo.class).toBe("com.acme.Handler");
+        const values = bo.extensionElements.values as { $type: string; values: unknown[] }[];
+        expect(values[0].$type).toBe("camunda:Properties");
+        expect(values[0].values[0]).toMatchObject({
+            $type: "camunda:Property",
+            name: "foo",
+            value: "bar",
+        });
+    });
+
+    it("C7 → C8: revives the shared bpmn base and drops the unknown camunda nodes without throwing", () => {
+        const payload = c7ServiceTaskPayload();
+        let revived: RevivedTree | undefined;
+
+        expect(() => {
+            revived = JSON.parse(payload, createReviver(c8Moddle())) as RevivedTree;
+        }).not.toThrow();
+
+        const bo = revived!["0"][0].businessObject;
+        // The shared bpmn: base survives...
+        expect(bo.$type).toBe("bpmn:ServiceTask");
+        // ...but the camunda: extension node is unknown to a C8 moddle and is
+        // dropped: the reviver returns undefined for the unknown $type, leaving a
+        // hole in the array (reads as `undefined`; re-serialises to `null`).
+        const values = bo.extensionElements.values as unknown[];
+        expect(values).toHaveLength(1);
+        expect(values[0]).toBeUndefined();
+    });
+});

--- a/apps/bpmn-webview/src/app/createModeler.ts
+++ b/apps/bpmn-webview/src/app/createModeler.ts
@@ -1,6 +1,6 @@
 import type { BpmnModelerSetting, LintRunEvent } from "@miragon/bpmn-modeler-types";
 import type { ModelerCapabilities } from "./capabilities";
-import type { LintingOptions } from "./publicApi";
+import type { ClipboardOptions, LintingOptions } from "./publicApi";
 import { BpmnModeler } from "./modeler";
 
 /**
@@ -22,6 +22,8 @@ export interface CreateModelerOptions {
      * in-page linting is on with the engine-aware default config.
      */
     linting?: LintingOptions;
+    /** [B] Clipboard override — omit for the native browser clipboard (#1374). */
+    clipboard?: ClipboardOptions;
     /**
      * Fired after every in-page lint run with the raw rule-keyed results and the
      * rules the bundled resolver could not cover. Never fires for an external

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -10,6 +10,7 @@ import { AppendMenuModule } from "@miragon/bpmn-modeler-append-menu";
 import { type CodeLinkMapClient } from "@miragon/bpmn-modeler-code-link";
 import { FlowNavigationModule } from "@miragon/bpmn-modeler-flow-navigation";
 import { CreateAppendC7ElementTemplatesModule } from "@miragon/create-append-c7";
+import { createClipboardModules } from "@miragon/bpmn-modeler-clipboard";
 import {
     BpmnlintConfig,
     BpmnModelerSetting,
@@ -168,6 +169,12 @@ export class BpmnModeler {
             propertiesPanelRootModule,
         ];
         const capModules = capabilityModules(engine, this.options.capabilities);
+        // Clipboard is a [B] built-in: omitting `clipboard` registers nothing, so
+        // bpmn-js's native (browser) clipboard stays in charge (#1374); a host that
+        // can't reach the system clipboard from its webview supplies a bridge.
+        const clipModules = this.options.clipboard
+            ? createClipboardModules({ element: this.options.clipboard.bridge })
+            : [];
         const extra = (this.options.extraModules as any[]) ?? [];
 
         const modelerOptions = {
@@ -188,6 +195,7 @@ export class BpmnModeler {
                         CreateAppendC7ElementTemplatesModule,
                         TransactionBoundariesModule,
                         ...capModules,
+                        ...clipModules,
                         ...extra,
                     ],
                 });
@@ -196,7 +204,7 @@ export class BpmnModeler {
             case "c8": {
                 this.modeler = new BpmnModeler8({
                     ...modelerOptions,
-                    additionalModules: [...commonModules, ...capModules, ...extra],
+                    additionalModules: [...commonModules, ...capModules, ...clipModules, ...extra],
                 });
                 break;
             }

--- a/apps/bpmn-webview/src/app/publicApi.spec.ts
+++ b/apps/bpmn-webview/src/app/publicApi.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { ModelNavigationPort } from "@miragon/bpmn-model-navigation";
 import { BpmnModeler } from "./modeler";
+import type { CreateModelerOptions } from "./createModeler";
 import type {
     BpmnModelerHandle,
     ClipboardOptions,
@@ -89,6 +90,17 @@ void [_lintOff, _lintExternal, _lintConfig];
 const _clipboard: ClipboardOptions = {
     bridge: { requestClipboard: () => Promise.resolve(""), writeClipboard: () => undefined },
 };
+// The runtime factory (#1374) accepts the same clipboard override — omit it for
+// the native browser clipboard, or pass `{ bridge }` to route through a host.
+const _createWithClipboard = {
+    propertiesPanelParent: document.createElement("div"),
+    clipboard: _clipboard,
+} satisfies CreateModelerOptions;
+void _createWithClipboard;
+const _createNativeClipboard = {
+    propertiesPanelParent: document.createElement("div"),
+} satisfies CreateModelerOptions;
+void _createNativeClipboard;
 const _builtinsShape = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -61,7 +61,7 @@ import {
     observeCanvasSize,
     setColorThemeMode,
 } from "@miragon/bpmn-modeler-types";
-import { VsCodeClipboardModule, LabelClipboardModule } from "@miragon/bpmn-modeler-clipboard";
+import { createClipboardModules } from "@miragon/bpmn-modeler-clipboard";
 import { TranslateModule, i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
 import { extras as i18nExtras } from "@miragon/bpmn-modeler-i18n-extras";
 import {
@@ -73,7 +73,7 @@ import {
 import type { HostApi } from "@miragon/bpmn-modeler-shared";
 import type { LintRunEvent, ResizableCanvas } from "@miragon/bpmn-modeler-types";
 import type { ModelerCapabilities } from "./app/capabilities";
-import type { LintingOptions } from "./app";
+import type { ClipboardOptions, LintingOptions } from "./app";
 import type { WebviewState } from "./app/webviewState";
 import { DiffMode } from "./app/diff/DiffMode";
 import { installHostEditorActions } from "./app/hostEditorActions";
@@ -92,6 +92,7 @@ export function bootstrap(
         extraModules?: unknown[];
         capabilities?: ModelerCapabilities;
         linting?: LintingOptions;
+        clipboard?: ClipboardOptions | "native";
         onLintResults?: (event: LintRunEvent) => void;
     } = {},
 ): void {
@@ -100,6 +101,7 @@ export function bootstrap(
         opts.extraModules,
         opts.capabilities,
         opts.linting,
+        opts.clipboard,
         opts.onLintResults,
     );
 }
@@ -118,6 +120,10 @@ export function bootstrap(
  *   the full protocol adapter so every real host keeps all features.
  * @param injectedLinting The bpmnlint tier; `undefined` selects the external
  *   (host-pushed) tier so every real host stays byte-identical to today.
+ * @param injectedClipboard The clipboard tier; `undefined` keeps today's
+ *   behaviour (dev-build native, otherwise the protocol bridge). `"native"`
+ *   forces the browser clipboard (demo/browser consumers, #1374); `{ bridge }`
+ *   routes through a caller-supplied override.
  * @param injectedOnLintResults In-page lint-run sink; only a consumer opting into
  *   in-page linting (the demo) passes one. Real hosts run the linter themselves.
  */
@@ -126,6 +132,7 @@ function startSession(
     injectedModules: unknown[] | undefined,
     injectedCapabilities: ModelerCapabilities | undefined,
     injectedLinting: LintingOptions | undefined,
+    injectedClipboard: ClipboardOptions | "native" | undefined,
     injectedOnLintResults: ((event: LintRunEvent) => void) | undefined,
 ): void {
     // Assigned in run() once the engine is known — flush/capability callbacks
@@ -318,11 +325,25 @@ function startSession(
         // hidden by .viewer-mode CSS once we confirm the mode below. For the
         // modeler path, initResizer() is called after the branch check.
 
-        // Build clipboard DI modules conditionally.
-        // In development (plain browser) NativeCopyPaste handles clipboard natively.
-        let clipboardModules: any[] | undefined;
+        // Build clipboard DI modules.
+        //
+        // - `undefined` (default): today's behavior — in dev (plain-browser
+        //   `serve`) the native browser clipboard handles copy/paste, so no
+        //   modules load; otherwise route through the host protocol bridge.
+        // - `"native"`: force the browser clipboard (demo/browser consumers) —
+        //   no modules, no polyfill.
+        // - `{ bridge }`: public override — one bridge drives both the element
+        //   modules and the contenteditable polyfill.
+        let clipboardModules: unknown[] | undefined;
 
-        if (process.env.NODE_ENV !== "development") {
+        if (injectedClipboard === "native") {
+            // Native browser clipboard: register nothing so bpmn-js's
+            // NativeCopyPaste stays in charge (#1374).
+        } else if (injectedClipboard) {
+            const { bridge } = injectedClipboard;
+            clipboardModules = createClipboardModules({ element: bridge });
+            installContentEditableClipboardPolyfill(bridge.requestClipboard, bridge.writeClipboard);
+        } else if (process.env.NODE_ENV !== "development") {
             const requestElementClipboard = async (): Promise<string> => {
                 elementClipboardResolver = createResolver<ClipboardQuery>();
                 host.postMessage(new GetClipboardCommand());
@@ -343,26 +364,18 @@ function startSession(
                 host.postMessage(new SetTextClipboardCommand(text));
             };
 
-            clipboardModules = [
-                VsCodeClipboardModule,
-                LabelClipboardModule,
-                {
-                    elementClipboardBridge: [
-                        "value",
-                        {
-                            requestClipboard: requestElementClipboard,
-                            writeClipboard: writeElementClipboard,
-                        },
-                    ],
-                    textClipboardBridge: [
-                        "value",
-                        {
-                            requestClipboard: requestTextClipboard,
-                            writeClipboard: writeTextClipboard,
-                        },
-                    ],
+            // Two independent protocol channels so element and label clipboards
+            // stay separate — byte-identical to today's real-host wiring.
+            clipboardModules = createClipboardModules({
+                element: {
+                    requestClipboard: requestElementClipboard,
+                    writeClipboard: writeElementClipboard,
                 },
-            ];
+                text: {
+                    requestClipboard: requestTextClipboard,
+                    writeClipboard: writeTextClipboard,
+                },
+            });
 
             /**
              * The FEEL editor (CodeMirror 6) in the C8 properties panel lives

--- a/apps/bpmn-webview/src/types/bpmn-moddle.d.ts
+++ b/apps/bpmn-webview/src/types/bpmn-moddle.d.ts
@@ -19,8 +19,15 @@ declare module "bpmn-moddle" {
         warnings: unknown[];
     }
 
+    interface ModdleElement {
+        $type: string;
+        [key: string]: unknown;
+    }
+
     interface BpmnModdleInstance {
         fromXML(xml: string): Promise<ParseResult>;
+        create(type: string, attrs?: Record<string, unknown>): ModdleElement;
+        getTypeDescriptor(type: string): unknown;
     }
 
     type BpmnModdleFactory = (

--- a/apps/bpmn-webview/vitest.config.ts
+++ b/apps/bpmn-webview/vitest.config.ts
@@ -31,6 +31,10 @@ export default defineConfig({
                 __dirname,
                 "../../libs/inline-scripting/src/index.ts",
             ),
+            "@miragon/bpmn-modeler-clipboard": resolve(
+                __dirname,
+                "../../libs/bpmn-clipboard/src/index.ts",
+            ),
         },
         coverage: {
             provider: "v8",

--- a/apps/demo-webapp/bpmn/demoHost.ts
+++ b/apps/demo-webapp/bpmn/demoHost.ts
@@ -1,7 +1,6 @@
 import {
     BpmnFileQuery,
     BpmnModelerSettingQuery,
-    ClipboardQuery,
     Command,
     ElementTemplatesQuery,
     MockHostApi,
@@ -22,7 +21,9 @@ function dispatch(event: MessageType): void {
  * Model navigation is wired through the `modelNavigation` capability in
  * `main.ts` (which resolves against the model registry and swaps the page), so
  * it no longer crosses this message boundary. Everything else a real host does —
- * deployment, code-link, script editor, clipboard, persistence — is a no-op here.
+ * deployment, code-link, script editor, persistence — is a no-op here. Clipboard
+ * is not bridged at all: the demo opts into the native browser clipboard
+ * (`clipboard: "native"` in main.ts, #1374).
  */
 export class BpmnDemoHost extends MockHostApi<WebviewState, MessageType> {
     override updateState(state: Partial<WebviewState>): void {
@@ -54,9 +55,6 @@ export class BpmnDemoHost extends MockHostApi<WebviewState, MessageType> {
                 break;
             case "GetPropertiesPanelStateCommand":
                 dispatch(new PropertiesPanelStateQuery(true));
-                break;
-            case "GetClipboardCommand":
-                dispatch(new ClipboardQuery(""));
                 break;
             // Deliberately no GetBpmnlintConfigCommand reply: the demo lints
             // in-page (`linting: {}`), and an external results/null push would

--- a/apps/demo-webapp/bpmn/main.ts
+++ b/apps/demo-webapp/bpmn/main.ts
@@ -14,6 +14,10 @@ mountDemoHeader("bpmn");
 bootstrap(new BpmnDemoHost(), {
     extraModules: [DemoGrayoutModule],
     linting: {},
+    // Plain-browser demo: use the native browser clipboard (#1374). The stub
+    // host cannot serve a real clipboard, so the protocol-bridge default would
+    // leave paste dead in the production build.
+    clipboard: "native",
     onLintResults: ({ results, unresolved }) => {
         console.debug("[demo] in-page lint", { results, unresolved });
     },

--- a/docs/adr/0007-public-modeler-api.md
+++ b/docs/adr/0007-public-modeler-api.md
@@ -191,7 +191,7 @@ follow-up (see below).
   | `setElementTemplates(JSON[] \| undefined)` | `setElementTemplates(object[])` | #1376 |
   | page-level `initTheme`/`setColorThemeMode` | `theme` option + `setTheme()` | #1376/#1377 |
   | page-level `i18n.setLanguage` + `TranslateModule` | `locale` option | #1376 |
-  | `VsCodeClipboardModule` via `extraModules` | `clipboard: { bridge }` | #1374 |
+  | `BridgedClipboardModule` (was `VsCodeClipboardModule`) via `extraModules`, built by `createClipboardModules` | `clipboard: { bridge }` | #1374 ✅ |
 
 - The capability ports widen to `void | Promise<void>` now (a small, real,
   behaviour-neutral change — all callers already ignore the return value), so
@@ -208,7 +208,9 @@ follow-up (see below).
 ## Follow-ups
 
 - #1373 — linting tier ladder + `onLintResults`/`onLintingToggled` runtime.
-- #1374 — clipboard polarity flip (native default, `clipboard: { bridge }`).
+- #1374 — clipboard polarity flip (native default, `clipboard: { bridge }`). ✅
+  Landed: `createClipboardModules` factory + `BridgedClipboardModule`;
+  `libs/bpmn-clipboard/README.md` documents the wire format as a public contract.
 - #1376 — package workspace; collapse `create(engine)` into the async factory;
   apply the rename/reshape map; wire a `tsc` type-check gate for the package.
 - #1377 — relocate the VS Code `<body>`-class theme watcher to the host adapter;

--- a/docs/vscode/contributing/architecture-overview.md
+++ b/docs/vscode/contributing/architecture-overview.md
@@ -59,7 +59,7 @@ libs/
 | `@miragon/bpmn-modeler-bridge` | `apps/modeler-bridge` | Out-of-process stdio JSON-RPC bridge running `modeler-core` for the IntelliJ host; ships as a Node-free Bun binary |
 | `@miragon/bpmn-modeler-shared` | `libs/shared` | Message types, cross-process utilities |
 | `@miragon/bpmn-modeler-core` | `libs/modeler-core` | Host-agnostic modeling engine (domain + services + ports), consumed by the VS Code plugin and the IntelliJ bridge |
-| `@miragon/bpmn-modeler-clipboard` | `libs/bpmn-clipboard` | bpmn-js DI module for clipboard integration |
+| `@miragon/bpmn-modeler-clipboard` | `libs/bpmn-clipboard` | Host-bridge clipboard override (native browser clipboard is the default; registered only when the webview can't reach the system clipboard) |
 | `@miragon/bpmn-modeler-i18n` | `libs/bpmn-i18n` | bpmn-js DI module for translations |
 | `@miragon/bpmn-modeler-append-menu` | `libs/append-menu` | Preact-based append menu overlay |
 | `@miragon/bpmn-modeler-element-template-chooser` | `libs/element-template-chooser` | Preact-based template chooser overlay |
@@ -179,9 +179,10 @@ new BpmnModeler({ additionalModules: [MyModule, ...] });
 
 **Event priorities.** Many bpmn-js services use `EventBus` handlers with a
 numeric priority. Higher priority runs first. Returning a non-`undefined` value
-(including `false`) stops propagation. This is how `VsCodeClipboardModule`
-intercepts copy at priority 2051 (above `NativeCopyPaste`'s 2050) — see
-`libs/bpmn-clipboard/` in the repository.
+(including `false`) stops propagation. This is how `BridgedClipboardModule`
+(the host-bridge clipboard override, registered only when the webview can't
+reach the system clipboard) intercepts copy at priority 2051 (above
+`NativeCopyPaste`'s 2050) — see `libs/bpmn-clipboard/` in the repository.
 
 **Patching existing services.** Several of our modules decorate a core bpmn-js
 method rather than adding a new service — e.g. `AppendMenuOverride` wraps

--- a/libs/README.md
+++ b/libs/README.md
@@ -22,7 +22,7 @@ can be composed into a webview and unit-tested in isolation.
 | --- | --- |
 | `append-menu` | This replaces the flat "Append element" dropdown with a two-panel Preact overlay. |
 | `element-template-chooser` | This provides a richer, searchable overlay for picking an element template. |
-| `bpmn-clipboard` | This makes copy and paste of elements and label text work inside the sandboxed webview iframe. |
+| `bpmn-clipboard` | Host-bridge override for element and label-text copy/paste; the native browser clipboard is the default, this routes it through the host when a sandboxed webview iframe can't reach the system clipboard. |
 | `code-link` | This adds a "Go to implementation" context-pad action that jumps to the task's source file. |
 | `inline-scripting` | This lets the user edit a Camunda 7 script task's (or script-typed listener's) inline script in a real host editor tab, arbitrating a single writer per script surface and keeping the panel field in sync. |
 | `model-navigation` | This adds a "Navigate to referenced model" action, jumping from a Call Activity to its BPMN process or from a Business Rule Task to its DMN decision. |

--- a/libs/bpmn-clipboard/README.md
+++ b/libs/bpmn-clipboard/README.md
@@ -1,68 +1,132 @@
 # `@miragon/bpmn-modeler-clipboard`
 
-Makes copy/paste work inside the BPMN editor when it runs in a VS Code webview
-iframe — both **diagram elements** (copy a shape/connection in one editor tab,
-paste it into another) and **label text** while direct-editing an element name.
-Inside a sandboxed webview `navigator.clipboard` is unusable (the iframe lacks
-`clipboard-read`/`clipboard-write` permissions), so neither bpmn-js's native
-copy-paste nor contenteditable's default clipboard handling can reach the
-system clipboard on their own.
+The **host-bridge override** for BPMN element and label-text copy/paste. By
+default the modeler uses bpmn-js's own native browser clipboard — this package
+is only registered when the modeler runs somewhere the system clipboard is out
+of reach from the diagram (a sandboxed webview iframe lacking
+`clipboard-read`/`clipboard-write`, e.g. VS Code / IntelliJ / Theia). It routes
+copy/paste through a `ClipboardBridge` the host wires to its own clipboard.
 
-## How it works
+## Polarity: native default, bridge override (#1374)
 
-The library routes every clipboard access through a `ClipboardBridge`
-(`requestClipboard` / `writeClipboard`) that the host wires to `postMessage`,
-so the real clipboard call (`vscode.env.clipboard`) happens on the extension
-host, outside the iframe. It ships two DI modules:
+Clipboard is a category-[B] *opinionated built-in* (ADR 0007): on by default,
+one override away.
 
-- **`VsCodeClipboardModule`** disables bpmn-js's `NativeCopyPaste`
-  (`nativeCopyPaste.toggle(false)`) and takes over at EventBus priority **2051**
-  (just above the disabled layer's 2050): on `copyPaste.elementsCopied` it
-  serialises the element tree to prefixed JSON and writes it through the bridge;
-  on `copyPaste.pasteElements` it reads back and revives it. It also intercepts
-  the DOM `copy` event in the **capture phase** so VS Code's own webview handler
-  can't overwrite the serialised BPMN with stale DOM text.
-- **`LabelClipboardModule`** attaches a capture-phase `keydown` listener to the
-  contenteditable label on `directEditing.activate`, so Cmd/Ctrl+C/V/A are
-  routed through the bridge *before* diagram-js's `DirectEditing._handleKey`
+- **Native (default).** camunda-bpmn-js always registers bpmn-js's
+  `NativeCopyPaste` (both C7 and C8). Registering **nothing** from this package
+  leaves it in charge — zero extra code, full wire compatibility. This is what a
+  plain browser (the demo, `serve`) gets.
+- **Bridged (override).** A host that can't reach the system clipboard from its
+  webview calls `createClipboardModules({ element, text? })` and adds the result
+  to `additionalModules`. This disables `NativeCopyPaste`
+  (`nativeCopyPaste.toggle(false)`) and takes over the same EventBus events at
+  priority **2051** (just above the disabled layer's 2050).
+
+The package exports exactly the factory and the bridge type; the DI value names
+(`elementClipboardBridge` / `textClipboardBridge`) are an internal detail.
+
+### What the override ships
+
+`createClipboardModules` returns two DI modules plus their value bindings:
+
+- **`BridgedClipboardModule`** — diagram elements. On `copyPaste.elementsCopied`
+  it serialises the element tree to prefixed JSON and writes it through the
+  bridge; on `copyPaste.pasteElements` it reads back and revives it. It also
+  intercepts the DOM `copy` event in the **capture phase** so VS Code's own
+  webview handler can't overwrite the serialised BPMN with stale DOM text, and
+  re-focuses the canvas after keyboard selection changes (both are
+  bridge-path-only repairs — never active on the native path).
+- **`LabelClipboardModule`** — contenteditable label text. Attaches a
+  capture-phase `keydown` listener on `directEditing.activate`, so Cmd/Ctrl+C/V/A
+  are routed through the bridge *before* diagram-js's `DirectEditing._handleKey`
   calls `stopPropagation()`.
 
-It binds two independent bridges, `elementClipboardBridge` and
-`textClipboardBridge`, so element and label clipboards stay separate.
-
-## Why this lives in its own library
-
-- **The bridge indirection is the whole point.** The webview half (these
-  modules) and the host half (`vscode.env.clipboard`) live on opposite sides of
-  the iframe boundary; isolating the webview half behind a small `ClipboardBridge`
-  interface keeps the diagram code free of webview message types and makes the
-  modules trivially mockable.
-- **It is opt-in per host.** In plain-browser dev mode the modules simply aren't
-  loaded and bpmn-js's `NativeCopyPaste` handles the clipboard natively. That
-  conditional wiring is cleaner as a separate package than as dead branches in
-  the webview.
+Two bridges are bound so element and label clipboards stay separate;
+`createClipboardModules` defaults `text` to `element`, so the single-bridge
+public API maps straight onto both channels.
 
 ## Usage
 
 ```ts
-import {
-    VsCodeClipboardModule,
-    LabelClipboardModule,
-    type ClipboardBridge,
-} from "@miragon/bpmn-modeler-clipboard";
+import { createClipboardModules, type ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
 
-const elementClipboardBridge: ClipboardBridge = {
-    requestClipboard: async () => { /* postMessage → host, await reply */ },
-    writeClipboard: (text) => { /* postMessage → host */ },
+const bridge: ClipboardBridge = {
+    requestClipboard: async () => {
+        /* postMessage → host, await reply */
+    },
+    writeClipboard: (text) => {
+        /* postMessage → host (may be async; the return is ignored) */
+    },
 };
-// ...a second bridge for label text...
 
 new BpmnModeler({
     additionalModules: [
-        VsCodeClipboardModule,
-        LabelClipboardModule,
-        { elementClipboardBridge: ["value", elementClipboardBridge] },
-        { textClipboardBridge: ["value", textClipboardBridge] },
+        // Omit this line entirely for the native browser clipboard.
+        ...createClipboardModules({ element: bridge }),
     ],
 });
 ```
+
+## Wire format (public contract)
+
+Both the native and bridged paths read/write the **same** `text/plain` payload,
+which is why a webview copy pastes into a plain browser tab and vice-versa:
+
+```
+bpmn-js-clip----<JSON.stringify(copyTree)>
+```
+
+- `bpmn-js-clip----` — a fixed prefix (from upstream
+  `bpmn-js-native-copy-paste`). Text without it is ignored on paste.
+- `copyTree` — bpmn-js's copy tree: `{ [depth]: descriptor[] }`, each descriptor
+  carrying a `businessObject` (and `di`) of moddle nodes tagged with `$type`.
+  Paste revives it with `createReviver(moddle)` from
+  `bpmn-js-native-copy-paste`.
+
+A real payload for a Camunda-7 service task with `camunda:class` and a
+`camunda:Properties` extension:
+
+```
+bpmn-js-clip----{"0":[{"businessObject":{"$type":"bpmn:ServiceTask","id":"ServiceTask_1","name":"Call","class":"com.acme.Handler","extensionElements":{"$type":"bpmn:ExtensionElements","values":[{"$type":"camunda:Properties","values":[{"$type":"camunda:Property","name":"foo","value":"bar"}]}]}},"id":"ServiceTask_1","name":"Call"}]}
+```
+
+### Versioning stance
+
+The payload is **unversioned by design** — no marker, no schema field. It is
+wire-compatible with `bpmn-js-native-copy-paste` 0.3.x, and adding a marker would
+break webview↔browser paste (an explicit requirement). Paste is fail-soft: it
+checks the prefix, `try/catch`es the parse, and revives with a reviver that drops
+unknown `$type` nodes — unparseable text is logged and ignored, never thrown. A
+future *breaking* change must use a **new prefix**, never a mutated payload under
+the same one.
+
+### Engine-mismatch policy: unsupported, fails soft
+
+Pasting across engines (a Camunda-7 element into a Camunda-8 modeler or the
+reverse) is not supported, but never corrupts or crashes. The reviver reconstructs
+each node with the **target** moddle:
+
+- The shared `bpmn:` base (tasks, events, gateways, flows) revives on both
+  engines.
+- An extension node whose `$type` the target moddle does not recognise
+  (`camunda:*` in a C8 moddle, `zeebe:*` in a C7 moddle) is **silently dropped** —
+  the reviver returns `undefined`, leaving a hole in the containing array (reads
+  as `undefined`, re-serialises to `null`). No throw.
+
+So a cross-engine paste lands the diagram shape and its execution-platform-specific
+configuration is stripped. This is verified in `clipboardWireFormat.spec.ts`
+(the executable statement of this policy).
+
+## Browser caveats (documented, not solved)
+
+The native path inherits the browser's clipboard-permission model:
+
+- **Chrome** prompts for clipboard-read permission on the first paste.
+- **Safari** restricts `navigator.clipboard.readText()` to transient user
+  activation, so programmatic paste can be denied.
+- **Firefox** prompt-gates `readText()`.
+- Context-pad paste (mouse-only, no keyboard `paste` event) depends on
+  `navigator.clipboard.readText()` rather than a `paste` DOM event, so it is
+  subject to the same per-browser gating.
+
+The bridged path sidesteps all of these by delegating to the host's clipboard.

--- a/libs/bpmn-clipboard/package.json
+++ b/libs/bpmn-clipboard/package.json
@@ -9,7 +9,7 @@
         "bpmn-js-native-copy-paste": "0.3.0"
     },
     "peerDependencies": {
-        "bpmn-js": "18.15.0"
+        "bpmn-js": "18.19.0"
     },
     "devDependencies": {
         "typescript": "6.0.3"

--- a/libs/bpmn-clipboard/src/BridgedClipboardModule.ts
+++ b/libs/bpmn-clipboard/src/BridgedClipboardModule.ts
@@ -1,10 +1,14 @@
 /**
- * bpmn-js DI module that intercepts element copy/paste operations and routes
- * them through the VS Code extension host clipboard.
+ * bpmn-js DI module: host-bridge override for element copy/paste in sandboxed
+ * webviews.
  *
- * Replaces the broken `NativeCopyPaste` layer (which activates in VS Code
- * webviews but cannot actually read/write the clipboard due to missing
- * iframe permissions) with extension-host-mediated clipboard access.
+ * The default clipboard path is bpmn-js's own `NativeCopyPaste` — registered by
+ * camunda-bpmn-js and emitting a wire-compatible payload; this module is only
+ * registered when the host cannot reach the system clipboard from the webview
+ * (e.g. a VS Code iframe lacking `clipboard-read`/`clipboard-write`). It
+ * disables `NativeCopyPaste` and routes copy/paste through a {@link ClipboardBridge}
+ * the host wires to its extension-host clipboard, keeping the same prefixed-JSON
+ * payload so webview-copy ↔ browser-paste stays interoperable.
  *
  * Uses proper didi DI value injection (`elementClipboardBridge`) instead of
  * `config.*` to ensure the bridge is always available when the module loads.
@@ -12,14 +16,15 @@
 import { createReviver } from "bpmn-js-native-copy-paste/lib/PasteUtil.js";
 
 /**
- * Bridge interface for clipboard operations routed through the VS Code
- * extension host.
+ * Bridge interface for clipboard operations routed through the host (e.g. the
+ * VS Code extension host) when the webview cannot reach the system clipboard.
  */
 export interface ClipboardBridge {
-    // Reads clipboard text from the extension host.
+    // Reads clipboard text from the host.
     requestClipboard: () => Promise<string>;
-    // Writes text to the system clipboard via the extension host.
-    writeClipboard: (text: string) => void;
+    // Writes text to the system clipboard via the host. May be async; the return
+    // is ignored, so a host may fire-and-forget or await internally.
+    writeClipboard: (text: string) => void | Promise<void>;
 }
 
 const CLIP_PREFIX = "bpmn-js-clip----";
@@ -27,16 +32,16 @@ const CLIP_PREFIX = "bpmn-js-clip----";
 /**
  * Intercepts `copyPaste.elementsCopied` and `copyPaste.pasteElements` at
  * priority 2051 (above NativeCopyPaste's 2050) to route element clipboard
- * operations through the extension host.
+ * operations through the host bridge.
  *
- * Disables `NativeCopyPaste` on construction so no broken
- * `navigator.clipboard` calls are made.
+ * Disables `NativeCopyPaste` on construction so no `navigator.clipboard` calls
+ * are made from the sandboxed webview (where they would be denied).
  *
  * Re-focuses the canvas SVG after keyboard-triggered selection changes
  * (e.g. Cmd+A) to prevent subsequent Cmd+C from silently failing when the
  * properties panel steals focus.
  */
-class VsCodeClipboard {
+class BridgedClipboard {
     static $inject = [
         "elementClipboardBridge",
         "eventBus",
@@ -135,6 +140,10 @@ class VsCodeClipboard {
         // (e.g. Cmd+A), the properties panel re-render can steal focus,
         // causing subsequent Cmd+C to silently fail.
         //
+        // This focus repair is bridge-path-only by design: it was never active
+        // on the native path (the module is not registered there), and it fixes
+        // side-by-side webview focus theft that only arises in a host shell.
+        //
         // The `hasFocus()` guard prevents cross-pane focus theft: every
         // external XML edit (e.g. typing in a side-by-side text editor)
         // re-imports the diagram, and importXML fires `selection.changed`
@@ -161,7 +170,7 @@ class VsCodeClipboard {
     }
 }
 
-export const VsCodeClipboardModule = {
-    __init__: ["vsCodeClipboard"],
-    vsCodeClipboard: ["type", VsCodeClipboard],
+export const BridgedClipboardModule = {
+    __init__: ["bridgedClipboard"],
+    bridgedClipboard: ["type", BridgedClipboard],
 };

--- a/libs/bpmn-clipboard/src/LabelClipboardModule.ts
+++ b/libs/bpmn-clipboard/src/LabelClipboardModule.ts
@@ -13,7 +13,7 @@
  * Uses proper didi DI value injection (`textClipboardBridge`) instead of
  * `config.*` to ensure the bridge is always available when the module loads.
  */
-import { ClipboardBridge } from "./VsCodeClipboardModule";
+import { ClipboardBridge } from "./BridgedClipboardModule";
 
 /**
  * Dispatches a synthetic `ClipboardEvent("paste")` with the given text.
@@ -57,8 +57,6 @@ class LabelClipboard {
     private activeElement: HTMLElement | null = null;
 
     constructor(bridge: ClipboardBridge, eventBus: any, directEditing: any) {
-        console.debug("[LabelClipboard] Module initialized");
-
         const { requestClipboard, writeClipboard } = bridge;
 
         eventBus.on("directEditing.activate", () => {

--- a/libs/bpmn-clipboard/src/createClipboardModules.ts
+++ b/libs/bpmn-clipboard/src/createClipboardModules.ts
@@ -1,0 +1,30 @@
+import { BridgedClipboardModule, type ClipboardBridge } from "./BridgedClipboardModule";
+import { LabelClipboardModule } from "./LabelClipboardModule";
+
+/**
+ * Builds the bpmn-js DI modules that override the native clipboard with a host
+ * bridge, for webviews that cannot reach the system clipboard directly (#1374).
+ * Omitting these modules entirely leaves bpmn-js's `NativeCopyPaste` in charge
+ * — the native default — so this factory is only the override path.
+ *
+ * Two DI channels are bound so element and label-text clipboards stay separate.
+ * The public single-bridge API ({@link ClipboardBridge} for both) maps directly:
+ * `text` defaults to `element`, while a host with two protocol channels (VS Code)
+ * supplies both.
+ *
+ * @param bridges.element Bridge for diagram-element copy/paste.
+ * @param bridges.text Bridge for label-text copy/paste; defaults to `element`.
+ */
+export function createClipboardModules(bridges: {
+    element: ClipboardBridge;
+    text?: ClipboardBridge;
+}): unknown[] {
+    return [
+        BridgedClipboardModule,
+        LabelClipboardModule,
+        {
+            elementClipboardBridge: ["value", bridges.element],
+            textClipboardBridge: ["value", bridges.text ?? bridges.element],
+        },
+    ];
+}

--- a/libs/bpmn-clipboard/src/index.ts
+++ b/libs/bpmn-clipboard/src/index.ts
@@ -1,3 +1,2 @@
-export { VsCodeClipboardModule } from "./VsCodeClipboardModule";
-export type { ClipboardBridge } from "./VsCodeClipboardModule";
-export { LabelClipboardModule } from "./LabelClipboardModule";
+export { createClipboardModules } from "./createClipboardModules";
+export type { ClipboardBridge } from "./BridgedClipboardModule";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,7 +3631,7 @@ __metadata:
     bpmn-js-native-copy-paste: "npm:0.3.0"
     typescript: "npm:6.0.3"
   peerDependencies:
-    bpmn-js: 18.15.0
+    bpmn-js: 18.19.0
   languageName: unknown
   linkType: soft
 
@@ -3871,6 +3871,7 @@ __metadata:
     bpmn-js-bpmnlint: "npm:0.24.0"
     bpmn-js-create-append-anything: "npm:2.0.0"
     bpmn-js-differ: "npm:3.2.0"
+    bpmn-js-native-copy-paste: "npm:0.3.0"
     bpmn-js-properties-panel: "npm:5.60.0"
     bpmn-js-token-simulation: "npm:0.39.4"
     bpmn-moddle: "npm:10.0.0"
@@ -3880,6 +3881,7 @@ __metadata:
     camunda-bpmn-moddle: "npm:7.0.1"
     camunda-transaction-boundaries: "npm:1.1.2"
     diagram-js: "npm:15.18.0"
+    didi: "npm:11.0.0"
     jsdom: "npm:30.0.1"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.3"
@@ -11609,7 +11611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"didi@npm:^11.0.0":
+"didi@npm:11.0.0, didi@npm:^11.0.0":
   version: 11.0.0
   resolution: "didi@npm:11.0.0"
   checksum: 10c0/e4516b9a5189b1803cfbcce2f520d625c172fa124ee1e7f74c54ae123ff202cb80175be93fca6cfe4e332003e0a0bf2a782de2813f2d78508b4115e5d7cd6bf1


### PR DESCRIPTION
## Issue

Closes #1374

## Description

Flips the clipboard polarity decided in [ADR 0007](docs/adr/0007-public-modeler-api.md): the native browser clipboard (bpmn-js's `NativeCopyPaste`, always registered by camunda-bpmn-js) is now the package default, and the host bridge is the override. `VsCodeClipboardModule` becomes the host-neutral `BridgedClipboardModule` behind a `createClipboardModules(bridges)` factory, so the DI value names stay package-private; `createModeler` gains the frozen `clipboard?: ClipboardOptions` option (omit = native). Real hosts (VS Code / IntelliJ / Theia) keep the protocol bridge by default and stay byte-identical, while the demo webapp opts into `clipboard: "native"` — fixing paste being silently dead in its production build. The `bpmn-js-clip----` wire format is now documented as a public contract in the package README (unversioned by design, wire-compatible with `bpmn-js-native-copy-paste` 0.3.x, fail-soft), with the C7↔C8 engine-mismatch policy captured as an executable spec (`clipboardWireFormat.spec.ts`: unsupported, fails soft — unknown `$type` nodes are dropped by the reviver) plus documented browser caveats.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A) — ADR 0007 already records this decision; its #1374 follow-up is ticked
- [ ] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
