### PR TITLE
docs(bpmn-modeler): clean up extraction-era comments

### DIFF
--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -7,8 +7,8 @@ clipboard, theming, and the Camunda element-template stack — with no VS Code /
 IntelliJ host required.
 
 > Extracted from the [miranum-ide](https://github.com/Miragon/miranum-ide)
-> modeler (epic #1293). `0.1.0` is the first standalone release; the public
-> surface is described by the TypeScript types shipped in `dist/index.d.ts`.
+> modeler. `0.1.0` is the first standalone release; the public surface is
+> described by the TypeScript types shipped in `dist/index.d.ts`.
 
 ## Install
 
@@ -93,14 +93,14 @@ Linting is an opinionated built-in with a tier ladder, selected via
 | `{ results: "external" }` | The modeler only *paints* results the host computes and pushes through `handle.applyLintResults(...)`; no in-webview linter runs. |
 
 The linting stack (`bpmn-js-bpmnlint`, `bpmnlint`, the rule plugin, and its CSS)
-is code-split into a lazily-loaded chunk (#1373): it is fetched only when an
+is code-split into a lazily-loaded chunk: it is fetched only when an
 instance actually lints, so `linting: false` keeps it out of your bundle's
 critical path entirely. Lint results surface through `onLintResults`, and the
 in-canvas enable/disable toggle through `onLintingToggled`.
 
 ## Clipboard wire format
 
-Copy/paste defaults to the native browser clipboard (#1374); a sandboxed host
+Copy/paste defaults to the native browser clipboard; a sandboxed host
 that cannot reach the system clipboard from the webview supplies a
 `ClipboardBridge` via `options.clipboard`.
 

--- a/packages/bpmn-modeler/src/architecture.spec.ts
+++ b/packages/bpmn-modeler/src/architecture.spec.ts
@@ -3,7 +3,7 @@ import { join, normalize } from "node:path";
 import { describe, expect, it } from "vitest";
 
 /**
- * Import-direction gate for `@miragon/bpmn-modeler` (epic #1293, ADR 0006/0007).
+ * Import-direction gate for `@miragon/bpmn-modeler`.
  *
  * The published package may reach only *downward* — relatives, the private
  * workspace libs it inlines at build time, and bare npm specifiers. It must
@@ -81,7 +81,7 @@ describe("bpmn-modeler import direction", () => {
     });
 
     it("package TS source reads no VS Code `<body>` theme classes", () => {
-        // Theme is host policy (#1377): the package resolves light/dark from
+        // Theme is host policy: the package resolves light/dark from
         // `prefers-color-scheme` or an injected mode, never by reading the host's
         // chrome. A `vscode-*` body class in TS source would mean the watcher
         // leaked back in. (CSS files legitimately style `body.vscode-dark`; this

--- a/packages/bpmn-modeler/src/bpmnlint/LintConfigService.spec.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/LintConfigService.spec.ts
@@ -7,7 +7,7 @@ const { runMock, ctorMock } = vi.hoisted(() => ({ runMock: vi.fn(), ctorMock: vi
 vi.mock("./browserLinter", () => ({
     // A class (not an arrow) so `new BrowserLinter()` constructs. `ctorMock`
     // records the (engine, config) args so a test can assert the handed-back
-    // config reaches the linter (#1384).
+    // config reaches the linter.
     BrowserLinter: class {
         constructor(...args: unknown[]) {
             ctorMock(...args);
@@ -217,7 +217,7 @@ describe("LintConfigService: startInPageLinting (host handback)", () => {
         expect(returned).toEqual(LINT_EVENT.results);
     });
 
-    it("builds the browser linter with the handed-back workspace config (#1384)", () => {
+    it("builds the browser linter with the handed-back workspace config", () => {
         ctorMock.mockClear();
         const { service } = makeService({ tier: "external", imported: true });
         const config = { extends: "bpmnlint:recommended" };

--- a/packages/bpmn-modeler/src/bpmnlint/LintConfigService.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/LintConfigService.ts
@@ -44,7 +44,7 @@ type Translate = (template: string) => string;
 
 /**
  * The per-instance tier decision, registered as the `lintTier` DI value by
- * {@link createLintModule}. `"external"` keeps today's host-pushed flow;
+ * {@link createLintModule}. `"external"` renders host-pushed results;
  * `"in-page"` runs {@link BrowserLinter} in the webview against the given
  * `engine` (and optional explicit `config`). `false`/off never reaches here — a
  * disabled instance registers no lint module at all.
@@ -106,20 +106,18 @@ function shallowCopyResults(results: LintResults): LintResults {
  *
  * It drives `bpmn-js-bpmnlint`'s `linting` module by overriding its `lint()` —
  * the module's own `update()` (fired on import, element changes, toggles) then
- * diffs and draws the overlays exactly as before, so no overlay/rendering code
- * changes across tiers. The override's body depends on the tier: `external`
- * returns the host's last-pushed results; `in-page` runs {@link BrowserLinter}
- * against the live tree and emits the raw result through `onLintResults`;
- * `in-page-disabled` returns nothing so the linter, which the vendor keeps
- * running even while inactive, does no real work.
+ * diffs and draws the overlays, so no overlay/rendering code changes across
+ * tiers. The override's body depends on the tier: `external` returns the host's
+ * last-pushed results; `in-page` runs {@link BrowserLinter} against the live
+ * tree and emits the raw result through `onLintResults`; `in-page-disabled`
+ * returns nothing so the linter, which the vendor keeps running even while
+ * inactive, does no real work.
  *
- * It also owns the in-canvas **disable affordance**: an "off" button beside the
+ * It also owns the in-canvas disable affordance: an "off" button beside the
  * lint summary pill, and a muted "Linting off" chip with an "Enable" action in
- * its place once disabled — the entry points a non-technical user needs, since
- * they may never open host settings. In the in-page tier the toggle is applied
+ * its place once disabled. In the in-page tier the toggle is applied
  * optimistically (the webview owns the linter); in the external tier it is
- * reported through `onLintingToggled` and the overlays wait for the host's push,
- * exactly as before.
+ * reported through `onLintingToggled` and the overlays wait for the host's push.
  */
 export class LintConfigService {
     static $inject = [
@@ -136,8 +134,8 @@ export class LintConfigService {
 
     // Present once the in-page tier is live; undefined for a purely external
     // instance. Mutable because the host can hand linting back to the webview
-    // after construction (#1373 Phase B) via {@link startInPageLinting}, which
-    // lazily builds it — the constructor only builds it for an up-front in-page tier.
+    // after construction via {@link startInPageLinting}, which lazily builds it —
+    // the constructor only builds it for an up-front in-page tier.
     private browserLinter?: BrowserLinter;
 
     // Kept from `tierInit` so a later {@link startInPageLinting} can construct a
@@ -147,10 +145,10 @@ export class LintConfigService {
 
     private readonly explicitConfig?: BpmnlintConfig;
 
-    // The config-version token of the last in-page instruction (#1384). Used to
-    // dedup a repeat covered instruction, but only while actually `"in-page"`:
-    // any disabled/external push in between leaves this stale, and the state
-    // guard below stops that stale token from dropping a genuine re-enable.
+    // The config-version token of the last in-page instruction. Used to dedup a
+    // repeat covered instruction, but only while actually `"in-page"`: any
+    // disabled/external push in between leaves this stale, and the state guard
+    // below stops that stale token from dropping a genuine re-enable.
     private lastConfigToken?: string;
 
     private results: LintResults = {};
@@ -196,10 +194,10 @@ export class LintConfigService {
     }
 
     /**
-     * Starts (or restarts) the in-page linter on host instruction — the #1373
-     * Phase B handback when the host finds no workspace `.bpmnlintrc`. Lazily
-     * builds the {@link BrowserLinter} (the constructor only builds it for an
-     * up-front in-page tier) and activates it if a diagram is already imported;
+     * Starts (or restarts) the in-page linter on host instruction — the handback
+     * when the host finds no workspace `.bpmnlintrc`. Lazily builds the
+     * {@link BrowserLinter} (the constructor only builds it for an up-front
+     * in-page tier) and activates it if a diagram is already imported;
      * otherwise the unconditional `import.done` listener activates it.
      *
      * No-ops when the user has disabled linting from the canvas — a host
@@ -236,7 +234,7 @@ export class LintConfigService {
     /**
      * Applies host-pushed results (external tier). Any push wins: an in-page
      * instance switches to `external` and its in-page run is suspended. `null`
-     * deactivates linting — the no-config experience, unchanged from before.
+     * deactivates linting — the no-config experience.
      */
     applyLintResults(results: LintResults | null): void {
         this.state = "external";
@@ -289,8 +287,7 @@ export class LintConfigService {
 
     /**
      * Renders `results`, or deactivates linting when `results` is `null` (no
-     * `.bpmnlintrc`, or a host read/lint failure) — keeping the no-config
-     * experience identical to before linting moved to the host.
+     * `.bpmnlintrc`, or a host read/lint failure).
      */
     private render(results: LintResults | null): void {
         this.hideDisabledChip();
@@ -336,7 +333,7 @@ export class LintConfigService {
      * Handles the off button. Reports the toggle to the host in every tier; in the
      * in-page tier it also flips the state and clears the overlays optimistically
      * (the webview owns the linter). In the external tier the render waits for the
-     * host's disabled push — today's behaviour.
+     * host's disabled push.
      */
     private handleOffClick(): void {
         this.callbacks.onLintingToggled?.(false);

--- a/packages/bpmn-modeler/src/bpmnlint/browserLinter.spec.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/browserLinter.spec.ts
@@ -7,8 +7,8 @@ type ModdleFactory = (ext?: Record<string, unknown>) => {
 };
 
 /**
- * The browser-compat gate for #1373: `@miragon/bpmnlint-plugin-rules` and
- * bpmnlint's `Linter` have only ever run in Node here. This drives the real stack
+ * The browser-compat gate: `@miragon/bpmnlint-plugin-rules` and bpmnlint's
+ * `Linter` have only ever run in Node here. This drives the real stack
  * (no mocks) over a parsed moddle tree in jsdom, so a rule reaching for a Node API
  * fails here — the earliest signal — rather than blank in a host webview. A rule
  * the bundled resolver cannot cover would degrade to `unresolved`, never throw.

--- a/packages/bpmn-modeler/src/bpmnlint/browserLinter.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/browserLinter.ts
@@ -12,13 +12,13 @@ import { RecordingBrowserResolver, staticUnresolvedModdleExtensions } from "./br
 /**
  * Runs bpmnlint against the *live* bpmn-js definitions tree, in the browser.
  *
- * This is the in-page tier of the #1373 lint ladder: instead of the host running
- * `NodeBpmnLinter` and pushing results down, the webview lints itself. The config
- * is either an explicit `{config}` a consumer supplied or the engine-aware
- * zero-config default (`getDefaultLintConfig({engine, preset: "modeling"})`,
- * matching the hosts' preset for later parity). Rules the bundled resolver cannot
- * cover degrade to no-ops and are reported via {@link LintRunEvent.unresolved},
- * so an unusual `{config}` is never fatal.
+ * This is the in-page tier: instead of the host running a linter and pushing
+ * results down, the webview lints itself. The config is either an explicit
+ * `{config}` a consumer supplied or the engine-aware zero-config default
+ * (`getDefaultLintConfig({engine, preset: "modeling"})`, matching the hosts'
+ * preset for parity). Rules the bundled resolver cannot cover degrade to no-ops
+ * and are reported via {@link LintRunEvent.unresolved}, so an unusual `{config}`
+ * is never fatal.
  *
  * The resolver is created once and reused; each {@link run} resets its recorded
  * misses so the emitted `unresolved` reflects that single lint. `moddleExtensions`

--- a/packages/bpmn-modeler/src/bpmnlint/browserResolver.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/browserResolver.ts
@@ -3,7 +3,7 @@ import { createBundledResolver, type Resolver } from "@miragon/bpmnlint-plugin-r
 
 // Re-exported so `browserLinter.ts` and `browserResolver.spec.ts` keep importing
 // it from here; the implementation moved to modeler-types so the host's
-// escalation pre-check shares the exact same logic (#1384).
+// escalation pre-check shares the exact same logic.
 export { staticUnresolvedModdleExtensions };
 
 /**
@@ -55,7 +55,6 @@ export class RecordingBrowserResolver implements Resolver {
         return NOOP_CONFIG;
     }
 
-    /** Clears the recorded misses so a fresh run starts from an empty list. */
     reset(): void {
         this.unresolved.length = 0;
     }

--- a/packages/bpmn-modeler/src/bpmnlint/index.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/index.ts
@@ -1,9 +1,9 @@
 /**
- * Lazy-loaded chunk entry for in-canvas bpmnlint (#1373, AC 6).
+ * Lazy-loaded chunk entry for in-canvas bpmnlint.
  *
  * This module — and only this module — statically imports the lint stack
  * (`bpmn-js-bpmnlint`, `bpmnlint`'s `Linter`, `@miragon/bpmnlint-plugin-rules`,
- * and the CSS). Because {@link BpmnModeler.create} reaches it through a dynamic
+ * and the CSS). Because the modeler reaches it through a dynamic
  * `import("./bpmnlint")`, the whole stack lands in a separate chunk that is
  * fetched only when an instance actually lints (`linting !== false`), keeping it
  * out of the main webview bundle.

--- a/packages/bpmn-modeler/src/bridgedClipboard.spec.ts
+++ b/packages/bpmn-modeler/src/bridgedClipboard.spec.ts
@@ -4,14 +4,14 @@ import { BpmnModdle } from "bpmn-moddle";
 import { createClipboardModules, type ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
 
 /**
- * Behavioural spec for the bridge-path clipboard module (`BridgedClipboard`,
- * #1374). The class is private to the lib, so it is exercised through the same
- * DI wiring the webview uses: `createClipboardModules` yields the module, and a
- * didi injector instantiates it against fake bpmn-js services + a real
- * `bpmn-moddle` (the reviver needs genuine type descriptors).
+ * Behavioural spec for the bridge-path clipboard module (`BridgedClipboard`).
+ * The class is private to the lib, so it is exercised through the same DI wiring
+ * the webview uses: `createClipboardModules` yields the module, and a didi
+ * injector instantiates it against fake bpmn-js services + a real `bpmn-moddle`
+ * (the reviver needs genuine type descriptors).
  *
  * The prefixed-JSON payload asserted here is byte-identical to upstream
- * `bpmn-js-native-copy-paste` — that wire compatibility is the point of #1374.
+ * `bpmn-js-native-copy-paste` — that wire compatibility is the point.
  */
 
 const CLIP_PREFIX = "bpmn-js-clip----";

--- a/packages/bpmn-modeler/src/canvasFocusIndicator.ts
+++ b/packages/bpmn-modeler/src/canvasFocusIndicator.ts
@@ -1,6 +1,6 @@
 /**
  * @internal Package-internal wiring — the green canvas focus reticle the
- * factory installs per instance. Not part of the designed public API (#1375).
+ * factory installs per instance. Not part of the public API.
  */
 
 /**
@@ -38,39 +38,27 @@ const FOCUS_WEAK_SVG = `<svg class="canvas-focus-indicator__off" viewBox="0 -960
 const FOCUS_STRONG_SVG = `<svg class="canvas-focus-indicator__on" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M200-120q-33 0-56.5-23.5T120-200v-160h80v160h160v80H200Zm400 0v-80h160v-160h80v160q0 33-23.5 56.5T760-120H600ZM120-600v-160q0-33 23.5-56.5T200-840h160v80H200v160h-80Zm640 0v-160H600v-80h160q33 0 56.5 23.5T840-760v160h-80ZM338.5-338.5Q280-397 280-480t58.5-141.5Q397-680 480-680t141.5 58.5Q680-563 680-480t-58.5 141.5Q563-280 480-280t-141.5-58.5Z"/></svg>`;
 
 /**
- * Installs a focus reticle in the canvas's top-right corner, beside the
- * "Open minimap" control, that lights up
- * brand-green with a solid center while the canvas holds keyboard focus *and*
- * no element is selected, and shows a faint hollow reticle otherwise. On
- * focus gain the glow briefly pulses (the "you're back" moment), then settles
- * to a steady glow — canvas-focused is the normal state users sit in for
- * minutes, so a perpetual pulse would be an attention magnet.
+ * Installs a focus reticle in the canvas's top-right corner, beside the "Open
+ * minimap" control: brand-green with a solid center while the canvas holds
+ * keyboard focus *and* nothing is selected, faint and hollow otherwise. On
+ * focus gain the glow pulses briefly, then settles to a steady glow.
  *
- * Selection gates the green state because clicking an element also puts DOM
- * focus on the canvas SVG — without the gate the reticle would light on every
- * selection, where the selection outline already shows that keystrokes target
- * the diagram. Green is reserved for the bare "canvas focus" state Escape
- * creates, which has no other visual marker.
+ * Selection gates the green state because clicking an element also focuses the
+ * canvas SVG; the selection outline already shows keystrokes target the diagram,
+ * so green is reserved for the bare "canvas focus" state Escape creates, which
+ * has no other marker. A reticle (not a bulb) because a bulb collides with the
+ * IDE-wide "quick fix available" lightbulb (VS Code/IntelliJ).
  *
- * A reticle (not a bulb or keyboard) because a bulb collides with the IDE-wide
- * "quick fix available" affordance (VS Code/IntelliJ lightbulb); the
- * weak/strong reticle pair literally depicts focus snapping onto the canvas.
+ * Subscribes to diagram-js's deduplicated `canvas.focus.changed` (fired from the
+ * canvas SVG's `focusin`/`focusout`) rather than a container-level `focusin` —
+ * the latter would false-positive when another widget inside the same
+ * `.djs-container` (e.g. the bpmnlint chip) takes focus.
  *
- * It is the visual counterpart to {@link installKeyboardFocus}. It subscribes
- * to diagram-js's own
- * deduplicated `canvas.focus.changed` signal (fired from the canvas SVG's
- * `focusin`/`focusout` listeners) rather than observing a container-level
- * `focusin` — the latter would false-positive when another floating widget
- * inside the same `.djs-container` (e.g. the bpmnlint chip) takes focus.
- *
- * Purely decorative: `aria-hidden` + `pointer-events: none`. The focus move
- * itself already conveys the state to assistive tech, and a clickable glyph
- * would need a tab stop and would steal canvas clicks.
+ * Purely decorative: `aria-hidden` + `pointer-events: none`.
  *
  * @param deps Injected parent/focus closures (see {@link CanvasFocusIndicatorDeps}).
- * @returns A disposer that removes the reticle from the DOM, so a destroyed
- *   modeler instance leaves no orphaned overlay in its (shared-page) container.
- *   The event subscriptions die with the modeler's own event bus on destroy.
+ * @returns A disposer that removes the reticle from the DOM. The event
+ *   subscriptions die with the modeler's own event bus on destroy.
  */
 export function installCanvasFocusIndicator(deps: CanvasFocusIndicatorDeps): () => void {
     const root = document.createElement("div");

--- a/packages/bpmn-modeler/src/clipboardModules.spec.ts
+++ b/packages/bpmn-modeler/src/clipboardModules.spec.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from "vitest";
 import { createClipboardModules, type ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
 
 /**
- * Contract of the clipboard-override factory (#1374). The two DI modules and
- * the value bindings are the whole surface bootstrap/createModeler rely on; the
- * `text ?? element` default is what lets the frozen single-bridge public API map
- * onto the two protocol channels a webview host actually needs.
+ * Contract of the clipboard-override factory. The two DI modules and the value
+ * bindings are the whole surface bootstrap/createModeler rely on; the
+ * `text ?? element` default is what lets the single-bridge public API map onto
+ * the two protocol channels a webview host actually needs.
  */
 
 function fakeBridge(): ClipboardBridge {

--- a/packages/bpmn-modeler/src/clipboardWireFormat.spec.ts
+++ b/packages/bpmn-modeler/src/clipboardWireFormat.spec.ts
@@ -5,8 +5,8 @@ import camundaModdle from "camunda-bpmn-moddle/resources/camunda.json";
 import zeebeModdle from "zeebe-bpmn-moddle/resources/zeebe.json";
 
 /**
- * Executable statement of the cross-engine clipboard policy (#1374): unsupported,
- * fails soft. The wire format is engine-agnostic — a Camunda-7 element pasted
+ * Executable statement of the cross-engine clipboard policy: unsupported, fails
+ * soft. The wire format is engine-agnostic — a Camunda-7 element pasted
  * into a Camunda-8 modeler revives its shared bpmn: base, and the reviver
  * silently drops every extension node whose `$type` the target moddle does not
  * know (`camunda:*` in a C8 moddle), replacing it with `null` rather than

--- a/packages/bpmn-modeler/src/createModeler.ts
+++ b/packages/bpmn-modeler/src/createModeler.ts
@@ -4,19 +4,18 @@ import type { ModelerOptions } from "./publicApi";
 import { BpmnModeler } from "./modeler";
 
 /**
- * Runtime options accepted by {@link createModeler}: the designed public
- * {@link ModelerOptions} plus one migration-only internal knob. The factory now
- * implements the designed type verbatim (#1376) — the only addition is
- * `handleGlobalEscape`, which stays `@internal` and out of `publicApi.ts`.
+ * Runtime options accepted by {@link createModeler}: the public
+ * {@link ModelerOptions} plus one internal knob (`handleGlobalEscape`), which
+ * stays `@internal` and out of `publicApi.ts`.
  */
 export interface CreateModelerOptions extends ModelerOptions {
     /**
      * When `true`, an Escape with nothing focused (`<body>`) re-homes this
-     * canvas. Default off; the single-instance bootstrap passes `true` to keep
-     * today's page-wide behaviour, while a multi-instance consumer leaves it off
-     * so each modeler only reacts to Escapes inside its own subtrees.
+     * canvas. Default off; the single-instance bootstrap passes `true` for
+     * page-wide behaviour, while a multi-instance consumer leaves it off so each
+     * modeler only reacts to Escapes inside its own subtrees.
      *
-     * @internal Not part of the designed public API (#1375).
+     * @internal Not part of the public API.
      */
     handleGlobalEscape?: boolean;
 }
@@ -27,8 +26,7 @@ export interface CreateModelerOptions extends ModelerOptions {
  * (element templates, settings, theme, locale) in the order the host expects.
  *
  * Async because {@link BpmnModeler.init} awaits the lazy bpmnlint chunk before
- * constructing bpmn-js. Engine selection is now up front (in `options.engine`),
- * collapsing the former two-step `create(engine)` into a single call.
+ * constructing bpmn-js.
  */
 export async function createModeler(
     container: HTMLElement,

--- a/packages/bpmn-modeler/src/diff/DiffLegend.ts
+++ b/packages/bpmn-modeler/src/diff/DiffLegend.ts
@@ -13,9 +13,6 @@ export interface DiffLegendCallbacks {
     onSwap?: () => void;
 }
 
-/**
- * Dictionary key rendered as a count slot's label.
- */
 type SlotKey = "Added" | "Removed" | "Changed" | "Moved";
 
 /**
@@ -122,12 +119,6 @@ export class DiffLegend {
         this.disposeI18n = i18n.onChange(() => this.renderLabels());
     }
 
-    /**
-     * Reveals the legend and renders the given context.  Disables the nav
-     * buttons when there are no changes at all; shows the filename subtitle
-     * when a `filename` is given and the swap button when `showSwap` is set
-     * (and an `onSwap` callback was supplied).
-     */
     update(context: DiffLegendContext): void {
         this.context = context;
         this.renderLabels();
@@ -182,11 +173,6 @@ export class DiffLegend {
         return btn;
     }
 
-    /**
-     * Redraws every translated label from the current {@link context} and
-     * {@link i18n} locale.  Called on init, on {@link update}, and whenever
-     * {@link i18n} notifies of a language switch.
-     */
     private renderLabels(): void {
         const { counts, filename } = this.context;
         const countFor: Record<SlotKey, number> = {
@@ -204,10 +190,6 @@ export class DiffLegend {
         this.filenameEl.textContent = filename ?? "";
     }
 
-    /**
-     * Unsubscribes the language-change listener and removes the legend from the
-     * DOM.  The instance must not be used afterwards.
-     */
     destroy(): void {
         this.disposeI18n();
         this.root.remove();

--- a/packages/bpmn-modeler/src/diff/DiffPaneCoordinator.ts
+++ b/packages/bpmn-modeler/src/diff/DiffPaneCoordinator.ts
@@ -66,12 +66,10 @@ export class DiffPaneCoordinator {
         }
     }
 
-    /** Advances the shared cursor to the next changed element on both panes. */
     next(): void {
         this.step(1);
     }
 
-    /** Advances the shared cursor to the previous changed element on both panes. */
     previous(): void {
         this.step(-1);
     }
@@ -80,7 +78,6 @@ export class DiffPaneCoordinator {
         return this._cursor;
     }
 
-    /** Unhooks the viewport-sync subscriptions.  Leaves the viewers intact. */
     destroy(): void {
         for (const dispose of this.disposers) {
             dispose();

--- a/packages/bpmn-modeler/src/diff/DiffViewer.ts
+++ b/packages/bpmn-modeler/src/diff/DiffViewer.ts
@@ -26,14 +26,7 @@ const DIFF_SELECTED_CLASS = "diff-selected";
  * Readonly BPMN canvas for one side of a diff view.
  *
  * Wraps `bpmn-js/lib/NavigatedViewer` so the pane supports mouse + keyboard
- * pan/zoom but not editing.  Exposes:
- *   - {@link importXML} — load the diagram and fit to viewport.
- *   - {@link applyHighlights} — mark elements with per-category CSS classes.
- *   - {@link getViewport} / {@link setViewport} — read/write canvas viewbox.
- *   - {@link onViewportChanged} — subscribe to user-driven viewport changes,
- *     with a suppression guard so programmatic `setViewport` calls don't
- *     re-emit (avoids feedback loops across synced panes).
- *   - {@link focusElement} — centre the viewport on a given element.
+ * pan/zoom but not editing.
  */
 export class DiffViewer {
     private readonly viewer: NavigatedViewer;

--- a/packages/bpmn-modeler/src/index.ts
+++ b/packages/bpmn-modeler/src/index.ts
@@ -1,19 +1,18 @@
 /**
- * `@miragon/bpmn-modeler` — the host-free, publishable BPMN modeler (epic #1293).
+ * `@miragon/bpmn-modeler` — the host-free, publishable BPMN modeler.
  *
- * The factory and the designed handle (#1375) are the supported surface; the
- * `@internal`-tagged exports below exist only for the in-repo `apps/bpmn-webview`
- * bootstrap and are removed once it becomes a thin adapter (#1377).
+ * The factory and the handle are the supported surface; the `@internal`-tagged
+ * exports below exist only for the in-repo `apps/bpmn-webview` adapter.
  */
 
-// Side-effect styles the modeler's own DOM depends on (the webview bootstrap
-// carried these before the extraction). A theme stylesheet is linked separately
-// by the consumer — see `styles.css` / `light-theme.css` / `dark-theme.css`.
+// Side-effect styles the modeler's own DOM depends on. A theme stylesheet is
+// linked separately by the consumer — see `styles.css` / `light-theme.css` /
+// `dark-theme.css`.
 import "./styles/default.css";
 import "./styles/diff.css";
 import "./styles/canvasFocusIndicator.css";
 
-// ── Public factory + designed API surface (#1375) ────────────────────────────
+// ── Public factory + API surface ─────────────────────────────────────────────
 export { createModeler } from "./createModeler";
 export type {
     ThemeMode,
@@ -44,7 +43,7 @@ export { ViewportManager } from "./viewport";
 export type { ViewportData } from "./viewport";
 export { SelectionManager } from "./selection";
 
-// ── Diff view — public rendering primitives + in-page coordinator (#1378) ─────
+// ── Diff view — public rendering primitives + in-page coordinator ─────────────
 // The data layer (`computeDiff`/`sideView` + result types) is the Node-safe
 // `@miragon/bpmn-modeler/diff` subpath; these are the browser-only primitives.
 export { DiffViewer } from "./diff/DiffViewer";

--- a/packages/bpmn-modeler/src/keyboardFocus.ts
+++ b/packages/bpmn-modeler/src/keyboardFocus.ts
@@ -1,6 +1,6 @@
 /**
  * @internal Package-internal wiring — the canvas-focus keyboard guard the
- * factory installs per instance. Not part of the designed public API (#1375).
+ * factory installs per instance. Not part of the public API.
  */
 
 /**

--- a/packages/bpmn-modeler/src/modeler.ts
+++ b/packages/bpmn-modeler/src/modeler.ts
@@ -66,9 +66,9 @@ const ALIGN_TO_ORIGIN_OPTIONS = {
  *
  * Per-instance by construction: it is bound to its own `container` and
  * `propertiesPanel.parent` (see {@link CreateModelerOptions}), so several
- * modelers can coexist on a page — the future in-page diff view wants two. Use
- * {@link createModeler} as the factory. All methods throw {@link NoModelerError}
- * if called before {@link init}, and {@link destroy} tears the instance down.
+ * modelers can coexist on a page. Use {@link createModeler} as the factory. All
+ * methods throw {@link NoModelerError} if called before {@link init}, and
+ * {@link destroy} tears the instance down.
  *
  * Viewport and selection concerns are delegated to {@link ViewportManager}
  * and {@link SelectionManager}, accessible via the corresponding getters
@@ -114,8 +114,6 @@ export class BpmnModeler {
 
     /**
      * Access the viewport manager after {@link init}.
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     get viewport(): ViewportManager {
         if (!this._viewport) {
@@ -126,8 +124,6 @@ export class BpmnModeler {
 
     /**
      * Access the selection manager after {@link init}.
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     get selection(): SelectionManager {
         if (!this._selection) {
@@ -140,8 +136,7 @@ export class BpmnModeler {
      * Access the root element manager after {@link init}.
      *
      * @internal Host-adapter surface (drill-down state restore); not part of the
-     *   designed public handle (#1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     *   public handle.
      */
     get rootElement(): RootElementManager {
         if (!this._rootElement) {
@@ -161,7 +156,7 @@ export class BpmnModeler {
      * installs first.
      *
      * @internal Construction step invoked by {@link createModeler}; not part of
-     *   the designed public handle (#1375).
+     *   the public handle.
      * @throws {UnsupportedEngineError} If the engine string is not recognised.
      */
     async init(): Promise<void> {
@@ -187,7 +182,7 @@ export class BpmnModeler {
         ];
         const capModules = capabilityModules(engine, this.options.capabilities);
         // Clipboard is a [B] built-in: omitting `clipboard` registers nothing, so
-        // bpmn-js's native (browser) clipboard stays in charge (#1374); a host that
+        // bpmn-js's native (browser) clipboard stays in charge; a host that
         // can't reach the system clipboard from its webview supplies a bridge.
         // A distinct `text` bridge routes label + contenteditable/FEEL surfaces
         // through the host's text channel; it defaults to the element bridge.
@@ -253,9 +248,6 @@ export class BpmnModeler {
 
         this.installFocusFeatures();
 
-        /**
-         * Apply default favourites immediately after creation.
-         */
         if (this.settings.favouriteBpmnElements) {
             const appendMenuOverride = this.getModeler().get<any>("appendMenuOverride", false);
             if (appendMenuOverride) {
@@ -273,8 +265,8 @@ export class BpmnModeler {
         }
 
         // The package-owned debounced content event: one full export per burst of
-        // model changes (300ms / 1000ms maxWait — the shape battle-tested in
-        // bootstrap). destroy() cancels a pending trailing export.
+        // model changes (300ms / 1000ms maxWait). destroy() cancels a pending
+        // trailing export.
         const onContentSaved = this.options.onContentSaved;
         if (onContentSaved) {
             this.contentSaved = asyncDebounce(
@@ -288,9 +280,9 @@ export class BpmnModeler {
 
     /**
      * Resolves the bpmnlint DI module(s) for the chosen tier, importing the lint
-     * chunk only when linting is not disabled (#1373, AC 6). `linting: false`
-     * returns no modules — the chunk, and the whole bpmnlint/rules stack, is never
-     * fetched. Every other value dynamically imports {@link createLintModule} and
+     * chunk only when linting is not disabled. `linting: false` returns no
+     * modules — the chunk, and the whole bpmnlint/rules stack, is never fetched.
+     * Every other value dynamically imports {@link createLintModule} and
      * registers one instance-scoped module carrying the tier, engine, explicit
      * config, and the facade callbacks.
      */
@@ -327,8 +319,6 @@ export class BpmnModeler {
      * Any push switches an in-page instance to the external tier. `null`
      * deactivates linting (no `.bpmnlintrc` / read failure). A no-op with a warning
      * when the instance was created with `linting: false` (no lint service).
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     applyLintResults(results: LintResults | null): void {
         const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
@@ -342,8 +332,6 @@ export class BpmnModeler {
     /**
      * Renders the host's user-disabled lint state (external tier): clears overlays
      * and shows the re-enable chip. A no-op with a warning when `linting: false`.
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     applyLintingDisabled(): void {
         const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
@@ -357,14 +345,12 @@ export class BpmnModeler {
     }
 
     /**
-     * Starts (or restarts) the in-page linter on host instruction — the #1373
-     * Phase B handback when the host finds no workspace `.bpmnlintrc`. Mirrors
+     * Starts (or restarts) the in-page linter on host instruction — the handback
+     * when the host finds no workspace `.bpmnlintrc`. Mirrors
      * {@link applyLintResults}: a no-op with a warning when the instance was
      * created with `linting: false` (no lint service). Never re-enables a
      * user-disabled linter (the service guards that); any later host push still
      * wins over the in-page run.
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     startInPageLinting(config?: BpmnlintConfig, configToken?: string): void {
         const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
@@ -461,9 +447,8 @@ export class BpmnModeler {
      * Subscribes to the `commandStack.changed` event on the modeler's event bus.
      *
      * @internal Raw change hook. The designed API exposes the debounced
-     *   `onContentSaved` event instead; this stays for the host adapter (#1375).
+     *   `onContentSaved` event instead; this stays for the host adapter.
      * @param cb Callback invoked whenever the command stack changes.
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     onCommandStackChanged(cb: () => void): void {
         this.getModeler().get<any>("eventBus").on("commandStack.changed", cb);
@@ -473,8 +458,6 @@ export class BpmnModeler {
      * Returns the live moddle definitions tree (`bpmn:Definitions` root) so
      * callers can walk the in-memory model — e.g. to extract process variables
      * for script IntelliSense — without round-tripping through XML.
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     getDefinitions(): any {
         return this.getModeler().getDefinitions();
@@ -486,41 +469,24 @@ export class BpmnModeler {
      * scan and filtering rules live in {@link collectInlineScriptTasks} so the
      * bulk path and the single-open path stay in agreement.
      *
-     * @internal Host-adapter surface (inline-scripting capability, #1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     * @internal Host-adapter surface (inline-scripting capability).
      */
     collectInlineScriptTasks(): ScriptTaskScript[] {
         return collectInlineScriptTasks(this.getModeler().get<any>("elementRegistry"));
     }
 
-    /**
-     * Creates a new, empty BPMN diagram in the modeler.
-     *
-     * @returns {@link ImportXMLResult} with any warnings produced during import.
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     */
     async newDiagram(): Promise<ImportXMLResult> {
         const result = await this.getModeler().createDiagram();
         this.applyEnginesFromDefinitions();
         return result;
     }
 
-    /**
-     * Loads the given BPMN XML into the modeler, replacing any current diagram.
-     *
-     * @param bpmn Raw BPMN 2.0 XML string.
-     * @returns {@link ImportXMLResult} with any warnings produced during import.
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     * @throws {Error} If the XML cannot be parsed.
-     */
     async loadDiagram(bpmn: string): Promise<ImportXMLResult> {
         try {
             return await this.getModeler()
                 .importXML(bpmn)
                 .then((result: ImportXMLResult) => {
-                    /**
-                     * Transaction boundaries are only available for the C7 modeler.
-                     */
+                    // Transaction boundaries are a C7-only feature.
                     if (this.engine === "c7" && this.settings.showTransactionBoundaries) {
                         this.getModeler().get<any>("transactionBoundaries").show();
                     }
@@ -538,13 +504,6 @@ export class BpmnModeler {
         }
     }
 
-    /**
-     * Serialises the current diagram to a BPMN 2.0 XML string.
-     *
-     * @returns Formatted XML string.
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     * @throws {Error} If the diagram cannot be serialised.
-     */
     async exportDiagram(): Promise<string> {
         const result: SaveXMLResult = await this.getModeler().saveXML({ format: true });
         if (result.xml) {
@@ -555,58 +514,32 @@ export class BpmnModeler {
         throw new Error("Failed to save changes made to the diagram!");
     }
 
-    /**
-     * Exports the current diagram as an SVG string.
-     *
-     * @returns SVG markup string.
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     */
     async getDiagramSvg(): Promise<string> {
         const result = await this.getModeler().saveSVG();
         return result.svg;
     }
 
-    /**
-     * Pushes a new set of element templates (as data) to the modeler's template
-     * loader.
-     *
-     * @param templates Array of element template objects.
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     */
     setElementTemplates(templates: object[]): void {
         this.getModeler().get<any>("elementTemplatesLoader").setTemplates(templates);
     }
 
-    /**
-     * Applies a partial settings update.
-     *
-     * @param settings Partial settings object to merge, or `undefined` (no-op).
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     */
     setSettings(settings: Partial<BpmnModelerSetting> | undefined): void {
         if (!settings) {
             return;
         }
-        // Ensure the modeler exists before applying any settings.
         this.getModeler();
         this.settings = { ...this.settings, ...settings };
 
         // `colorTheme` is deliberately not applied here: the page theme is host
-        // policy driven through `theme` / {@link setTheme} (#1377). It stays in
-        // the settings type/defaults but is inert on this path.
+        // policy driven through `theme` / {@link setTheme}. It stays in the
+        // settings type/defaults but is inert on this path.
 
-        /**
-         * Apply transaction boundary visibility change immediately for C7.
-         */
         if (this.engine === "c7") {
             const tb = this.getModeler().get<any>("transactionBoundaries");
             // eslint-disable-next-line @typescript-eslint/no-unused-expressions
             this.settings.showTransactionBoundaries ? tb.show() : tb.hide();
         }
 
-        /**
-         * Apply favourite BPMN elements to the append menu.
-         */
         if (settings.favouriteBpmnElements !== undefined) {
             const appendMenuOverride = this.getModeler().get<any>("appendMenuOverride", false);
             if (appendMenuOverride) {
@@ -619,9 +552,7 @@ export class BpmnModeler {
      * Triggers the align-to-origin plugin if the setting is enabled.
      *
      * @internal Host-adapter surface (invoked on save by the VS Code editor
-     *   controller); folded behind the `alignToOrigin` setting in the designed
-     *   API (#1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     *   controller); folded behind the `alignToOrigin` setting in the public API.
      */
     alignElementsToOrigin(): void {
         if (this.settings.alignToOrigin) {
@@ -632,13 +563,12 @@ export class BpmnModeler {
     /**
      * Returns a service from the modeler's dependency injection container.
      *
-     * @remarks Unstable escape hatch — kept public deliberately (see the
-     *   ADR 0007, `docs/adr`) so advanced integrations are not blocked, but
-     *   not covered by semver: DI service names can change across minor
-     *   versions. Prefer a typed option/method where one exists.
+     * @remarks Unstable escape hatch — kept public deliberately so advanced
+     *   integrations are not blocked, but not covered by semver: DI service names
+     *   can change across minor versions. Prefer a typed option/method where one
+     *   exists.
      * @param name The DI service name (e.g. `"customTranslator"`).
      * @returns The service instance.
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     getService<T = any>(name: string): T {
         return this.getModeler().get<T>(name);
@@ -654,8 +584,7 @@ export class BpmnModeler {
      * - `execution-listener` / `task-listener`: writes to the listener's
      *   nested `camunda:Script.scriptFormat`.
      *
-     * @internal Host-adapter surface (inline-scripting capability, #1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     * @internal Host-adapter surface (inline-scripting capability).
      */
     updateScriptFormat(
         elementId: string,
@@ -705,8 +634,7 @@ export class BpmnModeler {
      *   `listenerIndex` within the parent's filtered list of that listener
      *   type, then writes to its nested `camunda:Script` element's `value`.
      *
-     * @internal Host-adapter surface (inline-scripting capability, #1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     * @internal Host-adapter surface (inline-scripting capability).
      */
     updateScriptContent(
         elementId: string,
@@ -757,7 +685,7 @@ export class BpmnModeler {
      * modules are not registered for C8, so the service is resolved defensively
      * and the call is a no-op there.
      *
-     * @internal Host-adapter surface (inline-scripting capability, #1375).
+     * @internal Host-adapter surface (inline-scripting capability).
      */
     applyOpenScriptEditors(refs: OpenScriptEditorRef[]): void {
         this.getModeler().get<OpenScriptEditorsStore>("openScriptEditorsStore", false)?.set(refs);
@@ -768,7 +696,7 @@ export class BpmnModeler {
      * singleton (one `#theme-link`), so `"automatic"` follows the OS/browser
      * `prefers-color-scheme` live while `"light"`/`"dark"` force a fixed
      * stylesheet. A host that themes off its own chrome maps that signal to a
-     * forced mode at the adapter (#1377).
+     * forced mode at the adapter.
      */
     setTheme(theme: ThemeMode): void {
         setThemeMode(theme);
@@ -784,8 +712,7 @@ export class BpmnModeler {
      * omits the codeLink capability registers no `codeLinkMapClient`, and a
      * stray status push must then be a no-op rather than throw.
      *
-     * @internal Host-adapter surface (code-link capability, #1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     * @internal Host-adapter surface (code-link capability).
      */
     applyImplementationStatus(resolved: Record<string, boolean>): void {
         this.getModeler().get<CodeLinkMapClient>("codeLinkMapClient", false)?.applyStatus(resolved);

--- a/packages/bpmn-modeler/src/propertiesPanelClipboard.ts
+++ b/packages/bpmn-modeler/src/propertiesPanelClipboard.ts
@@ -1,7 +1,7 @@
 /**
  * @internal Host-adapter surface — routes the panel's plain-text copy/paste
- * through the extension-host clipboard bridge. Not part of the designed public
- * API (#1375); folded behind the `clipboard` option's bridge.
+ * through the extension-host clipboard bridge. Not part of the public API;
+ * folded behind the `clipboard` option's bridge.
  */
 import { isTextEditingSurface } from "@miragon/bpmn-modeler-types";
 

--- a/packages/bpmn-modeler/src/publicApi.spec.ts
+++ b/packages/bpmn-modeler/src/publicApi.spec.ts
@@ -14,23 +14,19 @@ import type {
 } from "./publicApi";
 
 /**
- * Type-level conformance + scenario spec for the designed public API (#1375).
+ * Type-level conformance + scenario spec for the public API.
  *
  * The assertions below are compile-checked (this file is type-checked by
  * `tsconfig.spec.json`); the single runtime `it` exists only so the test runner
  * has something to execute — esbuild strips the types without checking them, so
- * the guarantee is the `tsc` pass, not the vitest run. Each block encodes one
- * deliverable: (a) the current facade already satisfies the stable subset;
- * (b) the three bpm-iq scenarios type-check; (c) a demo-webapp-shaped literal.
+ * the guarantee is the `tsc` pass, not the vitest run.
  *
  * `satisfies` is used instead of a plain annotation so the checks cannot be
  * widened away by an over-broad target type.
  */
 
-// (a) Conformance: the current BpmnModeler class now satisfies the *full*
-// designed handle — `setTheme` landed and `setElementTemplates` widened to
-// `object[]` with #1376. If a future refactor reshapes one of these members,
-// this line stops compiling.
+// Conformance: the BpmnModeler class satisfies the full handle. If a future
+// refactor reshapes one of these members, this line stops compiling.
 const _conformance = (modeler: BpmnModeler): BpmnModelerHandle => modeler;
 void _conformance;
 
@@ -40,7 +36,7 @@ type _HandleIsSuperset = BpmnModelerHandle extends StableModelerSurface ? true :
 const _handleSuperset: _HandleIsSuperset = true;
 void _handleSuperset;
 
-// (b1) bpm-iq scenario 1 — element templates arrive as fetched data, not a path.
+// Element templates arrive as fetched data, not a path.
 const _scenarioTemplates = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -48,8 +44,8 @@ const _scenarioTemplates = {
 } satisfies ModelerOptions;
 void _scenarioTemplates;
 
-// (b2) bpm-iq scenario 2 — an async ModelNavigationPort (GitHub-API resolution
-// before opening a tab). The widened return type must accept `async`.
+// An async ModelNavigationPort (GitHub-API resolution before opening a tab).
+// The return type must accept `async`.
 const _asyncNavigation: ModelNavigationPort = {
     async openReference({ id, kind }) {
         await Promise.resolve();
@@ -64,9 +60,9 @@ const _scenarioAsyncNav = {
 } satisfies ModelerOptions;
 void _scenarioAsyncNav;
 
-// (b3) bpm-iq scenario 3 — graceful `{ config }` linting. The literal type-checks
-// against the BpmnlintConfig mirror; unresolvable rules degrade at runtime and
-// surface via onLintResults({ results, unresolved }).
+// Graceful `{ config }` linting. The literal type-checks against the
+// BpmnlintConfig mirror; unresolvable rules degrade at runtime and surface via
+// onLintResults({ results, unresolved }).
 const _scenarioLintConfig = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -92,16 +88,16 @@ const _clipboard: ClipboardOptions = {
 };
 // A host with two protocol channels (VS Code) supplies a separate `text`
 // bridge; the package forwards it to createClipboardModules' text binding and
-// drives the contenteditable polyfill from it (#1377).
+// drives the contenteditable polyfill from it.
 const _clipboardWithText: ClipboardOptions = {
     bridge: { requestClipboard: () => Promise.resolve(""), writeClipboard: () => undefined },
     text: { requestClipboard: () => Promise.resolve(""), writeClipboard: () => undefined },
 };
 void _clipboardWithText;
 // The runtime factory accepts the same clipboard override — omit it for the
-// native browser clipboard (#1374), or pass `{ bridge }` to route through a
-// host. The runtime options now implement the designed {@link ModelerOptions}
-// (engine + nested `propertiesPanel`), plus the internal `handleGlobalEscape`.
+// native browser clipboard, or pass `{ bridge }` to route through a host. The
+// runtime options extend {@link ModelerOptions} (engine + nested
+// `propertiesPanel`), plus the internal `handleGlobalEscape`.
 const _createWithClipboard = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -125,13 +121,12 @@ const _builtinsShape = {
 } satisfies ModelerOptions;
 void _builtinsShape;
 
-// The designed async factory signature is nameable and distinct from today's
-// synchronous `createModeler` (which #1376 collapses into this shape).
+// The async factory signature is nameable.
 type _FactoryReturn = ReturnType<CreateModeler>;
 const _factoryReturns: _FactoryReturn extends Promise<BpmnModelerHandle> ? true : never = true;
 void _factoryReturns;
 
-// (c) demo-webapp-shaped literal — model navigation only, no code-link/scripting.
+// Demo-webapp-shaped literal — model navigation only, no code-link/scripting.
 const _demoShape = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -146,7 +141,7 @@ const _demoShape = {
 } satisfies ModelerOptions;
 void _demoShape;
 
-describe("public API skeleton (#1375)", () => {
+describe("public API conformance", () => {
     it("is a type-only conformance spec; the guarantee is the tsc pass", () => {
         expect(true).toBe(true);
     });

--- a/packages/bpmn-modeler/src/publicApi.ts
+++ b/packages/bpmn-modeler/src/publicApi.ts
@@ -12,20 +12,14 @@ import type { ViewportManager } from "./viewport";
 import type { SelectionManager } from "./selection";
 
 /**
- * The designed public TypeScript surface of the future `@miragon/bpmn-modeler`
- * npm package (#1375, epic #1293). This file is a **type-only skeleton**: it
- * fixes the shape of `createModeler(container, options)`, the instance handle,
- * and the outbound event model *before* the package is extracted, so the
- * extraction moves code into a designed API instead of freezing today's
- * accidental facade. No runtime lives here — the current {@link BpmnModeler}
- * satisfies the stable subset (proved in `publicApi.spec.ts`), and #1373/#1376
- * grow the runtime up to the rest of this shape.
+ * The public TypeScript surface of the `@miragon/bpmn-modeler` package:
+ * `createModeler(container, options)`, the instance handle, and the outbound
+ * event model.
  *
  * ## Feature taxonomy
  *
  * Every capability the modeler exposes falls into exactly one of three
- * categories, and each declaration below is tagged with its category so the
- * ADR's taxonomy table has a machine-anchored home:
+ * categories, and each declaration below is tagged with its category:
  *
  * - **[A] Engine-intrinsic** — the diagram surface itself. Always present; not
  *   a toggle. Loading/exporting XML, the viewport, the selection, the engine.
@@ -46,13 +40,13 @@ import type { SelectionManager } from "./selection";
  * [B] Theme selection for a single instance. `"automatic"` follows the
  * OS/browser `prefers-color-scheme` live; `"light"`/`"dark"` force a fixed
  * stylesheet. A host that themes off its own chrome (VS Code `<body>` classes)
- * maps that signal to a forced mode in its adapter — the package no longer reads
- * host chrome (#1377).
+ * maps that signal to a forced mode in its adapter — the package does not read
+ * host chrome.
  */
 export type ThemeMode = "light" | "dark" | "automatic";
 
 /**
- * [B] Linting configuration, adopting #1373's tier ladder verbatim:
+ * [B] Linting configuration tiers:
  *
  * - `undefined` — linting on with the bundled default ruleset.
  * - `false` — linting off entirely (no chip, no overlay).
@@ -73,9 +67,9 @@ export type LintingOptions =
 
 /**
  * [B] Clipboard override. Default (option omitted) is the native browser
- * clipboard (#1374). A sandboxed host that cannot reach the system clipboard
- * from the webview supplies a {@link ClipboardBridge} to route copy/paste
- * through its extension host.
+ * clipboard. A sandboxed host that cannot reach the system clipboard from the
+ * webview supplies a {@link ClipboardBridge} to route copy/paste through its
+ * extension host.
  */
 export interface ClipboardOptions {
     /** Bridge for diagram-element copy/paste; also the default for `text`. */
@@ -91,10 +85,10 @@ export interface ClipboardOptions {
 
 /**
  * Outbound content notification. Debounced and owned by the package (300ms,
- * 1000ms maxWait — the shape battle-tested in `bootstrap`), because every
- * consumer needs exactly that debounce; raw `commandStack.changed` stays
- * reachable through the {@link BpmnModelerHandle.getService} escape hatch for
- * the rare consumer that wants it un-debounced.
+ * 1000ms maxWait), because every consumer needs exactly that debounce; raw
+ * `commandStack.changed` stays reachable through the
+ * {@link BpmnModelerHandle.getService} escape hatch for the rare consumer that
+ * wants it un-debounced.
  */
 export interface ContentSavedEvent {
     readonly xml: string;
@@ -109,23 +103,20 @@ export interface ContentSavedEvent {
 export interface ModelerOptions {
     // ── [A] Engine-intrinsic ────────────────────────────────────────────────
     /**
-     * [A] Camunda engine version. Required and known up front in the target
-     * shape (the current two-step `create(engine)` is the internal migration
-     * path; #1373/#1376 collapse it). Switching engines = `destroy()` + a new
+     * [A] Camunda engine version. Switching engines = `destroy()` + a new
      * instance.
      */
     engine: Engine;
 
     /**
      * [A] The panel host. Each instance owns its own properties-panel parent so
-     * several modelers can coexist on one page (rename of today's flat
-     * `propertiesPanelParent`).
+     * several modelers can coexist on one page.
      */
     propertiesPanel: { parent: HTMLElement };
 
     /**
-     * [A] Initial element templates as **data**, never a path (bpm-iq scenario
-     * 1): the host fetches the JSON and hands it in. Live updates go through
+     * [A] Initial element templates as **data**, never a path: the host fetches
+     * the JSON and hands it in. Live updates go through
      * {@link BpmnModelerHandle.setElementTemplates}.
      */
     elementTemplates?: object[];
@@ -135,8 +126,8 @@ export interface ModelerOptions {
 
     /**
      * [A] Escape hatch: extra bpmn-js DI modules. Unstable/advanced — the
-     * supported knobs are the typed options above. Renamed from the current
-     * `extraModules` to match bpmn-js's own `additionalModules`.
+     * supported knobs are the typed options above. Matches bpmn-js's own
+     * `additionalModules`.
      */
     additionalModules?: unknown[];
 
@@ -144,13 +135,13 @@ export interface ModelerOptions {
     /** [B] Linting tier — see {@link LintingOptions}. Omit for the bundled default. */
     linting?: LintingOptions;
 
-    /** [B] Clipboard override — omit for the native clipboard (#1374). */
+    /** [B] Clipboard override — omit for the native clipboard. */
     clipboard?: ClipboardOptions;
 
     /** [B] Colour theme — defaults to `"automatic"`. */
     theme?: ThemeMode;
 
-    /** [B] UI locale (BCP-47-ish tag) — defaults to `"en"`. Absorbs the page-level `TranslateModule` + `i18n.setLanguage` wiring. */
+    /** [B] UI locale (BCP-47-ish tag) — defaults to `"en"`. */
     locale?: string;
 
     // ── [C] Host capabilities ───────────────────────────────────────────────
@@ -165,10 +156,10 @@ export interface ModelerOptions {
     /** Debounced diagram content — see {@link ContentSavedEvent}. */
     onContentSaved?: (event: ContentSavedEvent) => void;
 
-    /** One lint pass completed — findings + gracefully-degraded rules (#1373). */
+    /** One lint pass completed — findings + gracefully-degraded rules. */
     onLintResults?: (event: LintRunEvent) => void;
 
-    /** The in-canvas lint chip was toggled on/off (absorbs today's `lintingHost`, #1373). */
+    /** The in-canvas lint chip was toggled on/off. */
     onLintingToggled?: (enabled: boolean) => void;
 
     /** A non-fatal warning (element-not-found, missing inline script) for the host log. */
@@ -179,13 +170,7 @@ export interface ModelerOptions {
 }
 
 /**
- * The instance handle {@link createModeler} resolves to — the designed
- * replacement for today's {@link BpmnModeler} class surface. Members are the
- * union of the **stable subset** (already implemented and frozen in shape) and
- * the **target-only** addition (`setTheme`) that #1376 adds
- * (`applyLintResults` / `applyLintingDisabled` landed with #1373's tier
- * ladder). `publicApi.spec.ts` asserts the current facade satisfies the stable
- * subset; the additions are documented in the ADR's rename/reshape map.
+ * The instance handle {@link createModeler} resolves to.
  */
 export interface BpmnModelerHandle {
     // ── [A] Engine-intrinsic ────────────────────────────────────────────────
@@ -221,23 +206,22 @@ export interface BpmnModelerHandle {
     destroy(): void;
 
     // ── [B] Opinionated built-ins ───────────────────────────────────────────
-    /** [B] Switch the colour theme live (target-only; #1376/#1377). */
+    /** [B] Switch the colour theme live. */
     setTheme(theme: ThemeMode): void;
 
     /**
-     * [B] Render host-computed lint results, or clear them with `null`
-     * (#1373's `results: "external"` tier).
+     * [B] Render host-computed lint results, or clear them with `null`.
      */
     applyLintResults(results: LintResults | null): void;
 
-    /** [B] Turn off the in-webview linter and clear its overlay (#1373). */
+    /** [B] Turn off the in-webview linter and clear its overlay. */
     applyLintingDisabled(): void;
 
     /**
-     * [B] Start (or restart) the in-webview linter — the host's no-workspace-config
-     * handback (#1373 Phase B). Optional `config` overrides the engine-aware
-     * default; optional `configToken` (#1384) lets a repeat instruction with the
-     * same version dedup while linting is live. Never re-enables a user-disabled
+     * [B] Start (or restart) the in-webview linter with the host's
+     * no-workspace-config handback. Optional `config` overrides the engine-aware
+     * default; optional `configToken` lets a repeat instruction with the same
+     * version dedup while linting is live. Never re-enables a user-disabled
      * linter.
      */
     startInPageLinting(config?: BpmnlintConfig, configToken?: string): void;
@@ -246,8 +230,8 @@ export interface BpmnModelerHandle {
     /**
      * Unstable escape hatch: reach a bpmn-js DI service by name. Not covered by
      * semver — plugin authors accept breakage across minor versions. Kept
-     * public deliberately (ADR decision) so advanced integrations are not
-     * blocked while the typed surface catches up.
+     * public deliberately so advanced integrations are not blocked while the
+     * typed surface catches up.
      *
      * @remarks Unstable. Prefer a typed option/method; open an issue if one is missing.
      */
@@ -255,15 +239,10 @@ export interface BpmnModelerHandle {
 }
 
 /**
- * [A] The designed package entry point: stand up one modeler bound to
- * `container` and resolve its {@link BpmnModelerHandle}. Async because #1373's
- * lazy lint chunk forces a construction await anyway; a host that learns the
- * engine late simply calls this late (today's `bootstrap` already constructs
- * after the file handshake).
- *
- * Type-only in this spike — the runtime factory is still
- * {@link createModeler} + the two-step `create(engine)`; #1376 collapses the
- * two into this signature.
+ * [A] The package entry point: stand up one modeler bound to `container` and
+ * resolve its {@link BpmnModelerHandle}. Async because the lazy lint chunk
+ * forces a construction await; a host that learns the engine late simply calls
+ * this late.
  */
 export type CreateModeler = (
     container: HTMLElement,
@@ -271,12 +250,8 @@ export type CreateModeler = (
 ) => Promise<BpmnModelerHandle>;
 
 /**
- * The stable subset of {@link BpmnModelerHandle}: the members the current
- * {@link BpmnModeler} already implements with target-final signatures, so their
- * shape is frozen and the extraction cannot silently reshape them.
- * `setElementTemplates` is intentionally excluded — its param widens from
- * `JSON[] | undefined` to `object[]` (see the ADR's reshape map), so it is not
- * yet stable.
+ * The subset of {@link BpmnModelerHandle} whose signatures are frozen, asserted
+ * against the runtime handle in `publicApi.spec.ts`.
  */
 export type StableModelerSurface = Pick<
     BpmnModelerHandle,

--- a/packages/bpmn-modeler/src/rootElement.ts
+++ b/packages/bpmn-modeler/src/rootElement.ts
@@ -1,14 +1,9 @@
 /**
  * @internal Host-adapter surface — drill-down root tracking used for canvas
- * view-state restore. Not part of the designed public API (#1375).
+ * view-state restore. Not part of the public API.
  */
 
-/**
- * Function type for accessing a service from the bpmn-js DI container.
- *
- * @template T The service type to retrieve.
- * @param name The DI service name.
- */
+/** Accessor for a service from the bpmn-js DI container, by name. */
 type ServiceAccessor = <T>(name: string) => T;
 
 /**
@@ -25,8 +20,7 @@ const IMPLICIT_ROOT_PREFIX = "__implicitroot";
  * The root element determines which plane is visible — the top-level
  * process or a collapsed sub-process drill-down. Decoupled from the
  * modeler through a {@link ServiceAccessor} so the concern can be tested
- * and composed independently, following the same pattern as
- * {@link ViewportManager} and {@link SelectionManager}.
+ * and composed independently.
  */
 export class RootElementManager {
     constructor(private readonly getService: ServiceAccessor) {}

--- a/packages/bpmn-modeler/src/selection.ts
+++ b/packages/bpmn-modeler/src/selection.ts
@@ -1,9 +1,4 @@
-/**
- * Function type for accessing a service from the bpmn-js DI container.
- *
- * @template T The service type to retrieve.
- * @param name The DI service name.
- */
+/** Accessor for a service from the bpmn-js DI container, by name. */
 type ServiceAccessor = <T>(name: string) => T;
 
 /**
@@ -15,9 +10,6 @@ type ServiceAccessor = <T>(name: string) => T;
 export class SelectionManager {
     constructor(private readonly getService: ServiceAccessor) {}
 
-    /**
-     * Returns the IDs of the currently selected elements.
-     */
     getSelectedElementIds(): string[] {
         return this.getService<any>("selection")
             .get()
@@ -25,12 +17,8 @@ export class SelectionManager {
     }
 
     /**
-     * Selects elements by their IDs.
-     *
      * Silently skips IDs that no longer exist in the diagram (e.g. element
      * was deleted before the tab switch).
-     *
-     * @param ids Element IDs to select.
      */
     selectElementsByIds(ids: string[]): void {
         const registry = this.getService<any>("elementRegistry");
@@ -40,11 +28,6 @@ export class SelectionManager {
         }
     }
 
-    /**
-     * Subscribes to selection changes on the event bus.
-     *
-     * @param cb Callback invoked with the IDs of the newly selected elements.
-     */
     onSelectionChanged(cb: (elementIds: string[]) => void): void {
         this.getService<any>("eventBus").on("selection.changed", (event: any) => {
             const ids = (event.newSelection ?? []).map((el: any) => el.id);

--- a/packages/bpmn-modeler/src/styles/dark-theme/diagram-js.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/diagram-js.css
@@ -81,8 +81,8 @@
  * scoping each rule to the known value. A blanket `*` override would beat — via
  * `!important` — the inline style bpmn-js writes for a user's "Set color" choice.
  * Value-scoping also handles two cases for free: `fill: none` (bpmn:Group, text
- * annotations) matches nothing and stays transparent (#1056), and filled throw
- * markers are covered by the rules below (#1017).
+ * annotations) matches nothing and stays transparent, and filled throw markers
+ * are covered by the rules below.
  */
 
 /* defaultFillColor (white) → dark surface */

--- a/packages/bpmn-modeler/src/theme.spec.ts
+++ b/packages/bpmn-modeler/src/theme.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
- * Page theme controller (#1377). The module is a page singleton (a `currentMode`
+ * Page theme controller. The module is a page singleton (a `currentMode`
  * plus one live `prefers-color-scheme` listener), so each test reloads it via
  * `vi.resetModules()` to start from the initial `"automatic"` state. Because the
  * initial mode is already `"automatic"`, the same-mode guard means a fresh

--- a/packages/bpmn-modeler/src/theme.ts
+++ b/packages/bpmn-modeler/src/theme.ts
@@ -8,9 +8,9 @@
  *
  * A host's own light/dark chrome (e.g. VS Code's `<body>` classes) is host
  * policy: the host adapter maps that signal to a forced `setTheme("light")` /
- * `setTheme("dark")` — the package never reads host chrome (#1377).
+ * `setTheme("dark")` — the package never reads host chrome.
  *
- * @internal Not part of the designed public handle; reached only through
+ * @internal Not part of the public handle; reached only through
  *   {@link BpmnModeler.setTheme}.
  */
 import type { ThemeMode } from "./publicApi";
@@ -49,8 +49,7 @@ export function applyResolvedTheme(kind: "light" | "dark"): void {
  * theme switch is reflected live; a forced `"light"`/`"dark"` stops that
  * listener so the fixed choice is not overwritten on the next scheme change.
  *
- * A no-op when the mode is unchanged — same guard the module singleton carried
- * before the extraction, so a hosted session that never sets `theme` is untouched.
+ * A no-op when the mode is unchanged.
  */
 export function setThemeMode(mode: ThemeMode): void {
     if (mode === currentMode) {
@@ -87,9 +86,6 @@ function startFollowingPreferredScheme(): void {
     mediaQuery.addEventListener("change", mediaListener);
 }
 
-/**
- * Disconnects the `prefers-color-scheme` listener.
- */
 function stopFollowingPreferredScheme(): void {
     if (mediaQuery && mediaListener) {
         mediaQuery.removeEventListener("change", mediaListener);

--- a/packages/bpmn-modeler/src/types/bpmnlint.d.ts
+++ b/packages/bpmn-modeler/src/types/bpmnlint.d.ts
@@ -7,7 +7,7 @@ declare module "bpmn-js-bpmnlint" {
 }
 
 /**
- * `bpmnlint` ships no type declarations. The in-page linter (#1373) drives only
+ * `bpmnlint` ships no type declarations. The in-page linter drives only
  * `Linter` directly — it builds the rule/config resolver from
  * `@miragon/bpmnlint-plugin-rules` (which is typed), so this shim needs only the
  * one class the webview constructs. Rule/config shapes are opaque, passed

--- a/packages/bpmn-modeler/src/viewport.ts
+++ b/packages/bpmn-modeler/src/viewport.ts
@@ -16,12 +16,7 @@ export interface ViewportData {
     scale?: number;
 }
 
-/**
- * Function type for accessing a service from the bpmn-js DI container.
- *
- * @template T The service type to retrieve.
- * @param name The DI service name.
- */
+/** Accessor for a service from the bpmn-js DI container, by name. */
 type ServiceAccessor = <T>(name: string) => T;
 
 // Zoom floor when focusing an element, so a far-zoomed-out view still shows it


### PR DESCRIPTION
## Issue

N/A — follow-up cleanup after the package extraction (#1393–#1397).

## Description

Removes GitHub issue/epic/ADR references and migration-planning narrative from the comments in `packages/bpmn-modeler`, left over from the extraction. Comments now carry only non-obvious why-context: restating docblocks were deleted, long design narratives trimmed, and one test name lost its embedded ticket number. Comment-only change — no runtime behavior touched; all 141 package tests pass.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)