### PR TITLE
docs(bpmn-modeler): clean up extraction-era comments

### DIFF
--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -104,23 +104,22 @@ export function bootstrap(
 }
 
 /**
- * One webview session. All state that used to live at module scope — the
- * modeler, resolvers, debounced syncs, flush responder, the "is initialized"
- * latch — is folded into this closure so a session owns its own lifetime rather
- * than a page-wide singleton. The single-instance hosts (VS Code, IntelliJ,
- * Theia) call {@link bootstrap} exactly once, so behaviour is unchanged; the
- * closure is the prerequisite for the multi-instance facade (issue #1372).
+ * One webview session. The modeler, resolvers, debounced syncs, flush
+ * responder, and the "is initialized" latch are scoped to this closure so a
+ * session owns its own lifetime rather than a page-wide singleton — the
+ * prerequisite for hosting more than one modeler on a page. Single-instance
+ * hosts (VS Code, IntelliJ, Theia) call {@link bootstrap} exactly once.
  *
  * @param host The injected host adapter.
  * @param injectedModules Host-specific extra bpmn-js DI modules.
  * @param injectedCapabilities Explicit per-feature ports; `undefined` selects
  *   the full protocol adapter so every real host keeps all features.
  * @param injectedLinting The bpmnlint tier; `undefined` selects the external
- *   (host-pushed) tier so every real host stays byte-identical to today.
- * @param injectedClipboard The clipboard tier; `undefined` keeps today's
- *   behaviour (dev-build native, otherwise the protocol bridge). `"native"`
- *   forces the browser clipboard (demo/browser consumers, #1374); `{ bridge }`
- *   routes through a caller-supplied override.
+ *   (host-pushed) tier that real hosts use.
+ * @param injectedClipboard The clipboard tier; `undefined` selects dev-build
+ *   native, otherwise the protocol bridge. `"native"` forces the browser
+ *   clipboard (demo/browser consumers); `{ bridge }` routes through a
+ *   caller-supplied override.
  * @param injectedOnLintResults In-page lint-run sink; only a consumer opting into
  *   in-page linting (the demo) passes one. Real hosts run the linter themselves.
  */
@@ -142,10 +141,10 @@ function startSession(
     // editor and focuses in one tick); apply it once the modeler is ready.
     let pendingFocusId: string | undefined;
 
-    // The opaque config-version token from the host's last BpmnlintInPageQuery
-    // (#1384), echoed back on every UpdateLintResultsCommand so the host can pair
-    // a run with the config version it linted and drop a stale run. `undefined`
-    // for the payload-free #1373 default tier (and reset to it on config→no-config).
+    // The opaque config-version token from the host's last BpmnlintInPageQuery,
+    // echoed back on every UpdateLintResultsCommand so the host can pair a run
+    // with the config version it linted and drop a stale run. `undefined` for
+    // the payload-free default tier (and reset to it on config→no-config).
     //
     // Pairing is race-free without any per-run plumbing: BrowserLinter.run is a
     // pure microtask chain (bpmnlint over the in-memory tree, no I/O), so it
@@ -158,7 +157,6 @@ function startSession(
     let elementClipboardResolver = createResolver<ClipboardQuery>();
     let textClipboardResolver = createResolver<TextClipboardQuery>();
 
-    // Create resolver to wait for the response from the backend.
     const bpmnFileResolver = createResolver<BpmnFileQuery>();
 
     // Resolvers that signal when element templates and settings have been
@@ -251,10 +249,10 @@ function startSession(
     }
 
     /**
-     * The default capability adapter: each port posts the existing protocol
-     * command to the host. Used whenever `bootstrap()` is called without
-     * explicit capabilities, so VS Code / IntelliJ / Theia are unaffected by the
-     * port indirection. Closes over the session {@link host} and {@link bpmnModeler}.
+     * The default capability adapter: each port posts the protocol command to
+     * the host. Selected whenever `bootstrap()` is called without explicit
+     * capabilities, so every real host (VS Code, IntelliJ, Theia) runs through
+     * it. Closes over the session {@link host} and {@link bpmnModeler}.
      *
      * `scripting` is always populated here even though its DI cluster is C7-only;
      * `capabilityModules` gates the registration, so the surplus port on C8 is inert.
@@ -328,12 +326,11 @@ function startSession(
 
         // Resolve the clipboard option passed to createModeler. The package
         // builds the DI modules and installs the contenteditable/FEEL polyfill
-        // from it (the polyfill therefore installs during createModeler rather
-        // than here — an invisible timing change).
+        // from it, so the polyfill installs during createModeler.
         //
-        // - `undefined` (default): today's behavior — in dev (plain-browser
-        //   `serve`) the native browser clipboard handles copy/paste, so no
-        //   option is passed; otherwise route both channels through the host.
+        // - `undefined` (default): in dev (plain-browser `serve`) the native
+        //   browser clipboard handles copy/paste, so no option is passed;
+        //   otherwise route both channels through the host.
         // - `"native"`: force the browser clipboard (demo/browser consumers) —
         //   no option, no polyfill.
         // - `{ bridge }`: public override — passed through unchanged; the
@@ -342,7 +339,7 @@ function startSession(
 
         if (injectedClipboard === "native") {
             // Native browser clipboard: pass no option so bpmn-js's
-            // NativeCopyPaste stays in charge (#1374).
+            // NativeCopyPaste stays in charge.
         } else if (injectedClipboard) {
             clipboard = injectedClipboard;
         } else if (process.env.NODE_ENV !== "development") {
@@ -367,9 +364,8 @@ function startSession(
             };
 
             // Two independent protocol channels so element and label/FEEL
-            // clipboards stay separate — byte-identical to today's real-host
-            // wiring. The package installs the contenteditable polyfill off the
-            // `text` bridge.
+            // clipboards stay separate. The package installs the contenteditable
+            // polyfill off the `text` bridge.
             clipboard = {
                 bridge: {
                     requestClipboard: requestElementClipboard,
@@ -405,7 +401,7 @@ function startSession(
 
         // Host HTML keeps its `js-canvas` / `js-properties-panel` ids; the
         // facade takes the resolved elements, not selectors, so a second modeler
-        // (in-page diff, #1372) can pass its own DOM hosts with no ids.
+        // (in-page diff) can pass its own DOM hosts with no ids.
         const canvasEl = document.getElementById("js-canvas");
         const propertiesPanelParent = document.getElementById("js-properties-panel");
         if (!canvasEl || !propertiesPanelParent) {
@@ -436,8 +432,8 @@ function startSession(
         }
 
         // The engine is known here (the file handshake above completed), so the
-        // former two-step createModeler + create(engine) collapses into one async
-        // call. A missing engine is fatal — bail before construction.
+        // modeler is created in one async call. A missing engine is fatal — bail
+        // before construction.
         const engine = bpmnFileQuery?.engine;
         if (!engine) {
             host.postMessage(new LogErrorCommand("ExecutionPlatformVersion undefined!"));
@@ -447,10 +443,9 @@ function startSession(
         const capabilities = injectedCapabilities ?? createProtocolCapabilities();
         const extraModules = (injectedModules as unknown[]) ?? [];
         // Real hosts run the linter themselves and push results, so the default
-        // tier is external — keeping VS Code / IntelliJ / Theia byte-identical to
-        // today. A consumer (or the demo) can opt into in-page linting by passing
-        // an explicit `linting`. The user's in-canvas toggle is relayed to the host
-        // as before; the host re-lints and pushes the new state down.
+        // tier is external. A consumer (or the demo) can opt into in-page linting
+        // by passing an explicit `linting`. The user's in-canvas toggle is relayed
+        // to the host, which re-lints and pushes the new state down.
         try {
             bpmnModeler = await createModeler(canvasEl, {
                 engine,
@@ -461,9 +456,9 @@ function startSession(
                 linting: injectedLinting ?? { results: "external" },
                 // A real host activates in-page linting only after it answers the
                 // GetBpmnlintConfigCommand with BpmnlintInPageQuery (no workspace
-                // config, #1373 Phase B); the webview then pushes its findings back
-                // so the host feeds its Problems panel + status bar. `??` keeps the
-                // demo's injected sink authoritative when one is supplied.
+                // config); the webview then pushes its findings back so the host
+                // feeds its Problems panel + status bar. `??` keeps the demo's
+                // injected sink authoritative when one is supplied.
                 onLintResults:
                     injectedOnLintResults ??
                     ((e: LintRunEvent) =>
@@ -527,13 +522,12 @@ function startSession(
             pendingFocusId = undefined;
         }
 
-        // The "Edit Script" / divergence bridge now lives entirely in the
-        // scripting capability port (InlineScriptingPortForwarder →
-        // createProtocolCapabilities), registered by capabilityModules on C7.
-        // Only the process-variable publisher stays here because it drives the
-        // host from a commandStack subscription rather than a lib-owned event. It
-        // belongs to the scripting capability, so gate it on both the engine and
-        // the port being present.
+        // The "Edit Script" / divergence bridge lives in the scripting capability
+        // port (InlineScriptingPortForwarder → createProtocolCapabilities),
+        // registered by capabilityModules on C7. Only the process-variable
+        // publisher stays here because it drives the host from a commandStack
+        // subscription rather than a lib-owned event. It belongs to the scripting
+        // capability, so gate it on both the engine and the port being present.
         if (bpmnFileQuery?.engine === "c7" && capabilities.scripting) {
             // Publish the process-variable model to the host so open script
             // editors get live variable completion. The chain is a feedback loop,
@@ -582,8 +576,8 @@ function startSession(
         // Panel visibility: this editor's own saved entry (applied early above)
         // wins. Only when absent do we fall back to the host's global default —
         // the seed for a first-ever open. This branch is deliberately *not*
-        // gated on templates/settings, so a slow or dropped templates reply can
-        // no longer leave the panel stuck at the pre-rendered default.
+        // gated on templates/settings, so a slow or dropped templates reply
+        // cannot leave the panel stuck at the pre-rendered default.
         if (savedPanelVisible === undefined) {
             const panelStateQuery = await panelStateResolver.wait(RESOLVER_TIMEOUT_MS);
             stateManager.restorePanelVisibility(
@@ -739,14 +733,13 @@ function startSession(
                 try {
                     const q = message.data as BpmnlintInPageQuery;
                     // The token stays current for the onLintResults echo. Dedup of
-                    // a repeat covered instruction now lives in LintConfigService,
-                    // where the tier state is known — a stale token from an
-                    // intervening disabled push can no longer drop a re-enable.
+                    // a repeat covered instruction lives in LintConfigService,
+                    // where the tier state is known, so a stale token from an
+                    // intervening disabled push cannot drop a re-enable.
                     currentLintConfigToken = q.configToken;
-                    // No workspace config → engine-aware default (#1373 Phase B);
-                    // a covered config (#1384) → lint it in-page. Either way
-                    // onLintResults pushes the findings back so the host feeds its
-                    // Problems panel + status bar.
+                    // No workspace config → engine-aware default; a covered config
+                    // → lint it in-page. Either way onLintResults pushes the
+                    // findings back so the host feeds its Problems panel + status bar.
                     bpmnModeler.startInPageLinting(q.config, q.configToken);
                 } catch (error: any) {
                     host.postMessage(new LogErrorCommand(errorPrefix + error.message));
@@ -757,8 +750,8 @@ function startSession(
                 const query = message.data as BpmnModelerSettingQuery;
                 try {
                     // Theme is host policy: the adapter drives the page theme off
-                    // the VS Code `<body>`-class watcher (initTheme) here, since
-                    // the package's setSettings no longer applies `colorTheme`.
+                    // the VS Code `<body>`-class watcher (initTheme) here, because
+                    // the package's setSettings does not apply `colorTheme`.
                     setColorThemeMode(query.setting.colorTheme);
                     bpmnModeler.setSettings(query.setting);
                 } catch (error: any) {

--- a/apps/bpmn-webview/src/state.ts
+++ b/apps/bpmn-webview/src/state.ts
@@ -76,7 +76,7 @@ export class WebviewStateManager {
      * `getState()`); a fresh open/reopen starts with empty state. So the
      * absence of a saved viewport discriminates a genuine fresh open, where we
      * fit the diagram — bpmn-js leaves the canvas at the origin on importXML,
-     * which renders a diagram moved far from the origin off-screen (#1149).
+     * which renders a diagram moved far from the origin off-screen.
      *
      * Safe to call repeatedly: nothing happens until the host has laid the
      * canvas out, and then it applies exactly once — re-fitting on every later

--- a/apps/bpmn-webview/src/webviewState.ts
+++ b/apps/bpmn-webview/src/webviewState.ts
@@ -1,6 +1,6 @@
 /**
  * @internal Host-adapter surface — persisted webview UI state shapes consumed by
- * `WebviewStateManager`. Not part of the designed public API (#1375).
+ * `WebviewStateManager`. Not part of the public modeler API.
  */
 
 import type { ViewportData } from "@miragon/bpmn-modeler";

--- a/apps/demo-webapp/bpmn/demoHost.ts
+++ b/apps/demo-webapp/bpmn/demoHost.ts
@@ -23,7 +23,7 @@ function dispatch(event: MessageType): void {
  * it no longer crosses this message boundary. Everything else a real host does —
  * deployment, code-link, script editor, persistence — is a no-op here. Clipboard
  * is not bridged at all: the demo opts into the native browser clipboard
- * (`clipboard: "native"` in main.ts, #1374).
+ * (`clipboard: "native"` in main.ts).
  */
 export class BpmnDemoHost extends MockHostApi<WebviewState, MessageType> {
     override updateState(state: Partial<WebviewState>): void {

--- a/apps/demo-webapp/bpmn/diff.ts
+++ b/apps/demo-webapp/bpmn/diff.ts
@@ -12,14 +12,14 @@ import "../../../packages/bpmn-modeler/src/styles/light-theme/index.css";
 import { DIFF_AFTER_XML, DIFF_BEFORE_XML } from "./diffFixtures";
 
 /**
- * In-page two-pane diff demo (issue #1378) — the in-repo consumer of the public
- * diff surface. No host, no bootstrap, no relayed protocol: two `DiffViewer`s,
- * the Node-safe `computeDiff` data layer fed two XML strings, and a
- * `DiffPaneCoordinator` arming viewport lockstep + a shared stepper. One
- * `DiffLegend` per pane drives prev/next on the shared coordinator.
+ * In-page two-pane diff demo — the in-repo consumer of the public diff surface.
+ * No host, no bootstrap, no relayed protocol: two `DiffViewer`s, the Node-safe
+ * `computeDiff` data layer fed two XML strings, and a `DiffPaneCoordinator` arming
+ * viewport lockstep + a shared stepper. One `DiffLegend` per pane drives prev/next
+ * on the shared coordinator.
  *
- * This is the bpm-iq scenario in miniature: two versions in, a `DiffResult` and
- * rendered primitives out. Manual checks: pan/zoom stays in lockstep across
+ * Two versions in, a `DiffResult` and rendered primitives out. Manual checks:
+ * pan/zoom stays in lockstep across
  * panes, and prev/next steps both panes together (including anchoring when a
  * step lands on an added/removed element that exists on only one side).
  */

--- a/apps/demo-webapp/bpmn/diffFixtures.ts
+++ b/apps/demo-webapp/bpmn/diffFixtures.ts
@@ -2,8 +2,8 @@
  * Self-contained BPMN XML pair for the two-pane diff demo (`bpmn/diff.html`).
  *
  * Two strings in, a `DiffResult` + rendered primitives out — the exact shape a
- * consumer like bpm-iq needs when diffing two fetched versions of a diagram
- * (issue #1378). The two diagrams differ in every category the differ reports:
+ * consumer needs when diffing two fetched versions of a diagram. The two diagrams
+ * differ in every category the differ reports:
  * `ServiceTask_1` is renamed (changed), `Gateway_1` is added, `UserTask_ToRemove`
  * is removed, and `ServiceTask_2` moves on the canvas (layoutChanged).
  */

--- a/apps/demo-webapp/bpmn/dual.ts
+++ b/apps/demo-webapp/bpmn/dual.ts
@@ -2,8 +2,8 @@ import { createModeler } from "@miragon/bpmn-modeler";
 import { getActiveModel } from "../src";
 
 /**
- * Two-instance regression proof for issue #1372: two independent modelers on one
- * page, each bound to its own canvas + panel host, neither using the legacy
+ * Two-instance regression proof: two independent modelers on one page, each
+ * bound to its own canvas + panel host, neither using the legacy
  * `#js-canvas` / `#js-properties-panel` ids (that absence is the proof). No host,
  * no bootstrap — a bare {@link createModeler} per pane. Manual checks: pan/zoom/
  * selection and the properties panels are independent, Escape in panel A focuses

--- a/apps/demo-webapp/bpmn/main.ts
+++ b/apps/demo-webapp/bpmn/main.ts
@@ -4,17 +4,17 @@ import { BpmnDemoHost } from "./demoHost";
 
 mountDemoHeader("bpmn");
 // The demo supplies only the model-navigation capability; codeLink and scripting
-// are omitted, so their context-pad entries / lock UI genuinely never render
-// (AC3 — a host-less consumer no longer gets dead buttons).
+// are omitted, so their context-pad entries / lock UI genuinely never render — a
+// host-less consumer gets no dead buttons.
 //
 // `linting: {}` opts into in-page linting with the engine-aware default config —
-// the host-less proof that the webview lints itself (#1373, AC 1). onLintResults
-// logs each run so the browser console shows the rule-keyed output + any rules
-// the bundled resolver could not cover.
+// the host-less proof that the webview lints itself. onLintResults logs each run
+// so the browser console shows the rule-keyed output + any rules the bundled
+// resolver could not cover.
 bootstrap(new BpmnDemoHost(), {
     extraModules: [DemoGrayoutModule],
     linting: {},
-    // Plain-browser demo: use the native browser clipboard (#1374). The stub
+    // Plain-browser demo: use the native browser clipboard. The stub
     // host cannot serve a real clipboard, so the protocol-bridge default would
     // leave paste dead in the production build.
     clipboard: "native",

--- a/apps/demo-webapp/vite.config.mts
+++ b/apps/demo-webapp/vite.config.mts
@@ -39,9 +39,9 @@ export default defineConfig(({ mode }) => {
             outDir: resolve(__dirname, `../../dist/demo/${target}`),
             emptyOutDir: true,
             // The bpmn page ships extra entries — the two-instance regression
-            // proof at /bpmn/dual.html (issue #1372) and the two-pane diff demo
-            // at /bpmn/diff.html (issue #1378). The dev server serves them
-            // automatically; only the build needs the extra rollup inputs.
+            // proof at /bpmn/dual.html and the two-pane diff demo at
+            // /bpmn/diff.html. The dev server serves them automatically; only the
+            // build needs the extra rollup inputs.
             rollupOptions:
                 target === "bpmn"
                     ? {

--- a/apps/deployment-webview/src/app/startInstanceForm.ts
+++ b/apps/deployment-webview/src/app/startInstanceForm.ts
@@ -31,14 +31,7 @@ export class StartInstanceForm {
     // Absolute path to the selected payload file, or empty string.
     private payloadFilePath = "";
 
-    /**
-     * Wires up all DOM element references and attaches event listeners.
-     *
-     * @param host The host channel used to post messages.
-     * @param getSharedAuth Callback to read the current auth config from the shared form fields.
-     * @param getSharedConnection Callback to read endpoint and engine from the shared form fields.
-     * @throws {Error} If any expected DOM element is missing.
-     */
+    /** Resolves DOM references and binds events; throws if an expected element is missing. */
     constructor(
         private readonly host: HostApi<unknown, Command | Query>,
         private readonly getSharedAuth: () => AuthConfigPayload,
@@ -57,29 +50,16 @@ export class StartInstanceForm {
         this.bindEvents();
     }
 
-    /**
-     * Sets the process definition key input value.
-     *
-     * @param key The process definition key extracted from the BPMN file.
-     */
     setProcessDefinitionKey(key: string): void {
         this.processDefinitionKeyInput.value = key;
     }
 
-    /**
-     * Sets the payload file display and stores the path internally.
-     *
-     * @param filePath Absolute path to the payload file.
-     * @param label Display label (typically the filename).
-     */
+    /** Shows the payload file label and stores its absolute path. */
     setPayloadFile(filePath: string, label: string): void {
         this.payloadFilePath = filePath;
         this.payloadFileInput.value = label || "(none)";
     }
 
-    /**
-     * Disables the Start Instance button and shows a progress indicator.
-     */
     showProgress(): void {
         this.startInstanceBtn.disabled = true;
         this.statusBanner.className = "status-banner progress";
@@ -87,11 +67,7 @@ export class StartInstanceForm {
         this.statusBanner.style.display = "block";
     }
 
-    /**
-     * Shows the start-instance result in the status banner and re-enables the button.
-     *
-     * @param result The result query received from the extension host.
-     */
+    /** Shows the start-instance result in the status banner and re-enables the button. */
     showResult(result: StartInstanceResultQuery): void {
         this.startInstanceBtn.disabled = false;
         this.statusBanner.className = result.success
@@ -108,9 +84,6 @@ export class StartInstanceForm {
 
     // --- Private helpers ---
 
-    /**
-     * Attaches click handlers to the Select Payload and Start Instance buttons.
-     */
     private bindEvents(): void {
         this.selectPayloadBtn.addEventListener("click", () => {
             this.host.postMessage(new RequestPayloadFilesCommand());
@@ -136,12 +109,7 @@ export class StartInstanceForm {
         });
     }
 
-    /**
-     * Reads the current form values and builds a {@link StartInstanceConfigPayload}.
-     *
-     * @returns A payload ready to attach to a {@link StartInstanceCommand}.
-     * @throws {Error} If required fields are empty.
-     */
+    /** Builds a {@link StartInstanceConfigPayload} from the form, throwing on empty required fields. */
     private getConfigPayload(): StartInstanceConfigPayload {
         const processDefinitionKey = this.processDefinitionKeyInput.value.trim();
         if (!processDefinitionKey) {
@@ -162,13 +130,7 @@ export class StartInstanceForm {
         };
     }
 
-    /**
-     * Returns the DOM element matching `selector` or throws if not found.
-     *
-     * @param selector CSS selector string.
-     * @returns The matching element.
-     * @throws {Error} If no element matches the selector.
-     */
+    /** Returns the DOM element matching `selector`, or throws if none matches. */
     private requireElement<T extends Element>(selector: string): T {
         const el = document.querySelector<T>(selector);
         if (!el) {

--- a/apps/deployment-webview/src/main.ts
+++ b/apps/deployment-webview/src/main.ts
@@ -113,13 +113,7 @@ function initTabs(): void {
     }
 }
 
-/**
- * Activates the given tab by toggling `.active` on buttons and panels.
- *
- * @param tab The tab identifier (matching `data-tab` attribute).
- * @param tabBtns All tab button elements.
- * @param tabPanels All tab panel elements.
- */
+/** Activates the given tab by toggling `.active` on its button and panel. */
 function activateTab(
     tab: string,
     tabBtns: NodeListOf<HTMLButtonElement>,
@@ -133,13 +127,7 @@ function activateTab(
     }
 }
 
-/**
- * Routes messages from the host application to the appropriate form method.
- *
- * @param event The raw `MessageEvent` from `window.addEventListener("message", …)`.
- * @param form The active {@link DeploymentForm} instance.
- * @param startForm The active {@link StartInstanceForm} instance.
- */
+/** Routes messages from the host to the appropriate form method. */
 function onReceiveMessage(
     event: MessageEvent<Query | Command>,
     form: DeploymentForm,

--- a/apps/dmn-webview/src/app/modeler.ts
+++ b/apps/dmn-webview/src/app/modeler.ts
@@ -77,21 +77,7 @@ export function createModeler(): DmnModeler {
     return modeler;
 }
 
-/**
- * Create a new diagram.
- * @returns ImportWarning with warnings if any
- * @throws NoModelerError if the modeler is not initialized
- */
-// export async function newDiagram(): Promise<DiagramWarning> {
-//     return loadDiagram(EMPTY_DIAGRAM_XML);
-// }
-
-/**
- * Load the diagram from the given XML content.
- * @param dmn
- * @returns ImportWarning with warnings if any
- * @throws NoModelerError if the modeler is not initialized
- */
+/** Imports the given DMN XML, collecting any import warnings into the thrown error. */
 export async function loadDiagram(dmn: string): Promise<DiagramWarning> {
     try {
         const m = getModeler();
@@ -110,12 +96,7 @@ export async function loadDiagram(dmn: string): Promise<DiagramWarning> {
     }
 }
 
-/**
- * Get the XML content of the current diagram.
- * @return the XML content
- * @throws NoModelerError if the modeler is not initialized
- * @throws Error if something went wrong
- */
+/** Serialises the current diagram to formatted DMN XML. */
 export async function exportDiagram(): Promise<string> {
     const m = getModeler();
     const result = await m.saveXML({ format: true });
@@ -132,10 +113,6 @@ export async function exportDiagram(): Promise<string> {
  * dmn-js only re-measures when a view is attached, so a host that lays the
  * webview out after the open leaves the DRD canvas on a stale box, throwing
  * off hit-testing and drag coordinates.
- *
- * @param container The element whose size drives the active view.
- * @returns A disposer that stops observing.
- * @throws NoModelerError if the modeler is not initialized
  */
 export function syncCanvasSize(container: Element): () => void {
     getModeler();
@@ -169,10 +146,7 @@ export function onCommandStackChanged(cb: () => void): void {
     });
 }
 
-/**
- * Get the modeler instance.
- * @throws NoModelerError if the modeler is not initialized
- */
+/** Returns the modeler instance, throwing {@link NoModelerError} before init. */
 function getModeler(): DmnModeler {
     if (!modeler) {
         throw new NoModelerError();

--- a/apps/intellij-plugin/README.md
+++ b/apps/intellij-plugin/README.md
@@ -6,9 +6,9 @@ A third host for the Miragon BPMN modeler (after VS Code and Theia). It opens
 running the **unmodified TypeScript core out-of-process**, as a supervised,
 **Node-free** binary.
 
-This is the host foundation from issue #1062. It is **pure transport + port
-adapters**: the modeling engine is `@miragon/bpmn-modeler-core`, consumed over a
-bridge (`apps/modeler-bridge/`), never reimplemented in Kotlin.
+This is the host foundation. It is **pure transport + port adapters**: the
+modeling engine is `@miragon/bpmn-modeler-core`, consumed over a bridge
+(`apps/modeler-bridge/`), never reimplemented in Kotlin.
 
 ## Architecture
 
@@ -120,7 +120,7 @@ as balloons. Tail the IDE log for `[bridge stderr]` lines to watch the seam.
 > `corepack yarn intellij:build` (or the full `intellij:run`) after editing the
 > webview.
 
-### Verifying the dark-mode Token Simulation fix (#1199)
+### Verifying the dark-mode Token Simulation fix
 
 Token Simulation used to break the diagram in dark mode (white shapes, vanished
 arrows). To verify it stays fixed: switch the sandbox IDE to a **dark** theme
@@ -191,11 +191,10 @@ JS/TS, so the Kotlin sources are untouched. Build output (`build/`, `.gradle/`,
 
 ## Cross-platform packaging (release follow-up)
 
-This PR stages only the **host** platform's binary. Shipping to the JetBrains
+The build stages only the **host** platform's binary. Shipping to the JetBrains
 Marketplace needs the Bun `--target` matrix (darwin-arm64/x64, linux-x64,
 windows-x64) each staged under `bin/<os>-<arch>/`, plus macOS codesign /
-notarization — tracked as the release-pipeline follow-up in the
-runtime-distribution ADR.
+notarization — see `docs/adr/0003-runtime-distribution.md`.
 
 ## If `runIde` fails to resolve versions
 

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffTool.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffTool.kt
@@ -21,7 +21,7 @@ import com.intellij.diff.requests.DiffRequest
  * the diagram diff is the default viewer. It deliberately does **not** suppress
  * those built-ins: keeping `SimpleDiffTool`/`UnifiedDiffTool` in the diff
  * viewer-chooser lets the user switch to the raw XML text diff — the only way to
- * see changes a diagram can't surface, e.g. inside a script task's body (#1282).
+ * see changes a diagram can't surface, e.g. inside a script task's body.
  * The platform remembers the last-picked viewer per diff place.
  */
 class BpmnDiffTool : FrameDiffTool {

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerBrowsers.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerBrowsers.kt
@@ -32,7 +32,7 @@ private val log = Logger.getInstance("io.miragon.intellij.bpmn.ModelerBrowsers")
  *
  * The builder does not create the native browser immediately (callers that need
  * that, e.g. [WarmBrowser], call `createImmediately()` themselves), so it is a
- * drop-in for the former `JBCefBrowser()` construction.
+ * drop-in for direct `JBCefBrowser()` construction.
  */
 fun createModelerBrowser(): JBCefBrowser = JBCefBrowserBuilder().setWindowlessFramerate(60).build()
 

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WebviewServer.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WebviewServer.kt
@@ -163,8 +163,8 @@ class WebviewServer : Disposable {
      * Synthesises the deployment tool-window shell with the IDE theme baked in,
      * mirroring [indexHtml]: the [IdeThemeSignal.bodyClass] on `<body>` and an
      * `#ide-theme-vars` block carrying the deployment form's mapped `--vscode-*`
-     * colors (the id `applyJs` rewrites live). Replaces the former static
-     * system-color block so the form follows the IDE theme, not the OS. The body
+     * colors (the id `applyJs` rewrites live) so the form follows the IDE theme,
+     * not the OS. The body
      * is just `<div id="app"></div>` because the deployment bundle
      * (`src/app/formTemplate.ts`) renders the form itself. Assets resolve under
      * `/deployment/...` → classpath `/webview-deployment`.

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/ProcessSupervisor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/ProcessSupervisor.kt
@@ -12,8 +12,8 @@ import java.util.concurrent.atomic.AtomicInteger
  * backoff respawn, the JVM shutdown hook, and teardown.
  *
  * **Locking.** [stateLock] guards [process] assignment and is held across the
- * paired [RpcChannel.attach]/[RpcChannel.detach] calls, preserving the
- * cross-cutting invariant the former single lock provided: [handleExit]'s
+ * paired [RpcChannel.attach]/[RpcChannel.detach] calls, preserving a
+ * cross-cutting invariant: [handleExit]'s
  * "`process !== dead` → return, else detach" check-and-act stays atomic w.r.t. a
  * concurrent [spawn] attaching the new writer. Lock order is always
  * `stateLock → channel.ioLock`.

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannel.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannel.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * coalescing: a flood of document syncs collapses to its latest frame.
  *
  * **Locking.** [ioLock] guards the [writer] reference and every write/flush — the
- * writer half of the former single `writeLock`. The supervisor's `stateLock`
+ * writer half of the split lock. The supervisor's `stateLock`
  * guards process identity and is held across the paired [attach]/[detach] calls;
  * lock order is always `stateLock → ioLock`, and [writerLoop] only ever takes
  * [ioLock], so the split cannot deadlock.

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcHandlerRegistry.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcHandlerRegistry.kt
@@ -8,8 +8,8 @@ internal fun interface RpcHandler {
 }
 
 /**
- * String-keyed registry of core→host RPC handlers — the dispatch mechanism that
- * replaces the monolithic `when (method)`.
+ * String-keyed registry of core→host RPC handlers — the dispatch mechanism for
+ * incoming methods.
  *
  * Handlers are registered via chainable [on] during `CoreProcess` construction,
  * which is single-threaded and strictly precedes the reader thread that calls

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/DeploymentRouterTest.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/DeploymentRouterTest.kt
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 
 /**
- * Covers Part B of #1106 — the deployment-state writes are *acknowledged* requests,
- * not fire-and-forget notifications. Each `deploymentState/save*` must persist
+ * Covers that the deployment-state writes are *acknowledged* requests, not
+ * fire-and-forget notifications. Each `deploymentState/save*` must persist
  * through [IntellijDeploymentState] (so a getter / re-seed reflects it across an IDE
  * restart) **and** answer the request id, so a failed persist surfaces as a rejected
  * promise on the core instead of being silently dropped.

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouterTest.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouterTest.kt
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.Test
 import java.nio.file.Files
 
 /**
- * Covers Part A of #1106 — explicit causation on the host's write echo — against a
- * **real** IntelliJ `Document`, the only way to verify that `Document.setText`
+ * Covers explicit causation on the host's write echo — against a **real**
+ * IntelliJ `Document`, the only way to verify that `Document.setText`
  * synchronously fires the editor's `DocumentListener` while [EditorSessionRouter]'s
  * per-editor causation token is set. A fake document could only assume that timing;
  * the whole point of the bug class (the bridge dropping its own write by causation

--- a/apps/modeler-bridge/README.md
+++ b/apps/modeler-bridge/README.md
@@ -5,9 +5,8 @@ plugin). A stdio JSON-RPC server that runs the **unmodified**
 `@miragon/bpmn-modeler-core` engine and exposes it to a host that owns the editor
 and the webview, shipped as a **Node-free Bun binary**.
 
-This is the production bridge promised by the #920 spike and the #1060 / #1061
-ADRs. This package imports only the `@miragon/bpmn-modeler-core` public
-entrypoint, never deep plugin paths.
+This package imports only the `@miragon/bpmn-modeler-core` public entrypoint,
+never deep plugin paths.
 
 ## Transport — one stdio NDJSON JSON-RPC pipe
 
@@ -76,9 +75,9 @@ BPMN editor render + `Ctrl+S` write-back + element templates (real, filesystem-
 backed) + the Notifier/StatusBar display ports + diff + Camunda 7/8 deployment
 (the shared `DeploymentMessageDispatcher` + REST stack, driven by the IntelliJ
 deployment tool window) + the template marketplace (add/update GitHub/GitLab/local
-sources into the element-template cache, with per-host PATs in `PasswordSafe`).
-DMN and scriptTask are their own follow-up issues and are intentionally not wired
-here.
+sources into the element-template cache, with per-host PATs in `PasswordSafe`) +
+inline script editing (C7 script tasks/listeners, via `scriptFeature`). The DMN
+editor is not wired here.
 
 ## Build & run
 

--- a/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
+++ b/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
@@ -6,9 +6,9 @@
  * temp filesystem, so the `BpmnLintConfigLocator` + `BpmnLintConfigService` +
  * `NodeBpmnLinter` do an actual nearest-`.bpmnlintrc` walk and run bpmnlint.
  * Covers the three tiers the webview's `GetBpmnlintConfigCommand` exposes: no
- * config hands linting to the webview's in-page default (#1373 Phase B); a
- * *covered* config is pushed down for the webview to lint in-page (#1384, a
- * config-carrying `BpmnlintInPageQuery`, no host lint) and escalates to a host
+ * config hands linting to the webview's in-page default; a *covered* config is
+ * pushed down for the webview to lint in-page (a config-carrying
+ * `BpmnlintInPageQuery`, no host lint) and escalates to a host
  * `BpmnlintResultsQuery` only once the webview reports it cannot cover a rule; an
  * *escalating* config (a Node-only string moddleExtension) is linted host-side
  * straight away. The temp dir has no `node_modules`, so the host path resolves
@@ -16,10 +16,10 @@
  * workspace without `bpmnlint` installed hits, and an unresolvable string
  * moddleExtension is recorded (never fatal), so the lint still produces findings.
  *
- * Phase C additionally asserts the mid-session transitions the `.bpmnlintrc`
- * watcher drives: a config that *appears* takes the editor over to the host
- * path (and drops a stale in-page push arriving after the flip), and a config
- * that is *deleted* hands linting back to the webview's in-page default.
+ * The suite also asserts the mid-session transitions the `.bpmnlintrc` watcher
+ * drives: a config that *appears* takes the editor over to the host path (and
+ * drops a stale in-page push arriving after the flip), and a config that is
+ * *deleted* hands linting back to the webview's in-page default.
  */
 
 import { promises as fs } from "node:fs";
@@ -98,7 +98,7 @@ const isLintResultsFrame = (frame: any): boolean =>
 const isInPageInstructionFrame = (frame: any): boolean =>
     frame.method === "editor/postMessage" && frame.params?.message?.type === "BpmnlintInPageQuery";
 
-// A #1384 covered-config instruction: an in-page instruction that carries the
+// A covered-config instruction: an in-page instruction that carries the
 // workspace config + version token (vs. the payload-free zero-config default).
 const isInPageConfigInstructionFrame = (frame: any): boolean =>
     isInPageInstructionFrame(frame) && frame.params?.message?.config != null;
@@ -148,7 +148,7 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
         );
     }
 
-    it("lints a covered .bpmnlintrc in-page — pushes the config, not host findings (#1384)", async () => {
+    it("lints a covered .bpmnlintrc in-page — pushes the config, not host findings", async () => {
         const { rpc, frames, root, editorId } = await setup();
         await fs.writeFile(
             join(root, ".bpmnlintrc"),
@@ -167,7 +167,7 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
         expect(frames.find(isLintResultsFrame)).toBeUndefined();
     });
 
-    it("escalates a covered config to a host lint when the webview reports unresolved (#1384)", async () => {
+    it("escalates a covered config to a host lint when the webview reports unresolved", async () => {
         const { rpc, frames, root, editorId } = await setup();
         await fs.writeFile(
             join(root, ".bpmnlintrc"),
@@ -231,7 +231,7 @@ describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
     });
 
     it("accepts the webview's in-page findings back over UpdateLintResultsCommand", async () => {
-        // Rule coverage for the bundled default now lives in the AC5 parity spec;
+        // Rule coverage for the bundled default lives in `lintParity.spec.ts`;
         // here we prove the webview→host results command is wired: after the
         // no-config in-page handback, a pushed UpdateLintResultsCommand is
         // accepted and applied (the debug log confirms the round-trip). The

--- a/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
+++ b/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
@@ -12,14 +12,13 @@ import { RegisterParams, SessionHooks } from "./sessionHooks";
 /**
  * The bpmnlint feature discovers the nearest `.bpmnlintrc` for an open BPMN
  * document and drives the shared three-tier policy in {@link BpmnLintConfigService}:
- * no config → the webview's engine-aware default in-page (#1373 Phase B); a
- * config the bundled resolver covers → the webview lints it in-page against the
- * pushed config (#1384); a config it cannot cover → the bridge runs bpmnlint in
- * a full Bun/Node context (so custom `bpmnlint-plugin-*` rules resolve against
- * the workspace exactly like in VS Code) and pushes the findings to the webview,
- * which only renders the in-canvas markers. In-page runs come back via
- * {@link UpdateLintResultsCommand} — the same core behaviour as VS Code, arriving
- * here structurally. It reuses the
+ * no config → the webview's engine-aware default in-page; a config the bundled
+ * resolver covers → the webview lints it in-page against the pushed config; a
+ * config it cannot cover → the bridge runs bpmnlint in a full Bun/Node context
+ * (so custom `bpmnlint-plugin-*` rules resolve against the workspace exactly like
+ * in VS Code) and pushes the findings to the webview, which only renders the
+ * in-canvas markers. In-page runs come back via {@link UpdateLintResultsCommand}
+ * — the same core behaviour as VS Code, arriving here structurally. It reuses the
  * host-agnostic core stack ({@link BpmnLintConfigLocator} +
  * {@link BpmnLintConfigService} + {@link NodeBpmnLinter}) over the
  * Workspace/Settings/Document/StatusBar ports the bridge already implements — the
@@ -49,9 +48,9 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
         await lintSvc.setBpmnlintConfig(editorId);
     });
 
-    // The webview posts its own in-page default findings back after each run
-    // (#1373 Phase B). The service ignores it once a workspace-config takeover
-    // has flipped the editor to the external path.
+    // The webview posts its own in-page default findings back after each run.
+    // The service ignores it once a workspace-config takeover has flipped the
+    // editor to the external path.
     deps.router.on("UpdateLintResultsCommand", (message: Command, editorId: string) => {
         const cmd = message as UpdateLintResultsCommand;
         lintSvc.applyWebviewLintResults(editorId, cmd.results, cmd.unresolved, cmd.configToken);

--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -242,13 +242,6 @@ export class NodeWorkspace implements WorkspacePort {
      * `node_modules`/`.git` are pruned so arming the recursive watch on a large
      * repo stays within the OS watch-descriptor budget (inotify on Linux).
      * Dot-dirs in general must stay watched — templates live under `.camunda/`.
-     *
-     * On Windows the watch runs in polling mode (`usePolling`). chokidar v3 has
-     * no native recursive Windows watch, so it opens a `ReadDirectoryChangesW`
-     * handle per directory; that handle locks `element-templates` against moves
-     * while a BPMN file is open (#1148). Polling via `fs.watchFile` holds no
-     * directory handle, releasing the lock — Bun implements `fs.watchFile`, so
-     * this works under the compiled bridge runtime.
      */
     createWatcher(
         rootPath: string,
@@ -300,8 +293,8 @@ export class NodeWorkspace implements WorkspacePort {
             // chokidar v3 has no native recursive watch on Windows, so it opens a
             // `ReadDirectoryChangesW` handle per directory — including
             // `element-templates`. That held handle makes Windows reject a `mv`
-            // into the folder while a BPMN file is open (#1148). Polling uses
-            // `fs.watchFile` (stat-based) and holds no directory handle, so the
+            // into the folder while a BPMN file is open. Polling uses `fs.watchFile`
+            // (stat-based, implemented by Bun) and holds no directory handle, so the
             // lock disappears; the cost is bounded by the node_modules/.git prune.
             usePolling: process.platform === "win32",
             interval: 300,

--- a/apps/modeler-bridge/src/nodeAdapters.watcherOptions.spec.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.watcherOptions.spec.ts
@@ -6,7 +6,7 @@ import { NodeWorkspace } from "./nodeAdapters";
  * Mocks chokidar to capture the options object `createWatcher` hands to
  * `watch(root, opts)`. The real-chokidar suite in `nodeAdapters.spec.ts`
  * cannot assert this: `usePolling` is `false` on the macOS/Linux CI it runs on,
- * so the Windows lock fix (#1148) would be unverified everywhere it actually
+ * so the Windows lock fix would be unverified everywhere it actually
  * matters. Mocking makes the assertion deterministic on every OS — it pins that
  * the Windows branch sets stat-based polling instead of `fs.watch`.
  */

--- a/apps/standalone/README.md
+++ b/apps/standalone/README.md
@@ -282,7 +282,3 @@ apps/standalone/
   `HideBuiltinViewsContribution`.
 - **Auto-update:** active only in packaged builds (`app.isPackaged`); a
   no-op during `yarn start` in dev mode.
-
-## Related
-
-- Issue: [#917](https://github.com/Miragon/bpmn-modeler/issues/917)

--- a/apps/vscode-plugin/src/architecture.spec.ts
+++ b/apps/vscode-plugin/src/architecture.spec.ts
@@ -15,12 +15,12 @@ import type { FileInfo } from "archunit";
  * reach a sibling only through its `index.ts` barrel).
  *
  * archunit resolves the import graph from a TypeScript project. The config is
- * pinned explicitly because the AC runs this via the *root* `vitest run`, whose
- * cwd is the repo root where archunit's auto-detect (walk up for a
- * `tsconfig.json`) finds none. Pinning the workspace config also fixes the
- * `rootDir`. Layer globs are written as recursive `<layer>` matchers (rather
- * than anchored at `src/<layer>`) because each layer subfolder now lives under
- * a feature prefix (`src/<feature>/<layer>/…`) after the Stage-3 reorg.
+ * pinned explicitly because the root `vitest run` runs this with its cwd at the
+ * repo root, where archunit's auto-detect (walk up for a `tsconfig.json`) finds
+ * none. Pinning the workspace config also fixes the `rootDir`. Layer globs are
+ * written as recursive `<layer>` matchers (rather than anchored at
+ * `src/<layer>`) because each layer subfolder lives under a feature prefix
+ * (`src/<feature>/<layer>/…`).
  */
 const WORKSPACE_ROOT = resolve(__dirname, "..");
 const TSCONFIG = resolve(WORKSPACE_ROOT, "tsconfig.json");
@@ -30,8 +30,8 @@ const TSCONFIG = resolve(WORKSPACE_ROOT, "tsconfig.json");
  *
  * archunit hands custom rules a `FileInfo` whose `path` is project-relative
  * (`src/…`) and populates `content` via cwd-relative `fs.readFileSync`. Under
- * the AC's `corepack yarn test` (root `vitest run`, cwd = repo root) that read
- * misses and `content` is silently `""` — which would make every custom rule
+ * the root `vitest run` (cwd = repo root) that read misses and `content` is
+ * silently `""` — which would make every custom rule
  * pass vacuously. Re-reading from `WORKSPACE_ROOT` keeps the host-module bans
  * real regardless of cwd. `resolve` leaves an already-absolute path untouched.
  */

--- a/apps/vscode-plugin/src/deployment/controller/DeploymentController.ts
+++ b/apps/vscode-plugin/src/deployment/controller/DeploymentController.ts
@@ -36,13 +36,6 @@ export const DEPLOY_CMD = "bpmn-modeler.deployDiagram";
  * `post` callback (`webview.postMessage`) and the visibility/active-editor wiring.
  */
 export class DeploymentController implements WebviewViewProvider {
-    /**
-     * @param editorStore Central registry for active editor state.
-     * @param vsDocument Document read/write operations for resolving file paths.
-     * @param deploymentService Deployment orchestration logic.
-     * @param startInstanceService Start-instance orchestration logic.
-     * @param notifier User-facing message and logging helper.
-     */
     constructor(
         private readonly editorStore: EditorSessionStore,
         private readonly vsDocument: VsCodeDocument,
@@ -54,8 +47,6 @@ export class DeploymentController implements WebviewViewProvider {
     /**
      * Registers the WebviewViewProvider for the deployment sidebar and the
      * `bpmn-modeler.deployDiagram` command with VS Code.
-     *
-     * @param context The VS Code extension context used to track disposables.
      */
     register(context: ExtensionContext): void {
         context.subscriptions.push(
@@ -72,10 +63,6 @@ export class DeploymentController implements WebviewViewProvider {
      * Builds the per-view dispatcher (its `post` targets this view's webview),
      * routes incoming messages to it, and re-pushes form defaults whenever the
      * panel is re-shown or the active editor changes.
-     *
-     * @param webviewView The WebviewView provided by VS Code.
-     * @param _context Resolve context (unused).
-     * @param _token Cancellation token (unused).
      */
     resolveWebviewView(
         webviewView: WebviewView,

--- a/apps/vscode-plugin/src/deployment/infrastructure/DeploymentWebviewHtml.ts
+++ b/apps/vscode-plugin/src/deployment/infrastructure/DeploymentWebviewHtml.ts
@@ -1,21 +1,15 @@
 import { Uri, Webview } from "vscode";
 import { getNonce } from "@miragon/bpmn-modeler-core";
 
-// Output directory name for the deployment webview build artefacts.
 const DEPLOYMENT_WEBVIEW_PATH = "deployment-webview";
 
 /**
  * Generates the HTML shell for the deployment sidebar WebviewView.
  *
- * Resolves asset URIs relative to the extension's install directory and
- * injects a nonce for the Content-Security-Policy `script-src` directive so
- * that only the bundled script can execute. The form body itself is rendered
- * by the bundle (`src/app/formTemplate.ts`), so this shell ships only an empty
- * `<div id="app">` — the single-source-of-markup contract every host honours.
- *
- * @param webview The VS Code Webview instance (used to convert local URIs).
- * @param extensionUri URI of the extension's install directory.
- * @returns HTML string to set as `webviewView.webview.html`.
+ * Injects a nonce for the Content-Security-Policy `script-src` directive so only
+ * the bundled script can execute. The form body itself is rendered by the bundle
+ * (`src/app/formTemplate.ts`), so this shell ships only an empty `<div id="app">`
+ * — the single-source-of-markup contract every host honours.
  */
 export function deploymentWebviewHtml(webview: Webview, extensionUri: Uri): string {
     const baseUri = Uri.joinPath(extensionUri, DEPLOYMENT_WEBVIEW_PATH);

--- a/apps/vscode-plugin/src/deployment/infrastructure/VsCodeDeploymentState.ts
+++ b/apps/vscode-plugin/src/deployment/infrastructure/VsCodeDeploymentState.ts
@@ -5,11 +5,8 @@ import { DeploymentStatePort } from "@miragon/bpmn-modeler-core";
 import { getContext } from "../../shared/infrastructure/extensionContext";
 
 /**
- * Persists and restores deployment form state (endpoint, tenantId, authType)
- * between VS Code sessions using the extension's `workspaceState` storage.
- *
- * Uses `getContext()` to access the `ExtensionContext` that was registered in `main.ts`
- * via `setContext()`.
+ * Persists deployment form state (endpoint, tenantId, authType, OAuth2 config)
+ * across VS Code sessions in the extension's `workspaceState`.
  */
 export class VsCodeDeploymentState implements DeploymentStatePort {
     private static readonly ENDPOINT_KEY = "bpmn-modeler.deployment.endpoint";
@@ -22,29 +19,14 @@ export class VsCodeDeploymentState implements DeploymentStatePort {
 
     private static readonly AUDIENCE_KEY = "bpmn-modeler.deployment.audience";
 
-    /**
-     * Returns the last-used REST endpoint URL.
-     *
-     * @returns The persisted endpoint, or an empty string if none has been saved.
-     */
     getEndpoint(): string {
         return getContext().workspaceState.get<string>(VsCodeDeploymentState.ENDPOINT_KEY, "");
     }
 
-    /**
-     * Returns the last-used tenant ID.
-     *
-     * @returns The persisted tenant ID, or an empty string if none has been saved.
-     */
     getTenantId(): string {
         return getContext().workspaceState.get<string>(VsCodeDeploymentState.TENANT_ID_KEY, "");
     }
 
-    /**
-     * Returns the last-used authentication type.
-     *
-     * @returns The persisted auth type, or `"none"` if none has been saved.
-     */
     getAuthType(): AuthTypePayload {
         return getContext().workspaceState.get<AuthTypePayload>(
             VsCodeDeploymentState.AUTH_TYPE_KEY,
@@ -52,27 +34,10 @@ export class VsCodeDeploymentState implements DeploymentStatePort {
         );
     }
 
-    /**
-     * Persists the auth type in workspace state.
-     *
-     * @param authType The authentication type to persist.
-     */
     async saveAuthType(authType: AuthTypePayload): Promise<void> {
         await getContext().workspaceState.update(VsCodeDeploymentState.AUTH_TYPE_KEY, authType);
     }
 
-    /**
-     * Persists the endpoint and tenantId after a successful deployment so they
-     * can be pre-filled on the next use.
-     *
-     * @param endpoint The REST endpoint URL to persist.
-     * @param tenantId The tenant ID to persist.
-     */
-    /**
-     * Returns the last-used OAuth2 token endpoint URL.
-     *
-     * @returns The persisted token endpoint, or an empty string if none has been saved.
-     */
     getTokenEndpoint(): string {
         return getContext().workspaceState.get<string>(
             VsCodeDeploymentState.TOKEN_ENDPOINT_KEY,
@@ -80,21 +45,10 @@ export class VsCodeDeploymentState implements DeploymentStatePort {
         );
     }
 
-    /**
-     * Returns the last-used OAuth2 audience.
-     *
-     * @returns The persisted audience, or an empty string if none has been saved.
-     */
     getAudience(): string {
         return getContext().workspaceState.get<string>(VsCodeDeploymentState.AUDIENCE_KEY, "");
     }
 
-    /**
-     * Persists OAuth2-specific non-secret configuration in workspace state.
-     *
-     * @param tokenEndpoint The token endpoint URL.
-     * @param audience The target audience.
-     */
     async saveOAuth2Config(tokenEndpoint: string, audience: string): Promise<void> {
         await getContext().workspaceState.update(
             VsCodeDeploymentState.TOKEN_ENDPOINT_KEY,

--- a/apps/vscode-plugin/src/diff/controller/BpmnDiffController.ts
+++ b/apps/vscode-plugin/src/diff/controller/BpmnDiffController.ts
@@ -49,10 +49,9 @@ const GIT_PROVIDED_SCHEMES = new Set<string>(["git", "gitfs"]);
  * {@link DiffPaneStore} and the diff content logic in {@link BpmnDiffService},
  * both kept vscode-free.
  *
- * The domain moved from "pair of panes with mutual partner pointers" to
- * {@link DiffSession}: an explicit object with fixed `before` / `after` URIs
- * that any diff origin (SCM, `compare-files`) can register into. Pane
- * resolution is a session lookup instead of a scheme-based heuristic.
+ * The domain is {@link DiffSession}: an explicit object with fixed `before` /
+ * `after` URIs that any diff origin (SCM, `compare-files`) can register into.
+ * Pane resolution is a session lookup rather than a scheme-based heuristic.
  */
 export class BpmnDiffController {
     /**

--- a/apps/vscode-plugin/src/main.ts
+++ b/apps/vscode-plugin/src/main.ts
@@ -20,9 +20,9 @@ export interface TestApi {
 }
 
 /**
- * Activation is now pure composition: build the shared collaborators once, then
- * let each feature wire itself via its own `register()`. Adding a feature means
- * adding one file and one line here — no longer surgery on a 200-line body.
+ * Activation is pure composition: build the shared collaborators once, then let
+ * each feature wire itself via its own `register()`. Adding a feature means
+ * adding one file and one line here.
  *
  * The register order is observable (it is the order custom editors, providers,
  * and commands become available) and is preserved exactly: diff → script →

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/CommandController.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/CommandController.ts
@@ -28,51 +28,27 @@ import { VsCodePicker } from "../../../shared/infrastructure/VsCodePicker";
 import { BpmnModelerService } from "@miragon/bpmn-modeler-core";
 import { BpmnMigrationService } from "../../../migration/index";
 
-// VS Code command ID for toggling the text editor.
 export const TOGGLE_CMD = "bpmn-modeler.toggleTextEditor";
-// VS Code command ID for opening the logging console.
 export const LOGGING_CMD = "bpmn-modeler.openLoggingConsole";
-// VS Code command ID for copying the diagram as SVG to the clipboard.
 export const COPY_SVG_CMD = "bpmn-modeler.copyDiagramAsSvg";
-// VS Code command ID for saving the diagram as an SVG file.
 export const SAVE_SVG_CMD = "bpmn-modeler.saveDiagramAsSvgCommand";
-// VS Code command ID for changing the engine version.
 export const CHANGE_ENGINE_VERSION_CMD = "bpmn-modeler.changeEngineVersion";
-// VS Code command ID for migrating all BPMN diagrams in the workspace.
 export const MIGRATE_ALL_CMD = "bpmn-modeler.migrateAllDiagrams";
-// VS Code command ID for changing the modeler language.
 export const CHANGE_LANGUAGE_CMD = "bpmn-modeler.changeLanguage";
-// VS Code command ID for turning BPMN linting on/off (the design-only opt-out).
 export const TOGGLE_LINTING_CMD = "bpmn-modeler.toggleLinting";
-// VS Code command ID for scaffolding a new BPMN model.
 export const NEW_BPMN_MODEL_CMD = "bpmn-modeler.newBpmnModel";
-// VS Code command ID for scaffolding a new DMN model.
 export const NEW_DMN_MODEL_CMD = "bpmn-modeler.newDmnModel";
-// VS Code command ID for reloading the active modeler webview. Manual fallback
+// Manual fallback
 // for setups where the element-template file watcher never fires (WSL +
 // symlinked workspace): a reload re-requests the templates from the host.
 export const RELOAD_MODELER_CMD = "bpmn-modeler.reloadModeler";
 
 /**
  * Registers and handles all VS Code command contributions for the modeler.
- *
- * Merges the three former command classes (`VsCodeToggleTextEditorCommand`,
- * `VsCodeOpenLoggingConsoleCommand`, `VsCodeDiagramAsSvgCommand`) into a
- * single, flat controller with no DI framework.
  */
 export class CommandController {
-    // Tracks the active SVG response subscription so it can be disposed before creating a new one.
     private svgSubscription: EditorSubscription | undefined;
 
-    /**
-     * @param editorStore Central registry for open editor panels and messaging.
-     * @param vsDocument Active-document path helper.
-     * @param notifier User-facing message and logging helper.
-     * @param textEditor Toggles the companion text editor pane for the active document.
-     * @param bpmnService BPMN-specific business logic for engine version changes.
-     * @param migrationSvc Workspace-wide BPMN migration orchestrator.
-     * @param picker Engine quick-pick used when scaffolding a new BPMN model.
-     */
     constructor(
         private readonly editorStore: EditorSessionStore,
         private readonly vsDocument: VsCodeDocument,
@@ -83,12 +59,7 @@ export class CommandController {
         private readonly picker: VsCodePicker,
     ) {}
 
-    /**
-     * Registers all commands with VS Code and pushes the resulting disposables
-     * into the extension context.
-     *
-     * @param context The VS Code extension context.
-     */
+    /** Registers all commands and pushes their disposables into the extension context. */
     register(context: ExtensionContext): void {
         context.subscriptions.push(
             commands.registerCommand(TOGGLE_CMD, this.toggle, this),
@@ -105,11 +76,7 @@ export class CommandController {
         );
     }
 
-    /**
-     * Toggles the standard VS Code text editor for the currently open document.
-     *
-     * @returns `true` if the text editor was opened, `false` if it was closed.
-     */
+    /** Toggles the standard VS Code text editor for the active document. */
     toggle(): Promise<boolean> {
         const activeId = this.editorStore.getActiveEditorId();
         const documentPath = this.vsDocument.getFilePath(activeId);
@@ -127,39 +94,24 @@ export class CommandController {
         this.editorStore.reload(this.editorStore.getActiveEditorId());
     }
 
-    /**
-     * Reveals the extension's output channel in the VS Code UI.
-     */
+    /** Reveals the extension's output channel. */
     showLogging(): void {
         this.notifier.openLoggingConsole();
     }
 
-    /**
-     * Prompts the user to select a new engine version for the active BPMN editor.
-     *
-     * Delegates to {@link BpmnModelerService.changeEngineVersion}.
-     */
+    /** Prompts for a new engine version for the active BPMN editor. */
     changeEngineVersion(): Promise<boolean> {
         return this.logAndRethrow(() =>
             this.bpmnService.changeEngineVersion(this.editorStore.getActiveEditorId()),
         );
     }
 
-    /**
-     * Migrates all BPMN diagrams in the workspace to a user-selected version.
-     *
-     * Delegates to {@link BpmnMigrationService.migrateAllDiagrams}.
-     */
+    /** Migrates all workspace BPMN diagrams to a user-selected version. */
     migrateAllDiagrams(): Promise<boolean> {
         return this.logAndRethrow(() => this.migrationSvc.migrateAllDiagrams());
     }
 
-    /**
-     * Prompts the user to select a UI language for the active modeler webview.
-     *
-     * Shows a QuickPick with all supported languages and sends the selected
-     * locale to the active webview via {@link BpmnModelerService.setLanguage}.
-     */
+    /** Prompts for a UI language and applies it to the active modeler webview. */
     changeLanguage(): Promise<void> {
         return this.logAndRethrow(async () => {
             const items = supportedModelerLanguages.map((lang) => ({
@@ -204,8 +156,7 @@ export class CommandController {
     }
 
     /**
-     * Prompts for a save location, picks the engine, then scaffolds a new BPMN
-     * model there and opens it in the custom editor.
+     * Scaffolds a new BPMN model and opens it in the custom editor.
      *
      * The engine is chosen *before* the file is written so a cancelled quick-pick
      * leaves nothing behind — the alternative (write empty, seed on open) orphans
@@ -237,10 +188,7 @@ export class CommandController {
         });
     }
 
-    /**
-     * Prompts for a save location, then scaffolds a new DMN model there and opens
-     * it in the custom editor. DMN has no engine choice, so no quick-pick.
-     */
+    /** Scaffolds a new DMN model and opens it. DMN has no engine choice, so no quick-pick. */
     newDmnModel(): Promise<void> {
         return this.logAndRethrow(async () => {
             const target = await this.promptNewModelTarget("New DMN Model", "DMN", "dmn");
@@ -290,26 +238,14 @@ export class CommandController {
         }
     }
 
-    /**
-     * Requests the SVG of the current BPMN diagram from the active webview and
-     * copies it to the system clipboard.
-     *
-     * Disposes any previous SVG subscription before creating a new one to
-     * prevent listener accumulation.
-     */
+    /** Requests the current diagram's SVG from the active webview and copies it to the clipboard. */
     writeToClipboard(): void {
         this.requestSvg((svg) => {
             env.clipboard.writeText(svg);
         });
     }
 
-    /**
-     * Requests the SVG of the current BPMN diagram from the active webview and
-     * writes it to a `.svg` file next to the `.bpmn` source file.
-     *
-     * Disposes any previous SVG subscription before creating a new one to
-     * prevent listener accumulation.
-     */
+    /** Requests the current diagram's SVG and writes it to a `.svg` next to the `.bpmn` source. */
     writeToFile(): void {
         this.requestSvg(async (svg) => {
             const filePath = this.vsDocument
@@ -321,13 +257,11 @@ export class CommandController {
     }
 
     /**
-     * Sends a `GetDiagramAsSVGCommand` to the active webview and subscribes
-     * to the response.  Disposes any previously active SVG subscription first.
-     *
-     * @param onSvg Callback invoked with the SVG string once received. Its
-     *   result is awaited so a rejected async sink (a failed `workspace.fs`
-     *   file write, a denied clipboard write) reaches the channel instead of
-     *   floating away as an unhandled rejection.
+     * Sends a `GetDiagramAsSVGCommand` to the active webview and subscribes to the
+     * response, disposing any previously active SVG subscription first. `onSvg`'s
+     * result is awaited so a rejected async sink (a failed `workspace.fs` write, a
+     * denied clipboard write) reaches the channel instead of floating away as an
+     * unhandled rejection.
      */
     private requestSvg(onSvg: (svg: string) => void | Promise<void>): void {
         const activeId = this.editorStore.getActiveEditorId();

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnlintParticipant.ts
@@ -51,7 +51,7 @@ export class BpmnlintParticipant implements EditorSessionParticipant {
         // Re-lint on edits: the custom text editor syncs webview edits into the
         // TextDocument, so the host always lints the current XML. Filter to this
         // session's `.bpmn` document so an edit elsewhere never re-lints it.
-        // In-page sessions (no workspace config, #1373 Phase B) lint in the
+        // In-page sessions (no workspace config) lint in the
         // webview on every diagram change already, so a host re-lint would be
         // pure churn — skip it and let the webview's own push drive the chrome.
         session.onDocumentChange((event) => {

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/EngineVersionStatusBarParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/EngineVersionStatusBarParticipant.ts
@@ -25,8 +25,7 @@ export class EngineVersionStatusBarParticipant implements EditorSessionParticipa
                 this.statusBar.hideEngineVersion();
             }
         });
-        // Strict improvement over the former controller, which leaked this
-        // listener: join it to the session bag so it dies with the session.
+        // Join the listener to the session bag so it dies with the session.
         session.addDisposable(subscription);
 
         session.onDispose(() => this.statusBar.hideEngineVersion());

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
@@ -417,7 +417,7 @@ describe("updateLintResultsHandler", () => {
         );
     });
 
-    it("forwards the config token so the service can pair the run with its config version (#1384)", () => {
+    it("forwards the config token so the service can pair the run with its config version", () => {
         const lintSvc = { applyWebviewLintResults: vi.fn() };
         const results = {};
 

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
@@ -125,7 +125,7 @@ export function getPropertiesPanelStateHandler(
 
 /**
  * `UpdateLintResultsCommand` → feed the host's Problems panel + status bar from
- * findings the webview computed in its in-page default run (#1373 Phase B). The
+ * findings the webview computed in its in-page default run. The
  * service ignores the push when the editor is no longer on the in-page path (a
  * workspace-config takeover) or when linting is disabled.
  */

--- a/apps/vscode-plugin/src/modeler/bpmn/infrastructure/PropertiesPanelStateRepository.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/infrastructure/PropertiesPanelStateRepository.ts
@@ -2,51 +2,34 @@ import { ExtensionContext } from "vscode";
 
 import { PropertiesPanelStatePort } from "@miragon/bpmn-modeler-core";
 
-// Default key used to persist the panel visibility in `context.globalState`.
 const DEFAULT_PANEL_VISIBLE_KEY = "propertiesPanelVisible";
 
 /**
- * Persists and retrieves the global default visibility of a modeler's
- * properties panel across VS Code sessions.
+ * Persists the global default visibility of a modeler's properties panel across
+ * VS Code sessions.
  *
- * The value stored here is the *default* applied to a freshly opened webview —
- * it does not override the in-memory state of already-running webviews.  That
- * separation is what allows side-by-side editors to keep independent
- * visibility while still honouring the user's last preference for newly opened
- * diagrams.
+ * The stored value is the *default* applied to a freshly opened webview — it
+ * does not override the in-memory state of already-running webviews. That
+ * separation lets side-by-side editors keep independent visibility while still
+ * honouring the user's last preference for newly opened diagrams.
  *
  * BPMN and DMN each pass a distinct `key`, so toggling one does not move the
- * other's default.
+ * other's default; `key` defaults to the BPMN key.
  */
 export class PropertiesPanelStateRepository implements PropertiesPanelStatePort {
-    /**
-     * @param context The VS Code extension context whose `globalState` backs
-     *   the persisted value.
-     * @param key `globalState` key for the default. Defaults to the historical
-     *   BPMN key for back-compat; the DMN editor passes its own.
-     */
     constructor(
         private readonly context: ExtensionContext,
         private readonly key: string = DEFAULT_PANEL_VISIBLE_KEY,
     ) {}
 
-    /**
-     * Returns the persisted panel visibility, or `true` when no value has
-     * been stored yet.  The default matches the current behaviour of opening
-     * a file with the panel visible.
-     */
     getVisibility(): boolean {
         return this.context.globalState.get<boolean>(this.key, true);
     }
 
     /**
-     * Persists `visible` as the new global default. Wraps VS Code's `Thenable`
-     * in a real `Promise` so the return type satisfies the host-agnostic
-     * {@link PropertiesPanelStatePort} (the port deliberately avoids the
-     * vscode-ambient `Thenable`).
-     *
-     * @param visible `true` to make the panel visible by default, `false` to
-     *   collapse it by default.
+     * Wraps VS Code's `Thenable` in a real `Promise` so the return type satisfies
+     * the host-agnostic {@link PropertiesPanelStatePort}, which deliberately
+     * avoids the vscode-ambient `Thenable`.
      */
     setVisibility(visible: boolean): Promise<void> {
         return Promise.resolve(this.context.globalState.update(this.key, visible));

--- a/apps/vscode-plugin/src/modeler/editor-session/EditorSessionParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/editor-session/EditorSessionParticipant.ts
@@ -39,10 +39,10 @@ export interface EditorSessionContext {
  * One self-contained editor lifecycle concern (render, element templates,
  * settings broadcast, engine-version status bar, …).
  *
- * Inverts the former god-controller: instead of `resolveCustomTextEditor`
- * hand-wiring every feature's setup, each feature contributes a participant that
- * is handed the session and registers itself. Adding a feature becomes "write a
- * participant + register it in `main.ts`" with zero controller edits.
+ * Instead of `resolveCustomTextEditor` hand-wiring every feature's setup, each
+ * feature contributes a participant that is handed the session and registers
+ * itself. Adding a feature becomes "write a participant + register it in
+ * `main.ts`" with zero controller edits.
  */
 export interface EditorSessionParticipant {
     /** Runs once per opened editor, after the session is registered. */

--- a/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.ts
+++ b/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.ts
@@ -39,9 +39,9 @@ export interface ModelerEditorOptions {
 /**
  * Generic `CustomTextEditorProvider` for the modeler editors.
  *
- * Constant-size as features grow: it no longer hand-wires each feature's
- * session setup. `resolveCustomTextEditor` reduces to URI routing → create
- * session → run participants → dispatch. Each lifecycle concern lives in an
+ * Constant-size as features grow: it does not hand-wire each feature's session
+ * setup. `resolveCustomTextEditor` reduces to URI routing → create session → run
+ * participants → dispatch. Each lifecycle concern lives in an
  * {@link EditorSessionParticipant}; this controller only owns the parts that are
  * the same for every modeler — message dispatch, tab tracking, and the single
  * aggregated dispose.
@@ -69,8 +69,8 @@ export class ModelerEditorController implements CustomTextEditorProvider {
     /**
      * Called by VS Code whenever a matching file is opened.
      *
-     * Order matters and preserves the former controllers' semantics: the diff
-     * branch short-circuits before any session is created; message/tab/dispose
+     * Order matters: the diff branch short-circuits before any session is
+     * created; message/tab/dispose
      * subscriptions are wired synchronously before any participant runs (a
      * participant may await, and the webview is already loading); the single
      * dispose subscription runs every participant's teardown once, after the

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptTaskService.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptTaskService.ts
@@ -214,16 +214,10 @@ export class ScriptTaskService {
      * For JavaScript, a kind-scoped `camunda.d.ts` + `jsconfig.json` are
      * placed next to the script so tsserver serves typed bean/SPIN completion.
      *
-     * @param editorId Document URI of the BPMN editor.
-     * @param elementId The BPMN element ID hosting the script (parent
-     *   element for listener kinds).
-     * @param kind Which surface the script lives on.
-     * @param listenerIndex For listener kinds, the index within the parent's
-     *   filtered list of listeners of that type. Undefined for `script-task`.
-     * @param eventName For listener kinds, the listener's `event` attribute
-     *   (e.g. `"start"`, `"create"`); used for the editor tab title.
-     * @param scriptFormat The Camunda `scriptFormat` value (e.g. `"javascript"`).
-     * @param content The current inline script content.
+     * `elementId` is the parent element for listener kinds; `listenerIndex` is
+     * the position within the parent's filtered list of listeners of that type
+     * (undefined for `script-task`); `eventName` is the listener's `event`
+     * attribute, used for the editor tab title.
      */
     async openScriptEditor(
         editorId: string,

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeDiagnostics.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeDiagnostics.ts
@@ -14,7 +14,7 @@ import { DiagnosticsPort } from "@miragon/bpmn-modeler-core";
 /**
  * Publishes bpmnlint findings into VS Code's Problems panel via a single shared
  * {@link DiagnosticCollection}, so lint results are searchable and clickable
- * without opening the diagram — the payoff of linting in the host (issue #1304).
+ * without opening the diagram — the payoff of linting in the host.
  *
  * bpmnlint reports address elements by id, not text ranges, so the range is a
  * best-effort scan for the element's `id="…"` in the XML, falling back to the

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeEditorHandle.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeEditorHandle.ts
@@ -66,7 +66,7 @@ export class VsCodeEditorHandle implements EditorHandle {
         // Canonicalize the drive letter so `getFilePath()`-derived paths land in
         // the same space as the workspace root the artifact walk compares them
         // against; VS Code's document URIs already lowercase it, but this keeps
-        // the guarantee explicit and host-boundary-local (issue #1204).
+        // the guarantee explicit and host-boundary-local.
         return canonicalizeDriveLetter(this.document.uri.path);
     }
 

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
@@ -13,10 +13,9 @@ const LOG_CHANNEL_ID = "bpmn.modeler";
  *
  * The channel is created with `{ log: true }`, so VS Code supplies the level
  * filtering (Output panel gear / *Developer: Set Log Level…*), per-line
- * timestamps, and persistence to the extension log file. The channel-name
- * prefix each line used to carry is therefore redundant — the channel already
- * identifies itself — and the ctor no longer `clear()`s, so the previous
- * session's trail survives a reload.
+ * timestamps, and persistence to the extension log file. The channel identifies
+ * itself, so lines carry no channel-name prefix; the ctor does not `clear()`, so
+ * the previous session's trail survives a reload.
  */
 export class VsCodeNotifier implements NotifierPort {
     private readonly channel: LogOutputChannel;

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeSettings.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeSettings.ts
@@ -6,20 +6,12 @@ import { MarketplaceSettingsEntry, SettingsPort } from "@miragon/bpmn-modeler-co
  * Pure VS Code workspace configuration reader for the BPMN modeler.
  */
 export class VsCodeSettings implements SettingsPort {
-    /**
-     * Reads the alignToOrigin setting from VS Code configuration.
-     * @returns `true` if align-to-origin is enabled, `false` otherwise.
-     */
     getAlignToOrigin(): boolean {
         return (
             workspace.getConfiguration("miragon.bpmnModeler").get<boolean>("alignToOrigin") ?? false
         );
     }
 
-    /**
-     * Reads the showTransactionBoundaries setting from VS Code configuration.
-     * @returns `true` if transaction boundaries should be shown (default), `false` otherwise.
-     */
     getShowTransactionBoundaries(): boolean {
         return (
             workspace
@@ -40,37 +32,16 @@ export class VsCodeSettings implements SettingsPort {
         );
     }
 
-    /**
-     * Reads the config folder name from VS Code configuration.
-     *
-     * Defaults to `.camunda` if the setting is not configured.
-     *
-     * @returns The config folder name (e.g. `.camunda`).
-     */
     getConfigFolder(): string {
         return workspace
             .getConfiguration("miragon.bpmnModeler")
             .get<string>("configFolder", ".camunda");
     }
 
-    /**
-     * Reads the Camunda 8 REST API version prefix from VS Code configuration.
-     *
-     * Defaults to `"v2"` if the setting is not configured.
-     *
-     * @returns The API version string (e.g. `"v2"`).
-     */
     getC8ApiVersion(): string {
         return workspace.getConfiguration("miragon.bpmnModeler").get<string>("c8ApiVersion", "v2");
     }
 
-    /**
-     * Reads the color theme mode from VS Code configuration.
-     *
-     * Defaults to `"automatic"` if the setting is not configured.
-     *
-     * @returns `"automatic"` to follow VS Code theme, or `"light"` for always-light.
-     */
     getColorTheme(): "automatic" | "light" {
         const value = workspace
             .getConfiguration("miragon.bpmnModeler")
@@ -78,26 +49,12 @@ export class VsCodeSettings implements SettingsPort {
         return value === "light" ? "light" : "automatic";
     }
 
-    /**
-     * Reads the favourite BPMN element types from VS Code configuration.
-     *
-     * Defaults to an empty array if not configured.
-     *
-     * @returns Array of BPMN type strings (e.g. `["bpmn:ServiceTask"]`).
-     */
     getFavouriteBpmnElements(): string[] {
         return workspace
             .getConfiguration("miragon.bpmnModeler")
             .get<string[]>("favouriteBpmnElements", []);
     }
 
-    /**
-     * Reads the UI language setting from VS Code configuration.
-     *
-     * Defaults to `"en"` (English) if the setting is not configured.
-     *
-     * @returns The locale code (e.g. `"de"`, `"fr"`).
-     */
     getLanguage(): string {
         return workspace.getConfiguration("miragon.bpmnModeler").get<string>("language", "en");
     }

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.spec.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.spec.ts
@@ -129,7 +129,7 @@ describe("VsCodeWorkspace.getWorkspaceFolderForDocument", () => {
     it("lowercases the workspace-folder drive letter so it compares against document paths", () => {
         // VS Code hands the folder its as-opened uppercase drive while document
         // URIs are lowercased; without canonicalization the two never match and
-        // the template walk collects nothing (issue #1204).
+        // the template walk collects nothing.
         getWorkspaceFolderMock.mockReturnValueOnce({ uri: { path: "/C:/ws" } });
         const sut = new VsCodeWorkspace();
 

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.ts
@@ -13,20 +13,11 @@ import { canonicalPath, toUri } from "./uriPath";
 const fs = workspace.fs;
 
 /**
- * VS Code workspace and filesystem helpers.
- *
- * Combines workspace-folder discovery (formerly `VsCodeWorkspaceAdapter`) and
- * filesystem access (formerly `VsCodeReadAdapter`) into a single infrastructure
- * class used by {@link ArtifactService}.
+ * VS Code workspace-folder discovery and filesystem access, used by
+ * {@link ArtifactService}.
  */
 export class VsCodeWorkspace implements WorkspacePort {
-    /**
-     * Returns the workspace folder path for the given document.
-     *
-     * @param document Absolute path to the document file.
-     * @returns The workspace folder path.
-     * @throws {NoWorkspaceFolderFoundError} If the document is not inside any workspace folder.
-     */
+    /** Returns the workspace folder path containing `document`, throwing {@link NoWorkspaceFolderFoundError} when it lies outside every open folder. */
     getWorkspaceFolderForDocument(document: string): string {
         const workspaceFolder = workspace.getWorkspaceFolder(toUri(document));
         if (!workspaceFolder) {
@@ -72,14 +63,9 @@ export class VsCodeWorkspace implements WorkspacePort {
     }
 
     /**
-     * Walks upward from `startDir` looking for a directory containing a `.git`
-     * entry, indicating the root of a git repository.
-     *
-     * Stops when the filesystem root is reached or a directory cannot be read.
-     *
-     * @param startDir Absolute path to the directory to start from.
-     * @returns The path of the directory that contains `.git`, or `undefined` if
-     *   no git root is found.
+     * Walks upward from `startDir` for a directory containing a `.git` entry.
+     * Returns `undefined` at the filesystem root or when a directory cannot be
+     * read.
      */
     async findGitRoot(startDir: string): Promise<string | undefined> {
         let current = startDir;
@@ -96,9 +82,7 @@ export class VsCodeWorkspace implements WorkspacePort {
             }
 
             const parent = posix.dirname(current);
-            /**
-             * Stop at filesystem root (dirname returns the same path).
-             */
+            // Filesystem root reached — dirname is a fixed point here.
             if (parent === current) {
                 return undefined;
             }
@@ -107,11 +91,8 @@ export class VsCodeWorkspace implements WorkspacePort {
     }
 
     /**
-     * Lists the direct children of a directory.
-     *
-     * @param path Absolute path to the directory.
-     * @returns An array of `[name, type]` tuples where type is `"file"` or `"directory"`.
-     *   Symbolic links and other types are excluded.
+     * Lists the direct children of a directory as `[name, type]` tuples;
+     * symbolic links and other non-file/directory entries are excluded.
      */
     async readDirectory(path: string): Promise<[string, "file" | "directory"][]> {
         let dir: [string, FileType][];
@@ -130,15 +111,11 @@ export class VsCodeWorkspace implements WorkspacePort {
     }
 
     /**
-     * Reads a file and returns its content as a UTF-8 string.
-     *
-     * @param path Absolute path to the file.
-     * @returns The file content as a string.
-     * @throws {FileNotFound} only when the file is absent. Any other fs failure
-     *   (permission denied, target is a directory, …) propagates unchanged so
-     *   callers can surface it — `ScriptVariableManifestService` relies on this
-     *   to distinguish "no manifest" from "manifest unreadable" (mirrors
-     *   `NodeWorkspace.readFile`).
+     * Reads a file as a UTF-8 string. Throws {@link FileNotFound} only when the
+     * file is absent; any other fs failure (permission denied, target is a
+     * directory, …) propagates unchanged so callers can surface it —
+     * `ScriptVariableManifestService` relies on this to distinguish "no manifest"
+     * from "manifest unreadable" (mirrors `NodeWorkspace.readFile`).
      */
     async readFile(path: string): Promise<string> {
         try {
@@ -152,12 +129,7 @@ export class VsCodeWorkspace implements WorkspacePort {
         }
     }
 
-    /**
-     * Writes content to a file on disk, creating it if it does not exist.
-     *
-     * @param path Absolute path to the file.
-     * @param content The string content to write.
-     */
+    /** Writes content to a file, creating it if it does not exist. */
     async writeFile(path: string, content: string): Promise<void> {
         const uri = toUri(path);
         // Create the parent directory first (idempotent). `fs.writeFile` already
@@ -175,8 +147,6 @@ export class VsCodeWorkspace implements WorkspacePort {
      * A `FileNotFound` is swallowed so pruning a marketplace cache slot that was
      * already removed (or never written) is a silent no-op, matching the port
      * contract; any other failure propagates so a real fs error is not masked.
-     *
-     * @param path Absolute path to the directory to remove.
      */
     async deleteDirectory(path: string): Promise<void> {
         try {
@@ -190,16 +160,10 @@ export class VsCodeWorkspace implements WorkspacePort {
     }
 
     /**
-     * Finds files in the workspace matching the given glob pattern.
-     *
-     * @param pattern A glob pattern (e.g. `"**\/*.bpmn"`).
-     * @param exclude Optional glob (or `null`) forwarded to
-     *   {@link workspace.findFiles}.  `undefined` keeps VS Code's default
-     *   (`files.exclude` only); a glob string adds those patterns on top;
-     *   `null` opts out of every default exclude.
-     * @param limit Optional cap on the number of results returned, forwarded
-     *   as `maxResults` to {@link workspace.findFiles}.
-     * @returns An array of absolute file paths.
+     * Finds files matching `glob`. `exclude` is forwarded to
+     * {@link workspace.findFiles}: `undefined` keeps VS Code's default
+     * (`files.exclude` only), a glob string adds those patterns on top, and
+     * `null` opts out of every default exclude.
      */
     async findFiles(pattern: string, exclude?: string | null, limit?: number): Promise<string[]> {
         const uris = await workspace.findFiles(pattern, exclude, limit);
@@ -256,12 +220,7 @@ export class VsCodeWorkspace implements WorkspacePort {
         };
     }
 
-    /**
-     * Maps a VS Code `FileType` enum value to a simplified string.
-     *
-     * @param type The VS Code FileType value.
-     * @returns `"file"`, `"directory"`, `"symbolicLink"`, or `"unknown"`.
-     */
+    /** Maps a VS Code `FileType` to `"file"`, `"directory"`, `"symbolicLink"`, or `"unknown"`. */
     private parseFileType(type: FileType): string {
         switch (type) {
             case FileType.File:

--- a/apps/vscode-plugin/src/shared/infrastructure/WebviewHtml.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/WebviewHtml.ts
@@ -2,29 +2,21 @@ import { Uri, Webview } from "vscode";
 
 import { getNonce } from "@miragon/bpmn-modeler-core";
 
-// Output directory name for the BPMN webview build artefacts.
 const BPMN_WEBVIEW_PATH = "bpmn-webview";
-// Output directory name for the DMN webview build artefacts.
 const DMN_WEBVIEW_PATH = "dmn-webview";
 
 /**
- * Generates the HTML content for the BPMN modeler webview.
+ * Generates the HTML for the BPMN modeler webview, resolving asset URIs relative
+ * to the extension's install directory. The initial theme stylesheet is always
+ * `lightTheme.css`; the webview's own `initTheme()` swaps it to the correct
+ * theme at runtime from VS Code's body CSS classes.
  *
- * Resolves all asset URIs relative to the extension's install directory and
- * injects them into the HTML template.  The initial theme stylesheet is always
- * `lightTheme.css`; the webview's own `initTheme()` call swaps it to the
- * correct theme at runtime based on VS Code's body CSS classes.
- *
- * @param webview The VS Code Webview instance (used to convert local URIs).
- * @param extensionUri URI of the extension's install directory.
- * @param initialPanelVisible The host's global properties-panel default — the
- *   seed for a first-ever open. When `false`, the panel and its resizer are
- *   rendered with the `collapsed` class (and `width: 0` on the panel) so the
- *   panel never flashes visible before the webview's JavaScript applies state.
- *   A webview that carries its own per-editor `panelVisible` entry overrides
- *   this hint at runtime (early-apply, before diagram import). Defaults to
- *   `true` for safety (e.g. diff panes that hide the panel via CSS anyway).
- * @returns HTML string to set as `webview.html`.
+ * `initialPanelVisible` is the host's global properties-panel default seeding a
+ * first-ever open: when `false`, the panel and its resizer render with the
+ * `collapsed` class (and `width: 0`) so the panel never flashes visible before
+ * the webview's JavaScript applies state. A webview carrying its own per-editor
+ * `panelVisible` entry overrides this hint at runtime. Defaults to `true` for
+ * safety (e.g. diff panes that hide the panel via CSS anyway).
  */
 export function bpmnEditorUi(
     webview: Webview,
@@ -69,14 +61,7 @@ export function bpmnEditorUi(
     `;
 }
 
-/**
- * Generates the HTML content for the DMN modeler webview.
- *
- * @param webview The VS Code Webview instance.
- * @param extensionUri URI of the extension's install directory.
- * @param initialPanelVisible determines if the panel is visible initially
- * @returns HTML string to set as `webview.html`.
- */
+/** Generates the HTML for the DMN modeler webview. */
 export function dmnModelerHtml(
     webview: Webview,
     extensionUri: Uri,

--- a/apps/vscode-plugin/src/shared/infrastructure/uriPath.spec.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/uriPath.spec.ts
@@ -60,7 +60,7 @@ describe("canonicalPath", () => {
     });
 
     it("collapses an uppercase-drive folder and a lowercase-drive document to the same string", () => {
-        // The exact skew from issue #1204: `WorkspaceFolder.uri.path` keeps the
+        // The exact drive-letter skew: `WorkspaceFolder.uri.path` keeps the
         // as-opened uppercase drive while the document URI is lowercased.
         const folder = canonicalPath({ path: "/C:/ws" } as never);
         const document = canonicalPath({ path: "/c:/ws/sub" } as never);

--- a/apps/vscode-plugin/src/shared/infrastructure/uriPath.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/uriPath.ts
@@ -9,7 +9,7 @@ import { Uri } from "vscode";
  * folder was opened with — typically *uppercase* from Explorer (`/C:/…`). Since
  * `uri.path` strings compare case-sensitively, a document under `/c:/…` never
  * tests as being inside a `/C:/…` workspace root, so the template/config walk
- * collects nothing (issue #1204, microsoft/vscode#194692). Funnelling every
+ * collects nothing (microsoft/vscode#194692). Funnelling every
  * path this adapter emits through {@link canonicalizeDriveLetter} removes the
  * skew; lowercase is the canon because that is what the URIs we compare against
  * already use.

--- a/libs/append-menu/src/AppendMenuOverride.ts
+++ b/libs/append-menu/src/AppendMenuOverride.ts
@@ -33,9 +33,7 @@ class AppendMenuOverride {
 
     /**
      * Sets the favourite BPMN element types to pin at the top of the palette.
-     *
-     * @param types Array of BPMN type strings (e.g. `["bpmn:ServiceTask", "bpmn:UserTask"]`).
-     *   Maximum of 6 items; extras are silently dropped.
+     * Maximum of 6 items; extras are silently dropped.
      */
     setFavourites(types: string[]): void {
         this.favourites = types.slice(0, MAX_FAVOURITES);

--- a/libs/append-menu/src/components/AppendMenuOverlay.tsx
+++ b/libs/append-menu/src/components/AppendMenuOverlay.tsx
@@ -221,12 +221,8 @@ export function AppendMenuOverlay({
         return () => document.removeEventListener("keydown", handleKey, true);
     }, [onCancel]);
 
-    /**
-     * Handles a template card click / Enter.
-     *
-     * Single-type templates are applied immediately. Multi-type templates are
-     * selected so the palette can be filtered (see the selection effect).
-     */
+    // Single-type templates apply immediately; multi-type ones become selected
+    // so the palette can be filtered (see the selection effect).
     const handleTemplateClick = useCallback(
         (enriched: EnrichedTemplateEntry, event: Event) => {
             const appliesTo = enriched.template?.appliesTo ?? [];
@@ -240,12 +236,8 @@ export function AppendMenuOverlay({
         [onSelect],
     );
 
-    /**
-     * Handles a BPMN element button click / Enter in the palette.
-     *
-     * If a multi-type template is selected, creates the element using
-     * the template's action.  Otherwise, creates a plain BPMN element.
-     */
+    // With a multi-type template selected, creates the element via the template's
+    // action; otherwise creates a plain BPMN element.
     const handleBpmnSelect = useCallback(
         (action: PopupMenuEntryAction, event: Event) => {
             if (selectedTemplate) {

--- a/libs/append-menu/src/components/TemplatePanel.tsx
+++ b/libs/append-menu/src/components/TemplatePanel.tsx
@@ -83,11 +83,8 @@ export function TemplatePanel({
         }
     }, [highlightedIndex]);
 
-    /**
-     * Handles hover state changes from individual cards.
-     * Uses a short delay before hiding to allow the mouse to move
-     * from the card to the hover card without flickering.
-     */
+    // Short delay before hiding so the mouse can travel from the card to the
+    // hover card without flickering.
     const handleCardHover = useCallback((index: number, hovered: boolean) => {
         window.clearTimeout(hideTimeoutRef.current);
         if (hovered) {

--- a/libs/append-menu/src/types.ts
+++ b/libs/append-menu/src/types.ts
@@ -7,9 +7,6 @@ import type {
     TemplateProperty,
 } from "@miragon/bpmn-modeler-element-template-chooser";
 
-/**
- * Re-export for use in components.
- */
 export type { TemplateProperty };
 
 /**
@@ -51,26 +48,18 @@ export interface EnrichedTemplateEntry {
     template: ElementTemplate | undefined;
 }
 
-/**
- * A standard BPMN element entry keyed by its popup menu ID.
- */
 export interface BpmnElementEntry {
     id: string;
     entry: PopupMenuEntry;
 }
 
-/**
- * BPMN element entries grouped by their `group.id`.
- */
+/** BPMN element entries grouped by their `group.id`. */
 export interface BpmnElementGroup {
     id: string;
     name: string;
     entries: BpmnElementEntry[];
 }
 
-/**
- * Result of classifying popup menu entries into templates vs. BPMN elements.
- */
 export interface ClassifiedEntries {
     templates: EnrichedTemplateEntry[];
     bpmnGroups: BpmnElementGroup[];
@@ -81,10 +70,6 @@ export interface ClassifiedEntries {
  *
  * Template entries are identified by their key containing `template-`
  * or by having an `imageUrl` (which standard BPMN entries never have).
- *
- * @param key The popup menu entry key (e.g. `"append.template-my-tpl"`).
- * @param entry The popup menu entry object.
- * @returns `true` if the entry is a template entry.
  */
 function isTemplateEntry(key: string, entry: PopupMenuEntry): boolean {
     return key.includes("template-") || !!entry.imageUrl;
@@ -95,9 +80,6 @@ function isTemplateEntry(key: string, entry: PopupMenuEntry): boolean {
  *
  * Keys follow the pattern `append.template-{templateId}` or
  * `create.template-{templateId}`.
- *
- * @param key The popup menu entry key.
- * @returns The extracted template ID, or `undefined` if not a template key.
  */
 function extractTemplateId(key: string): string | undefined {
     const match = key.match(/template-(.+)$/);
@@ -110,10 +92,6 @@ function extractTemplateId(key: string): string | undefined {
  *
  * Template entries are optionally enriched with the full `ElementTemplate`
  * data for richer UI display (implementation detail, property preview).
- *
- * @param entries Record of popup menu entries keyed by ID.
- * @param allTemplates All available element templates (for enrichment).
- * @returns Classified entries split into templates and BPMN element groups.
  */
 export function classifyEntries(
     entries: Record<string, PopupMenuEntry>,
@@ -159,9 +137,6 @@ export function classifyEntries(
  *
  * Handles both the plain function form and the `{ click, dragstart }` object
  * form used by different providers.
- *
- * @param action The entry's action.
- * @param event The DOM event that triggered the action.
  */
 export function executeEntryAction(action: PopupMenuEntryAction, event: Event): void {
     if (typeof action === "function") {
@@ -173,14 +148,7 @@ export function executeEntryAction(action: PopupMenuEntryAction, event: Event): 
 
 // ─── BPMN type → icon class mapping ──────────────────────────────────────
 
-/**
- * Maps a BPMN element type string to its bpmn-font CSS icon class.
- *
- * Falls back to `"bpmn-icon-task"` for unknown types.
- *
- * @param bpmnType The BPMN type (e.g. `"bpmn:ServiceTask"`).
- * @returns The CSS class name for the bpmn-font icon.
- */
+/** Maps a BPMN element type to its bpmn-font CSS icon class (`"bpmn-icon-task"` for unknown types). */
 const BPMN_TYPE_ICON_MAP: Record<string, string> = {
     "bpmn:Task": "bpmn-icon-task",
     "bpmn:UserTask": "bpmn-icon-user",
@@ -254,11 +222,8 @@ const IMPLEMENTATION_BINDINGS: {
  * Extracts the primary implementation detail from a template's properties.
  *
  * Searches for well-known binding types and names across both C7 and C8
- * patterns and returns the first match with its value.  Returns `undefined`
- * if no implementation binding is found or the value is empty.
- *
- * @param properties The template's property array.
- * @returns The implementation detail, or `undefined`.
+ * patterns and returns the first match with its value, or `undefined` if no
+ * implementation binding is found or the value is empty.
  */
 export function extractImplementationDetail(
     properties: TemplateProperty[],
@@ -282,19 +247,12 @@ export function extractImplementationDetail(
 
 // ─── Binding direction classification ─────────────────────────────────────
 
-/**
- * Direction category for a template property binding.
- */
 export type BindingDirection = "input" | "output" | "property" | "hidden";
 
 /**
- * Classifies a template property binding into a direction category.
- *
- * Used to split template properties into input, output, and property
- * sections in the hover card preview.
- *
- * @param binding The property's binding descriptor.
- * @returns The classified direction.
+ * Classifies a template property binding into a direction category, used to
+ * split properties into input, output, and property sections in the hover card
+ * preview.
  */
 export function classifyBinding(binding: TemplateProperty["binding"]): BindingDirection {
     const type = binding.type;

--- a/libs/bpmn-clipboard/README.md
+++ b/libs/bpmn-clipboard/README.md
@@ -7,10 +7,9 @@ of reach from the diagram (a sandboxed webview iframe lacking
 `clipboard-read`/`clipboard-write`, e.g. VS Code / IntelliJ / Theia). It routes
 copy/paste through a `ClipboardBridge` the host wires to its own clipboard.
 
-## Polarity: native default, bridge override (#1374)
+## Polarity: native default, bridge override
 
-Clipboard is a category-[B] *opinionated built-in* (ADR 0007): on by default,
-one override away.
+Clipboard is on by default, one override away.
 
 - **Native (default).** camunda-bpmn-js always registers bpmn-js's
   `NativeCopyPaste` (both C7 and C8). Registering **nothing** from this package

--- a/libs/bpmn-clipboard/src/BridgedClipboardModule.ts
+++ b/libs/bpmn-clipboard/src/BridgedClipboardModule.ts
@@ -10,8 +10,8 @@
  * the host wires to its extension-host clipboard, keeping the same prefixed-JSON
  * payload so webview-copy ↔ browser-paste stays interoperable.
  *
- * Uses proper didi DI value injection (`elementClipboardBridge`) instead of
- * `config.*` to ensure the bridge is always available when the module loads.
+ * Uses didi DI value injection (`elementClipboardBridge`) rather than `config.*`
+ * so the bridge is always available when the module loads.
  */
 import { createReviver } from "bpmn-js-native-copy-paste/lib/PasteUtil.js";
 
@@ -59,7 +59,7 @@ class BridgedClipboard {
         nativeCopyPaste: any,
         canvas: any,
     ) {
-        // Disable the broken NativeCopyPaste middle layer.
+        // Disable NativeCopyPaste so the bridge owns copy/paste in this webview.
         nativeCopyPaste.toggle(false);
 
         const { requestClipboard, writeClipboard } = bridge;

--- a/libs/bpmn-clipboard/src/createClipboardModules.ts
+++ b/libs/bpmn-clipboard/src/createClipboardModules.ts
@@ -3,7 +3,7 @@ import { LabelClipboardModule } from "./LabelClipboardModule";
 
 /**
  * Builds the bpmn-js DI modules that override the native clipboard with a host
- * bridge, for webviews that cannot reach the system clipboard directly (#1374).
+ * bridge, for webviews that cannot reach the system clipboard directly.
  * Omitting these modules entirely leaves bpmn-js's `NativeCopyPaste` in charge
  * — the native default — so this factory is only the override path.
  *

--- a/libs/bpmn-diff/README.md
+++ b/libs/bpmn-diff/README.md
@@ -1,7 +1,7 @@
 # @miragon/bpmn-modeler-diff
 
 Host-agnostic, Node- and browser-safe data layer for BPMN diffing. Private
-workspace lib (epic #1293); it is **inlined** into the publishable
+workspace lib; it is **inlined** into the publishable
 `@miragon/bpmn-modeler` package under its `./diff` subpath and imported directly
 by the extension engine (`@miragon/bpmn-modeler-core`) — layering forbids
 `libs → packages`, so the computation lives here rather than in the package.

--- a/libs/bpmn-diff/src/bpmnFlowOrder.ts
+++ b/libs/bpmn-diff/src/bpmnFlowOrder.ts
@@ -2,31 +2,25 @@
  * Builds a navigation order for diff highlights based on BPMN sequence-flow
  * direction.
  *
- * The diff stepper used to walk ids in the order `bpmn-js-differ` happened to
- * report them — effectively undefined.  This module produces a deterministic
- * "Start Event → End Event" ordering by traversing the parsed `bpmn-moddle`
- * definitions:
- *
- *   1. Collect every FlowElementsContainer (Process, SubProcess) recursively
- *      and index its FlowElements by id.
- *   2. BFS from each StartEvent following outgoing SequenceFlows.  Sequence
- *      flows themselves get an index immediately after their source so they
- *      slot between the two shapes they connect.
- *   3. Use BPMNDI bounds (visual `y` then `x`) as the tiebreaker for parallel
- *      branches and as the key for orphan nodes that the BFS never reaches.
+ * Produces a deterministic "Start Event → End Event" ordering so the stepper
+ * walks ids in flow direction rather than the arbitrary order `bpmn-js-differ`
+ * reports them. The order comes from a BFS over the parsed `bpmn-moddle`
+ * definitions (from each StartEvent following outgoing SequenceFlows across
+ * nested containers, each flow indexed right after its source), with BPMNDI
+ * bounds (visual `y` then `x`) as the tiebreaker for parallel branches and the
+ * key for orphan nodes the BFS never reaches.
  *
  * Removed elements only exist on the *before* canvas, so the after-pane order
  * has no slot for them.  {@link buildRemovedAnchors} walks the before graph
  * for each removed id, picks a surviving neighbour (incoming source first,
  * outgoing target as fallback), and assigns the removed id a fractional index
  * adjacent to that anchor's position in the after order.  This places removed
- * nodes near where they used to live in the flow rather than at the end.
+ * nodes near where they sit in the flow rather than at the end.
  *
  * The ordering is a heuristic — multi-pool collaborations, complex parallel
  * gateway fan-outs, and disconnected nodes all have known limitations
  * documented inline.  It will not always match a human's mental walk of every
- * diagram, but it is far more recognisable than the previous insertion-order
- * cycle.
+ * diagram, but it is far more recognisable than an insertion-order sequence.
  */
 
 /**

--- a/libs/bpmn-diff/src/computeDiff.ts
+++ b/libs/bpmn-diff/src/computeDiff.ts
@@ -71,7 +71,7 @@ export async function computeDiff(beforeXml: string, afterXml: string): Promise<
     // start event to end event instead of in the differ's arbitrary insertion
     // order.  Removed elements live only on the before canvas; anchor each one
     // next to a surviving neighbour in the after order so it appears near where
-    // it used to be in the flow.
+    // it sits in the flow.
     const afterOrder = buildFlowOrder(afterDefs as never);
     const removedAnchors = buildRemovedAnchors(removed, beforeDefs as never, afterOrder);
     const sortedAdded = sortIdsByOrder(added, afterOrder);

--- a/libs/bpmn-diff/src/index.ts
+++ b/libs/bpmn-diff/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * `@miragon/bpmn-modeler-diff` — the host-agnostic, Node- and browser-safe data
- * layer for BPMN diffing (epic #1293).
+ * layer for BPMN diffing.
  *
  * `computeDiff(beforeXml, afterXml)` parses and compares two BPMN documents and
  * returns a serializable {@link DiffResult}; `sideView` projects that result

--- a/libs/bpmn-diff/vitest.config.ts
+++ b/libs/bpmn-diff/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     test: {
         name: "bpmn-diff",
         // Node environment (no jsdom): mechanically proves `computeDiff` runs
-        // outside a browser — the Node-safety acceptance criterion for #1378.
+        // outside a browser, its Node-safety guarantee.
         environment: "node",
         include: ["src/**/*.{spec,test}.ts"],
     },

--- a/libs/bpmn-i18n-extras/README.md
+++ b/libs/bpmn-i18n-extras/README.md
@@ -4,12 +4,12 @@ The modeler's local translation **overlay** on top of the shared
 [`@miragon/bpmn-modeler-i18n`](https://github.com/Miragon/camunda-modeler-i18n-plugin/tree/develop/packages/translations)
 library.
 
-The shared library now ships this modeler's Camunda-7 (Platform) palette /
-context-pad / properties-panel strings as a first-class overlay (`en` ≈ 1016
-keys, 12 locales). So the overlay has **collapsed to the handful of
-modeler-internal strings the shared library still lacks** — today just the
-script-lock badge labels the webview emits (`Read-only`, `Being edited in`). The
-webviews merge them onto the shared dictionaries at startup:
+The shared library ships this modeler's Camunda-7 (Platform) palette /
+context-pad / properties-panel strings (`en` ≈ 1016 keys, 12 locales), so this
+overlay covers **only the handful of modeler-internal strings the shared library
+lacks** — today just the script-lock badge labels the webview emits (`Read-only`,
+`Being edited in`). The webviews merge them onto the shared dictionaries at
+startup:
 
 ```ts
 import { i18n } from "@miragon/bpmn-modeler-i18n";

--- a/libs/bpmn-i18n-extras/src/index.ts
+++ b/libs/bpmn-i18n-extras/src/index.ts
@@ -2,13 +2,13 @@
  * The modeler's local i18n overlay on top of the shared
  * `@miragon/bpmn-modeler-i18n` library.
  *
- * The shared library now ships this modeler's Camunda-7 palette / context-pad /
- * properties-panel strings as a first-class overlay, so the overlay has
- * collapsed to a handful of modeler-internal strings the shared library still
- * lacks — the script-lock badge labels the webview emits ({@link extras}). The
- * webviews merge them onto the shared dictionaries at startup via
- * `i18n.extend(extras)`; the shared translations stay authoritative for every
- * key they cover, and nothing regresses to English.
+ * The shared library ships this modeler's Camunda-7 palette / context-pad /
+ * properties-panel strings, so this overlay covers only the handful of
+ * modeler-internal strings the shared library lacks — the script-lock badge
+ * labels the webview emits ({@link extras}). The webviews merge them onto the
+ * shared dictionaries at startup via `i18n.extend(extras)`; the shared
+ * translations stay authoritative for every key they cover, and nothing
+ * regresses to English.
  *
  * It also exposes {@link supportedModelerLanguages}: the shared language
  * catalogue narrowed to the locales the modeler actually has full coverage for.

--- a/libs/bpmn-i18n-extras/src/languages/index.ts
+++ b/libs/bpmn-i18n-extras/src/languages/index.ts
@@ -1,9 +1,9 @@
 /*
  * Registry of the modeler's local translation overlay, one dictionary per
  * locale. These are the modeler-internal keys the shared
- * @miragon/bpmn-modeler-i18n library does not ship (the C7 strings this overlay
- * used to carry are upstream now); the webviews merge them onto the shared
- * dictionaries at startup with i18n.extend(). GENERATED barrel.
+ * @miragon/bpmn-modeler-i18n library does not ship (the C7 strings live in the
+ * shared library); the webviews merge them onto the shared dictionaries at
+ * startup with i18n.extend(). GENERATED barrel.
  */
 import type { SupportedLocale } from "@miragon/bpmn-modeler-i18n";
 

--- a/libs/code-link/README.md
+++ b/libs/code-link/README.md
@@ -72,5 +72,4 @@ the sync runs.
 
 The library keeps a runtime import of `implementationStatusKey` from
 `@miragon/bpmn-modeler-shared` (the composite status-map key both sides must
-agree on byte-for-byte) until the public/protocol split (#1371); everything else
-it takes from shared is `import type`.
+agree on byte-for-byte); everything else it takes from shared is `import type`.

--- a/libs/code-link/src/CodeLinkPort.ts
+++ b/libs/code-link/src/CodeLinkPort.ts
@@ -7,9 +7,6 @@ import type { ImplementationEntry } from "@miragon/bpmn-modeler-types";
  * so the library never imports the postMessage protocol and registering its
  * providers without a host is unrepresentable — no port, no module (see
  * {@link createCodeLinkModule}).
- *
- * `ImplementationEntry` is a type-only import from the protocol-free
- * `@miragon/bpmn-modeler-types` package (#1371).
  */
 export interface CodeLinkPort {
     /**

--- a/libs/code-link/src/index.ts
+++ b/libs/code-link/src/index.ts
@@ -38,7 +38,7 @@ export type { CodeLinkPort } from "./CodeLinkPort";
  *
  * @internal Package-internal composition wiring: consumers enable this feature
  *   through the modeler's `capabilities.codeLink` port, not by calling this
- *   factory directly (#1375).
+ *   factory directly.
  */
 export function createCodeLinkModule(port: CodeLinkPort) {
     return {

--- a/libs/element-template-chooser/src/search.spec.ts
+++ b/libs/element-template-chooser/src/search.spec.ts
@@ -64,7 +64,7 @@ const templates: ElementTemplate[] = [
 const index = new TemplateSearchIndex(templates);
 
 describe("TemplateSearchIndex", () => {
-    it("finds a template despite a single-character typo (issue #1231 repro)", () => {
+    it("finds a template despite a single-character typo", () => {
         expect(index.search("resources")).toContain(repro);
     });
 

--- a/libs/element-template-chooser/src/search.ts
+++ b/libs/element-template-chooser/src/search.ts
@@ -1,12 +1,11 @@
 /**
  * Ranked fuzzy search over element templates for the chooser overlay.
  *
- * The old chooser filtered with a single whole-query substring test over a
- * space-joined name/description/category/keywords string. That missed typos
- * ("resources" vs the German "Resourcen"), was sensitive to word order and
- * adjacency, and let one field's tail match the next field's head across the
- * join. This module replaces it with MiniSearch: per-term AND matching, typo
- * tolerance, prefix matching, and field-boosted relevance ranking.
+ * Uses MiniSearch for per-term AND matching, typo tolerance, prefix matching,
+ * and field-boosted relevance ranking. A plainer whole-query substring test over
+ * a space-joined name/description/category/keywords string would miss typos
+ * ("resources" vs the German "Resourcen"), be sensitive to word order and
+ * adjacency, and let one field's tail match the next field's head across the join.
  */
 import MiniSearch from "minisearch";
 import type { ElementTemplate } from "./types";

--- a/libs/element-template-chooser/src/types.ts
+++ b/libs/element-template-chooser/src/types.ts
@@ -1,9 +1,4 @@
-/**
- * Represents a single property defined in an element template.
- *
- * Properties describe the input/output parameters, hidden bindings,
- * and user-configurable fields that a template applies to a BPMN element.
- */
+/** A single property (input/output, binding, or user-configurable field) an element template applies. */
 export interface TemplateProperty {
     label?: string;
     type: string;
@@ -30,12 +25,7 @@ export interface TemplateProperty {
     };
 }
 
-/**
- * Represents a Camunda element template as loaded from a JSON file.
- *
- * Element templates define reusable configurations for BPMN elements,
- * including which element types they apply to and what properties they set.
- */
+/** A Camunda element template as loaded from a JSON file. */
 export interface ElementTemplate {
     $schema?: string;
     id: string;
@@ -54,18 +44,9 @@ export interface ElementTemplate {
     properties: TemplateProperty[];
 }
 
-/**
- * Binding type groupings used to classify template properties
- * for the preview panel display.
- */
+/** Binding-type groupings used to classify template properties for the preview panel. */
 export type BindingDirection = "input" | "output" | "property" | "hidden";
 
-/**
- * Returns the direction of a template property binding.
- *
- * @param binding The property binding object.
- * @returns The classified direction.
- */
 /**
  * An implementation detail extracted from template properties that
  * identifies the technical binding (topic, delegate, class, called element).
@@ -110,11 +91,8 @@ const IMPLEMENTATION_BINDINGS: {
  * Extracts the primary implementation detail from a template's properties.
  *
  * Searches for well-known binding types and names across both C7 and C8
- * patterns and returns the first match with its value. Returns `undefined`
- * if no implementation binding is found or the value is empty.
- *
- * @param properties The template's property array.
- * @returns The implementation detail, or `undefined`.
+ * patterns and returns the first match with its value, or `undefined` if no
+ * implementation binding is found or the value is empty.
  */
 export function extractImplementationDetail(
     properties: TemplateProperty[],
@@ -124,9 +102,7 @@ export function extractImplementationDetail(
             if (p.binding.type !== bindingType) {
                 return false;
             }
-            /**
-             * For "property" bindings, also match on the binding name.
-             */
+            // For "property" bindings, also match on the binding name.
             if (bindingName && p.binding.name !== bindingName) {
                 return false;
             }

--- a/libs/inline-scripting/src/index.ts
+++ b/libs/inline-scripting/src/index.ts
@@ -65,7 +65,7 @@ export type { OpenScriptEditorEvent, ScriptSourceChangedEvent, InlineScriptingPo
  *
  * @internal Package-internal composition wiring: consumers enable this feature
  *   through the modeler's `capabilities.scripting` port (C7 only), not by
- *   calling this factory directly (#1375).
+ *   calling this factory directly.
  */
 export function createInlineScriptingModules(port: InlineScriptingPort): Record<string, unknown>[] {
     return [

--- a/libs/model-navigation/src/index.ts
+++ b/libs/model-navigation/src/index.ts
@@ -30,7 +30,7 @@ export type { ModelNavigationPort, ModelReference } from "./ModelNavigationPort"
  *
  * @internal Package-internal composition wiring: consumers enable this feature
  *   through the modeler's `capabilities.modelNavigation` port, not by calling
- *   this factory directly (#1375).
+ *   this factory directly.
  */
 export function createModelNavigationModule(port: ModelNavigationPort) {
     return {

--- a/libs/modeler-core/src/deployment/domain/deployment.ts
+++ b/libs/modeler-core/src/deployment/domain/deployment.ts
@@ -97,78 +97,36 @@ export class DeploymentConfigBuilder {
 
     private _auth: AuthConfig = new NoAuth();
 
-    /**
-     * Sets the deployment name (required).
-     *
-     * @param name Human-readable deployment name.
-     * @returns `this` for chaining.
-     */
     withDeploymentName(name: string): this {
         this._deploymentName = name;
         return this;
     }
 
-    /**
-     * Sets the optional tenant ID.
-     *
-     * @param tenantId Tenant identifier string (may be empty).
-     * @returns `this` for chaining.
-     */
     withTenantId(tenantId: string): this {
         this._tenantId = tenantId;
         return this;
     }
 
-    /**
-     * Sets the REST endpoint URL (required).
-     *
-     * @param endpoint Base URL of the Camunda REST API.
-     * @returns `this` for chaining.
-     */
     withEndpoint(endpoint: string): this {
         this._endpoint = endpoint;
         return this;
     }
 
-    /**
-     * Sets the target execution platform.
-     *
-     * @param engine `"c7"` for Camunda Platform 7, `"c8"` for Camunda Cloud 8.
-     * @returns `this` for chaining.
-     */
     withEngine(engine: Engine): this {
         this._engine = engine;
         return this;
     }
 
-    /**
-     * Sets the absolute path to the primary BPMN file (required).
-     *
-     * @param filePath Absolute filesystem path of the main BPMN file.
-     * @returns `this` for chaining.
-     */
     withMainFilePath(filePath: string): this {
         this._mainFilePath = filePath;
         return this;
     }
 
-    /**
-     * Sets the list of additional file paths to include in the deployment.
-     *
-     * @param filePaths Array of absolute filesystem paths.
-     * @returns `this` for chaining.
-     */
     withAdditionalFilePaths(filePaths: string[]): this {
         this._additionalFilePaths = filePaths;
         return this;
     }
 
-    /**
-     * Sets the authentication configuration.
-     *
-     * @param auth Authentication strategy to use. Defaults to {@link NoAuth}.
-     * @returns `this` for chaining.
-     */
     withAuth(auth: AuthConfig): this {
         this._auth = auth;
         return this;

--- a/libs/modeler-core/src/diff/domain/DiffSession.ts
+++ b/libs/modeler-core/src/diff/domain/DiffSession.ts
@@ -46,10 +46,9 @@ export function basenameOfUriString(uri: string): string {
  * A paired BPMN diff view — the domain object the diff service revolves
  * around.
  *
- * Promotes what used to be implicit pairing (mutual `partner` pointers on
- * two pane records) into an explicit object that owns both URIs and both
- * pane slots. A session can exist with zero, one, or two attached panes
- * — this matters because:
+ * An explicit object that owns both URIs and both pane slots, rather than a
+ * pairing implied by mutual `partner` pointers on two pane records. A session
+ * can exist with zero, one, or two attached panes — this matters because:
  *
  * - `compare-files` sessions are created up front with both URIs known but
  *   no panes attached yet; the panes attach as VS Code resolves the two
@@ -73,11 +72,9 @@ export class DiffSession {
      * {@link forScm}) over calling this directly — they encapsulate each
      * origin's side-assignment rule.
      *
-     * @param origin How this session came to be. Surfaces in the diff-legend
-     *   UI so compare-files panes can show origin-specific affordances (the
-     *   filename label, the swap button) that don't apply to SCM diffs.
-     * @param beforeUri Stringified URI rendered in the left pane.
-     * @param afterUri Stringified URI rendered in the right pane.
+     * `origin` surfaces in the diff-legend UI so compare-files panes can show
+     * origin-specific affordances (the filename label, the swap button) that
+     * don't apply to SCM diffs.
      */
     constructor(
         readonly origin: DiffOrigin,

--- a/libs/modeler-core/src/diff/infrastructure/DiffPaneStore.ts
+++ b/libs/modeler-core/src/diff/infrastructure/DiffPaneStore.ts
@@ -138,10 +138,8 @@ export class DiffPaneStore implements EditorSubscription {
     }
 
     /**
-     * Drops a pending SCM pane by identity (used when a pane that never
-     * paired is disposed).
-     *
-     * @returns `true` when a pending entry was found and removed.
+     * Drops a pending SCM pane by identity (used when a pane that never paired is
+     * disposed). Returns `true` when a pending entry was found and removed.
      */
     removePendingByHandle(handle: DiffPaneHandle): boolean {
         for (const [key, pending] of this.pendingScm) {

--- a/libs/modeler-core/src/migration/domain/MigrationPlan.ts
+++ b/libs/modeler-core/src/migration/domain/MigrationPlan.ts
@@ -41,39 +41,22 @@ export class MigrationPlan {
         readonly undetected: readonly string[],
     ) {}
 
-    /**
-     * Returns `true` if at least one Camunda 7 file was found.
-     */
     hasC7(): boolean {
         return this.c7Files.length > 0;
     }
 
-    /**
-     * Returns `true` if at least one Camunda 8 file was found.
-     */
     hasC8(): boolean {
         return this.c8Files.length > 0;
     }
 
-    /**
-     * Returns `true` if both Camunda 7 and 8 files were found.
-     */
     hasBothPlatforms(): boolean {
         return this.hasC7() && this.hasC8();
     }
 
-    /**
-     * Returns `true` if no classifiable BPMN files were found.
-     */
     isEmpty(): boolean {
         return !this.hasC7() && !this.hasC8();
     }
 
-    /**
-     * Returns the number of files covered by the given scope.
-     *
-     * @param scope The migration scope to count.
-     */
     fileCount(scope: MigrationScope): number {
         switch (scope) {
             case "c7":

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/CompositeResolver.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/CompositeResolver.ts
@@ -30,8 +30,8 @@ const NOOP_CONFIG = { rules: {} };
  *
  * A rule/config that no delegate can resolve is *skipped*, not thrown: its name
  * is collected in {@link unresolved} and a no-op is returned so the rest of the
- * lint still runs. This is what turns the old "unknown rule → whole lint fails"
- * (or the webview's silent drop) into a visible, non-fatal "N rules skipped".
+ * lint still runs. An unknown rule becomes a visible, non-fatal "N rules skipped"
+ * rather than failing the whole lint or being silently dropped.
  */
 export class CompositeResolver implements Resolver {
     /** Names of rules/configs that could not be resolved this run. */

--- a/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/lintParity.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/infrastructure/bpmnlint/lintParity.spec.ts
@@ -12,11 +12,11 @@ import { NodeBpmnLinter } from "./NodeBpmnLinter";
 import { BrowserLinter } from "../../../../../../../packages/bpmn-modeler/src/bpmnlint/browserLinter";
 
 /**
- * AC5 parity: the host-side {@link NodeBpmnLinter} default run and the webview's
+ * Parity: the host-side {@link NodeBpmnLinter} default run and the webview's
  * in-page {@link BrowserLinter} default run must produce byte-identical findings
- * for the same diagram. Phase B moves the no-config path in-page for hosted
- * sessions, so this is the contract that a user sees the *same* lint whether the
- * host ran it (workspace config) or the webview did (no config).
+ * for the same diagram. The no-config path runs in-page for hosted sessions, so
+ * this is the contract that a user sees the *same* lint whether the host ran it
+ * (workspace config) or the webview did (no config).
  *
  * Both sides lint the same moddle tree with the same engine-aware default config
  * (`getDefaultLintConfig({ engine, preset: "modeling" })`) and must report no
@@ -89,7 +89,7 @@ describe("bpmnlint default parity: NodeBpmnLinter vs BrowserLinter", () => {
         expect(browserOut.unresolved).toEqual([]);
     });
 
-    // #1384: a covered *workspace* config (a real `.bpmnlintrc`, not the
+    // A covered *workspace* config (a real `.bpmnlintrc`, not the
     // zero-config default) that the bundled resolver can fully honour must lint
     // identically host-side and in-page — so a user who edits `bpmnlint:recommended`
     // into their config sees the exact same findings the host would have produced.

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
@@ -23,7 +23,7 @@ const RESULTS = {
     "label-required": [{ id: "Task_1", message: "Element requires a label", category: "warn" }],
 };
 
-// The bundled resolver covers this (no moddleExtensions) → linted in-page (#1384).
+// The bundled resolver covers this (no moddleExtensions) → linted in-page.
 const COVERED_CONFIG = { extends: "bpmnlint:recommended" };
 const COVERED_RAW = JSON.stringify(COVERED_CONFIG);
 // A string moddleExtension is a Node-only module path → the static pre-check
@@ -113,7 +113,7 @@ function noResultsQueryPosted(editorStore: Store): boolean {
     return postedOfType(editorStore, "BpmnlintResultsQuery").length === 0;
 }
 
-/** Arranges a live covered (#1384 in-page) session and returns its instruction token. */
+/** Arranges a live covered (in-page) session and returns its instruction token. */
 async function coveredSession(): Promise<ReturnType<typeof createService> & { token: string }> {
     const ctx = createService();
     ctx.locator.findNearestConfig.mockResolvedValue(CONFIG_PATH);
@@ -229,7 +229,7 @@ describe("BpmnLintConfigService.setBpmnlintConfig — escalated workspace config
     });
 });
 
-describe("BpmnLintConfigService.setBpmnlintConfig — covered workspace config (#1384 in-page)", () => {
+describe("BpmnLintConfigService.setBpmnlintConfig — covered workspace config (in-page)", () => {
     it("instructs the webview to lint the config in-page with a token, and never lints host-side", async () => {
         const { service, editorStore, locator, lintRunner, diagnostics, statusBar } =
             createService();

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
@@ -32,9 +32,9 @@ import {
  * Where a set of findings came from, so {@link BpmnLintConfigService.applyFindings}
  * can pick the right status-bar indicator and log line. `"workspace"` is a
  * host-side (escalated) Node run against a discovered `.bpmnlintrc`; `"in-page"`
- * is a webview run — either the zero-config default (#1373 Phase B, no
- * `configPath`) or the #1384 covered workspace tier (`configPath` set, so it
- * shows the `showBpmnlintActive` indicator rather than `showBpmnlintDefault`).
+ * is a webview run — either the zero-config default tier (no `configPath`) or the
+ * covered workspace tier (`configPath` set, so it shows the `showBpmnlintActive`
+ * indicator rather than `showBpmnlintDefault`).
  */
 type LintFindingsSource =
     | { kind: "workspace"; configPath: string }
@@ -45,8 +45,8 @@ type LintFindingsSource =
  * so a panel re-activation (`setBpmnlintConfig` from the panel-active hook) can
  * restore the Problems panel + status bar instead of going blank until the next
  * edit re-runs the webview linter. `configPath` records which tier produced it
- * (set = #1384 covered workspace config; undefined = #1373 zero-config default)
- * so a replay restores the right status-bar indicator.
+ * (set = covered workspace config; undefined = zero-config default) so a replay
+ * restores the right status-bar indicator.
  */
 interface CachedInPageEvent {
     readonly xml: string;
@@ -58,7 +58,7 @@ interface CachedInPageEvent {
 
 /**
  * The per-(editor × config-version) escalation decision for a workspace
- * `.bpmnlintrc` (#1384). Version identity is `configPath` + `rawConfig` (the
+ * `.bpmnlintrc`. Version identity is `configPath` + `rawConfig` (the
  * exact bytes read from disk): editing either mints a fresh decision. `decision`
  * starts `"in-page"` (the webview lints the covered config itself) and only ever
  * flips forward to `"escalated"` — when the static pre-check, or the webview's
@@ -82,13 +82,13 @@ interface LintNegotiation {
  *
  * Three tiers, chosen per document:
  *
- *  - **No config** (#1373 Phase B) — no workspace `.bpmnlintrc`: the host tells
+ *  - **Zero-config default tier** — no workspace `.bpmnlintrc`: the host tells
  *    the webview to run its own engine-aware default in-page (payload-free
  *    {@link BpmnlintInPageQuery}); the webview pushes findings back through
  *    {@link applyWebviewLintResults}. The host does not lint, so a non-workspace
  *    diagram never pays for a host-side re-lint.
- *  - **Covered workspace config** (#1384) — a `.bpmnlintrc` exists and the
- *    bundled resolver can cover it: the host pushes the config down
+ *  - **Covered workspace tier** — a `.bpmnlintrc` exists and the bundled
+ *    resolver can cover it: the host pushes the config down
  *    ({@link BpmnlintInPageQuery} carrying `config`) and the webview lints it
  *    in-page, so a covered config also skips the host re-lint per edit. A static
  *    pre-check ({@link staticUnresolvedModdleExtensions}) escalates immediately;
@@ -164,8 +164,8 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
     }
 
     /**
-     * Applies findings the webview computed in an in-page run (the #1373 default
-     * tier or the #1384 covered workspace tier) to the host's chrome. Guarded so
+     * Applies findings the webview computed in an in-page run (the zero-config
+     * default tier or the covered workspace tier) to the host's chrome. Guarded so
      * a push that arrives after an escalation or a workspace-config takeover — or
      * while linting is disabled — is ignored: the mode flips to `"external"`
      * *before* the takeover push, so a late in-page push finds the wrong mode.
@@ -195,7 +195,7 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
 
         const negotiation = this.negotiations.get(editorId);
         if (negotiation) {
-            // Workspace-config in-page tier (#1384). Drop a run paired with a
+            // Covered workspace tier. Drop a run paired with a
             // superseded config version, or one arriving after this version
             // already escalated (the synchronous double-event guard).
             if (configToken !== negotiation.token) {
@@ -239,7 +239,7 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
             return;
         }
 
-        // No negotiation: the #1373 payload-free default tier. A token here means
+        // No negotiation: the payload-free zero-config default tier. A token here means
         // the run belongs to a since-deleted config era — drop it.
         if (configToken !== undefined) {
             this.notifier.logDebug(
@@ -259,11 +259,11 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
 
     /**
      * Resolves the nearest `.bpmnlintrc` and drives the right tier. No config →
-     * the webview's in-page default (#1373 Phase B). A config → consult the
-     * per-editor negotiation: a cached decision re-lints in its settled tier
-     * (in-page instruction or Node run); a new/changed version re-negotiates,
-     * escalating immediately when the static pre-check proves the bundled
-     * resolver cannot cover it, otherwise lints it in-page (#1384). A
+     * the webview's in-page default. A config → consult the per-editor
+     * negotiation: a cached decision re-lints in its settled tier (in-page
+     * instruction or Node run); a new/changed version re-negotiates, escalating
+     * immediately when the static pre-check proves the bundled resolver cannot
+     * cover it, otherwise lints it in-page. A
      * read/parse/lint failure — including a malformed `.bpmnlintrc` — degrades to
      * the no-config-*failure* state (linting off in the webview) rather than
      * crashing the editor, and forgets the negotiation so a later valid edit
@@ -485,7 +485,7 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
     /**
      * The single results→chrome mapping shared by the workspace-config run and
      * the in-page webview push, so both feed the Problems panel, status bar, and
-     * unresolved warning identically (AC5 parity is structural). The status bar
+     * unresolved warning identically. The status bar
      * is only touched when `reflectInStatusBar`; diagnostics always publish.
      */
     private applyFindings(
@@ -506,7 +506,7 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
                     this.statusBar.showBpmnlintActive(source.configPath);
                 }
             } else if (source.configPath !== undefined) {
-                // #1384 covered workspace tier: linted in-page, but against a real
+                // Covered workspace tier: linted in-page, but against a real
                 // .bpmnlintrc — surface it as Active, not the zero-config default.
                 this.statusBar.showBpmnlintActive(source.configPath);
             } else {
@@ -591,9 +591,9 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
     }
 
     /**
-     * Tells the webview to run its in-page linter. Payload-free = the #1373
-     * engine-aware default (no workspace config); with `config` + `configToken` =
-     * the #1384 covered workspace tier, the config to lint plus the version stamp
+     * Tells the webview to run its in-page linter. Payload-free = the engine-aware
+     * default (no workspace config); with `config` + `configToken` = the covered
+     * workspace tier, the config to lint plus the version stamp
      * the webview echoes back on {@link UpdateLintResultsCommand}. Same
      * recoverable-drop handling as {@link pushResults}: a hidden panel makes the
      * post reject, and the webview re-requests on reload.

--- a/libs/modeler-core/src/modeler/bpmn/service/DefaultBpmnlintConfigService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/DefaultBpmnlintConfigService.ts
@@ -4,7 +4,7 @@ import { Engine } from "@miragon/bpmn-modeler-types";
 /**
  * Builds the zero-config **default** bpmnlint config, used when no `.bpmnlintrc`
  * is found from the document up to the workspace root, so a diagram gets baseline
- * validation for free (issue #1327). A workspace `.bpmnlintrc` — even `{}` — is
+ * validation for free. A workspace `.bpmnlintrc` — even `{}` — is
  * still nearest-config-wins and never reaches here.
  *
  * The layered config comes from `@miragon/bpmnlint-plugin-rules`'

--- a/libs/modeler-core/src/modeler/dmn/domain/emptyDmn.ts
+++ b/libs/modeler-core/src/modeler/dmn/domain/emptyDmn.ts
@@ -2,8 +2,8 @@
  * Minimal DMN XML used when scaffolding a new blank `.dmn` file.
  *
  * A full decision table + DMNDI so DMN-js can open and render the model
- * without errors. Extracted from `DmnModelerService` so the "New DMN Model"
- * command and the empty-file editor flow seed byte-identical content.
+ * without errors. Shared by the "New DMN Model" command and the empty-file
+ * editor flow so both seed byte-identical content.
  */
 export const EMPTY_DMN_DIAGRAM = `
 <?xml version="1.0" encoding="UTF-8"?>

--- a/libs/modeler-core/src/scriptTask/domain/localDeclarations.ts
+++ b/libs/modeler-core/src/scriptTask/domain/localDeclarations.ts
@@ -8,8 +8,8 @@
  * `def myVar` — is never consulted. Locals therefore have to come from us.
  *
  * This is a deliberately slim, line-based fallback, not a parser: inline
- * scripts are short snippets, and once scripts live on disk (#1219) external
- * language servers own general language intelligence. Known, accepted gaps:
+ * scripts are short snippets, so general language intelligence is out of scope.
+ * Known, accepted gaps:
  * multi-declarators (`def a, b`), destructuring, dotted type names
  * (`java.util.List x`), function parameters, and declaration-shaped text
  * inside block comments or multiline strings.

--- a/libs/modeler-core/src/scriptTask/domain/scriptCompletion.ts
+++ b/libs/modeler-core/src/scriptTask/domain/scriptCompletion.ts
@@ -3,7 +3,7 @@ import { ScriptKind } from "@miragon/bpmn-modeler-types";
 /**
  * Pure helpers backing {@link ScriptCompletionProvider}.
  *
- * Extracted from the provider so they can be unit-tested without mocking
+ * Kept separate from the provider so they can be unit-tested without mocking
  * the `vscode` module — the provider itself depends on `vscode.languages`,
  * `CompletionItem`, etc., which the jest test environment doesn't supply.
  */

--- a/libs/modeler-core/src/scriptTask/domain/scriptLanguage.ts
+++ b/libs/modeler-core/src/scriptTask/domain/scriptLanguage.ts
@@ -30,11 +30,7 @@ export class ScriptLanguage {
     // The file extension without a leading dot (e.g. `"js"`).
     readonly extension: string;
 
-    /**
-     * Creates a ScriptLanguage from a Camunda `scriptFormat` value.
-     *
-     * @param scriptFormat Raw format string from the BPMN model (e.g. `"javascript"`, `"groovy"`).
-     */
+    /** Creates a ScriptLanguage from a Camunda `scriptFormat` value (e.g. `"javascript"`, `"groovy"`). */
     constructor(scriptFormat: string) {
         const normalized = ScriptLanguage.normalize(scriptFormat);
         const mapping = ScriptLanguage.MAPPINGS.get(normalized) ?? ScriptLanguage.FALLBACK;

--- a/libs/modeler-core/src/shared/domain/BpmnDocument.ts
+++ b/libs/modeler-core/src/shared/domain/BpmnDocument.ts
@@ -12,19 +12,12 @@ import { Engine } from "@miragon/bpmn-modeler-types";
 import { ExecutionPlatformNotDetectedError } from "./errors";
 
 export class BpmnDocument {
-    /**
-     * @param xml Raw BPMN XML string backing this document.
-     */
     constructor(readonly xml: string) {}
 
     /**
-     * Returns an empty BPMN diagram for the given engine and version.
-     *
-     * The template XML is the minimal structure required by bpmn-js to open
-     * and render a new diagram without errors.
-     *
-     * @param engine The target Camunda execution engine (`"c7"` or `"c8"`).
-     * @param version The version string (e.g. `"7.24.0"` or `"8.8.0"`).
+     * Returns an empty BPMN diagram for the given engine and version — the
+     * minimal structure bpmn-js needs to open and render a new diagram without
+     * errors.
      */
     static empty(engine: Engine, version: string): BpmnDocument {
         if (engine === "c7") {
@@ -103,8 +96,6 @@ export class BpmnDocument {
 
     /**
      * Returns a new `BpmnDocument` with the `modeler:executionPlatformVersion` replaced.
-     *
-     * @param version The new version string (e.g. `"8.7.0"`).
      */
     withVersion(version: string): BpmnDocument {
         return new BpmnDocument(
@@ -116,17 +107,9 @@ export class BpmnDocument {
     }
 
     /**
-     * Returns a new `BpmnDocument` with execution platform attributes injected
-     * into the `<bpmn:definitions>` opening tag.
-     *
-     * The function locates the `<bpmn:definitions ...>` opening tag, strips its
-     * closing `>`, appends the new attributes, and re-closes the tag.
-     *
-     * @param platform The execution platform name (e.g. `"Camunda Platform"`).
-     * @param version The version string (e.g. `"7.20.0"`).
-     * @param schema Optional namespace attribute to inject (e.g.
-     *   `xmlns:camunda="http://camunda.org/schema/1.0/bpmn"`).
-     * @throws {Error} If the XML does not contain a `<bpmn:definitions>` tag.
+     * Returns a new `BpmnDocument` with execution platform attributes (and an
+     * optional `schema` namespace attribute) injected into the
+     * `<bpmn:definitions>` opening tag. Throws when the XML has no such tag.
      */
     withExecutionPlatform(platform: string, version: string, schema?: string): BpmnDocument {
         const regex = /<bpmn:definitions[^>]*>/;

--- a/libs/modeler-core/src/shared/domain/engineVersions.ts
+++ b/libs/modeler-core/src/shared/domain/engineVersions.ts
@@ -32,22 +32,12 @@ export const C8_VERSIONS: readonly string[] = [
     "8.0.0",
 ];
 
-/**
- * Returns the latest (first) version for the given platform.
- *
- * @param platform The execution platform identifier.
- * @returns The latest version string for that platform.
- */
+/** Returns the latest (first) version for the given platform. */
 export function getLatestVersion(platform: Engine): string {
     return getVersions(platform)[0];
 }
 
-/**
- * Returns the version list for the given platform.
- *
- * @param platform The execution platform identifier.
- * @returns An ordered list of version strings (newest first).
- */
+/** Returns the platform's version list, newest first. */
 export function getVersions(platform: Engine): readonly string[] {
     return platform === "c7" ? C7_VERSIONS : C8_VERSIONS;
 }

--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -9,9 +9,6 @@
  * names, in domain terms, exactly which host facilities the core relies on —
  * the contract any non-VS-Code host would have to satisfy. The concrete
  * `VsCode*` classes in `infrastructure/` `implements` these.
- *
- * Mirrors the port/adapter seam already proven by {@link CamundaEnginePort}
- * (`ports.ts`) and `DiffPaneHandle` (`DiffSession.ts`).
  */
 
 import { AuthTypePayload } from "@miragon/bpmn-modeler-shared";

--- a/libs/modeler-core/src/shared/infrastructure/EditorSessionStore.ts
+++ b/libs/modeler-core/src/shared/infrastructure/EditorSessionStore.ts
@@ -12,10 +12,9 @@ import {
  * bookkeeping. Holds {@link EditorHandle}s (the port), never a `WebviewPanel`
  * or `TextDocument`, so services depend on it without pulling in `vscode`.
  *
- * Was the registry half of the former `EditorStore`; the VS Code half now lives
- * in {@link VsCodeEditorHandle}. The subscription methods are thin delegations
- * to the active or addressed handle — they keep their former call sites so
- * controllers barely change, but their signatures are now `vscode`-free.
+ * The VS Code half lives in {@link VsCodeEditorHandle}. The subscription methods
+ * are thin delegations to the active or addressed handle, with `vscode`-free
+ * signatures.
  */
 export class EditorSessionStore {
     /**
@@ -40,9 +39,8 @@ export class EditorSessionStore {
     constructor(private readonly onOpenCountChanged: (count: number) => void) {}
 
     /**
-     * Registers an already-constructed session and makes it active. Replaces
-     * the storage half of the former `createEditor`; webview bootstrap now
-     * happens in {@link VsCodeEditorHandle.create}.
+     * Registers an already-constructed session and makes it active. Webview
+     * bootstrap happens separately in {@link VsCodeEditorHandle.create}.
      */
     register(handle: EditorHandle): void {
         this.editors.set(handle.id, handle);

--- a/libs/modeler-core/src/shared/infrastructure/WebviewMessageRouter.ts
+++ b/libs/modeler-core/src/shared/infrastructure/WebviewMessageRouter.ts
@@ -38,8 +38,8 @@ export class WebviewMessageRouter {
     /**
      * Runs every handler registered for `message.type` sequentially, awaiting
      * each before the next so ordering-dependent fan-out (e.g. setSettings →
-     * setLanguage → resync) behaves exactly as the old switch did. An unknown
-     * type is a silent no-op.
+     * setLanguage → resync) stays in registration order. An unknown type is a
+     * silent no-op.
      */
     async dispatch(message: Command, editorId: string): Promise<void> {
         const handlers = this.handlers.get(message.type);

--- a/libs/modeler-core/src/template-marketplace/service/TemplateMarketplaceService.spec.ts
+++ b/libs/modeler-core/src/template-marketplace/service/TemplateMarketplaceService.spec.ts
@@ -1072,8 +1072,8 @@ describe("TemplateMarketplaceService private-repo auth", () => {
         ).rejects.not.toThrow(/can't access/);
     });
 
-    // Regression #1250: a public marketplace raised the macOS keychain popup
-    // because every fetch eagerly read the PasswordSafe-backed token store.
+    // A public marketplace must not raise the macOS keychain popup, which happens
+    // when a fetch eagerly reads the PasswordSafe-backed token store.
     it("never consults the token store or prompt for a public marketplace", async () => {
         // The default service serves a public manifest (relative + github source)
         // with no gating, so every fetch succeeds anonymously.

--- a/libs/modeler-types/README.md
+++ b/libs/modeler-types/README.md
@@ -5,13 +5,12 @@ types (engine, lint, settings, scripting, implementation, diff) and browser
 utilities (theme, canvas resize, properties-panel focus/resizer, BPMN flow
 order) that carry no dependency on the webview ↔ host message protocol.
 
-This package exists to draw a hard line for epic #1293 (extract the BPMN
-modeler into a publishable `@miragon/bpmn-modeler` npm package). The former
-`@miragon/bpmn-modeler-shared` mixed two audiences behind one barrel:
-publishable types the package needs, and the internal Query/Command protocol +
-`HostApi` that must stay private. Inlining the publishable libs into the
-package would otherwise drag the protocol along. Everything here is safe to
-publish; everything protocol-shaped stays in `@miragon/bpmn-modeler-shared`.
+This package draws a hard line so the modeler can ship as a publishable
+`@miragon/bpmn-modeler` npm package without dragging the host protocol along:
+publishable types the package needs live here, while the internal Query/Command
+protocol + `HostApi` stay private in `@miragon/bpmn-modeler-shared`. Everything
+here is safe to publish; everything protocol-shaped stays in
+`@miragon/bpmn-modeler-shared`.
 
 ## The boundary
 

--- a/libs/modeler-types/src/canvasResize.ts
+++ b/libs/modeler-types/src/canvasResize.ts
@@ -1,7 +1,7 @@
 /**
  * @internal `observeCanvasSize` and its helpers are package-internal wiring the
- * facade installs per instance; the exported names are not part of the designed
- * public API (#1375).
+ * facade installs per instance; the exported names are not part of the modeler
+ * public API.
  */
 
 /**

--- a/libs/modeler-types/src/index.ts
+++ b/libs/modeler-types/src/index.ts
@@ -1,12 +1,11 @@
 /**
  * Public, host-agnostic types and browser utilities for the BPMN/DMN modeler.
  *
- * This barrel is the publishable half of the former `@miragon/bpmn-modeler-shared`
- * package (#1371): the domain/model types and DOM helpers a future
- * `@miragon/bpmn-modeler` npm package needs, with **no** dependency on the
- * Query/Command host protocol or `HostApi`, which stay private in
- * `@miragon/bpmn-modeler-shared`. The boundary is enforced by eslint
- * (`BND-PROTOCOL-PRIVATE`), not convention.
+ * This barrel is the publishable half of the modeler's shared code: the
+ * domain/model types and DOM helpers the `@miragon/bpmn-modeler` npm package
+ * needs, with **no** dependency on the Query/Command host protocol or `HostApi`,
+ * which stay private in `@miragon/bpmn-modeler-shared`. The boundary is enforced
+ * by eslint (`BND-PROTOCOL-PRIVATE`), not convention.
  */
 export * from "./asyncDebounce";
 export * from "./engine";

--- a/libs/modeler-types/src/lint.ts
+++ b/libs/modeler-types/src/lint.ts
@@ -30,7 +30,7 @@ export type BpmnlintRuleConfig = BpmnlintRuleSeverity | readonly [BpmnlintRuleSe
 
 /**
  * Structural mirror of a bpmnlint configuration (`.bpmnlintrc`) as the public
- * `linting: { config }` option accepts it (#1373). Kept structural — not an
+ * `linting: { config }` option accepts it. Kept structural — not an
  * import of bpmnlint's own types — so the published API surface does not leak a
  * transitive bpmnlint dependency. Unresolvable `extends`/`rules` degrade
  * gracefully at load and surface via {@link LintRunEvent.unresolved}.
@@ -87,7 +87,7 @@ export function staticUnresolvedModdleExtensions(config: BpmnlintConfig): string
 }
 
 /**
- * Outbound notification payload for one lint pass (#1373's `onLintResults`):
+ * Outbound notification payload for one lint pass (the `onLintResults` event):
  * the findings the overlay renders plus the rule names that could not be
  * resolved from the supplied {@link BpmnlintConfig}. `unresolved` is how the
  * modeler reports graceful degradation instead of failing the whole run when a

--- a/libs/modeler-types/src/propertiesPanelFocus.ts
+++ b/libs/modeler-types/src/propertiesPanelFocus.ts
@@ -1,6 +1,6 @@
 /**
  * @internal Page-level webview chrome coupled to the `js-properties-panel` DOM
- * id and the panel shortcuts. Not part of the designed public API (#1375).
+ * id and the panel shortcuts. Not part of the modeler public API.
  * `isTextEditingSurface` is the one broadly-reused helper here.
  */
 import type { PropertiesPanelHandle } from "./propertiesPanelResizer";

--- a/libs/modeler-types/src/propertiesPanelResizer.ts
+++ b/libs/modeler-types/src/propertiesPanelResizer.ts
@@ -1,7 +1,7 @@
 /**
  * @internal Page-level webview chrome bound to hard-coded DOM ids
- * (`js-panel-resizer`, `js-properties-panel`). Not part of the designed public
- * API (#1375); the multi-instance facade owns its own panel host instead.
+ * (`js-panel-resizer`, `js-properties-panel`). Not part of the modeler public
+ * API; the multi-instance facade owns its own panel host instead.
  */
 
 /**
@@ -51,9 +51,6 @@ export interface PropertiesPanelResizerOptions {
  * properties-panel visibility without touching the DOM directly.
  */
 export interface PropertiesPanelHandle {
-    /**
-     * `true` if the panel is currently visible, `false` if collapsed.
-     */
     isVisible(): boolean;
 
     /**
@@ -76,11 +73,10 @@ export interface PropertiesPanelHandle {
 }
 
 /**
- * Returned when the resizer cannot find its DOM targets.  All operations on
- * this handle are no-ops so the rest of the webview can call
+ * Returned when the resizer cannot find its DOM targets. All operations on this
+ * handle are no-ops so the rest of the webview can call
  * {@link PropertiesPanelHandle.setVisible} or subscribe without extra null
- * checks.  Matches the historical behaviour where the old `initResizer()`
- * silently returned after logging a warning.
+ * checks.
  */
 const NOOP_HANDLE: PropertiesPanelHandle = {
     isVisible: () => true,

--- a/libs/modeler-types/src/theme.ts
+++ b/libs/modeler-types/src/theme.ts
@@ -5,17 +5,17 @@
  * - `"automatic"`: follows the VS Code theme via a MutationObserver on `<body>`.
  * - `"light"`: always uses the default bpmn-js light theme.
  * - `"dark"`: always forces the dark theme (the injected per-instance `theme`
- *   option, #1376).
+ *   option).
  *
  * VS Code injects `vscode-dark`, `vscode-light`, or `vscode-high-contrast`
  * onto `<body>` in every webview.
  *
  * @internal Host-specific and module-singleton — reads VS Code `<body>` classes
- *   and mutates a single `#theme-link`, so it is not part of the designed
- *   modeler public API (#1375). This is the VS Code body-class watcher the
- *   bpmn/dmn **host adapters** own (#1377): the adapter maps the `<body>` class
- *   to a forced light/dark and hands that to the modeler, so the publishable
- *   `@miragon/bpmn-modeler` package never reads host chrome itself.
+ *   and mutates a single `#theme-link`, so it is not part of the modeler public
+ *   API. It is the VS Code body-class watcher the bpmn/dmn host adapters own: the
+ *   adapter maps the `<body>` class to a forced light/dark and hands that to the
+ *   modeler, so the publishable `@miragon/bpmn-modeler` package never reads host
+ *   chrome itself.
  */
 
 let currentMode: "automatic" | "light" | "dark" = "automatic";

--- a/libs/shared/README.md
+++ b/libs/shared/README.md
@@ -9,7 +9,7 @@ Used by both the extension host (`apps/vscode-plugin`), the modeler-bridge, and
 the webview bootstrap/host-adapter layers. It is **not** publishable: it encodes
 the internal transport contract.
 
-## The public/protocol split (#1371)
+## The public/protocol split
 
 The publishable, host-agnostic types and browser utilities that used to live
 here (engine/lint/settings/scripting/implementation/diff types, `theme`,

--- a/libs/shared/src/lib/modeler.ts
+++ b/libs/shared/src/lib/modeler.ts
@@ -142,10 +142,11 @@ export class BpmnLintDisabledQuery extends Query {
  * Tells the webview to run its **own in-page** linter. Two tiers travel on this
  * one message:
  *
- *  - **Payload-free** (#1373 Phase B) — no workspace `.bpmnlintrc`: the webview's
- *    {@link BrowserLinter} derives the engine-aware zero-config default from the
- *    live modeler itself, so nothing has to travel.
- *  - **With `config`** (#1384) — a workspace `.bpmnlintrc` exists and the host's
+ *  - **Payload-free** (zero-config default tier) — no workspace `.bpmnlintrc`:
+ *    the webview's {@link BrowserLinter} derives the engine-aware zero-config
+ *    default from the live modeler itself, so nothing has to travel.
+ *  - **With `config`** (covered workspace tier) — a workspace `.bpmnlintrc`
+ *    exists and the host's
  *    escalation pre-check ({@link staticUnresolvedModdleExtensions}) proved the
  *    bundled resolver can cover it: the host lints it in-page against the
  *    supplied `config` instead of running the Node linter on every edit. If the
@@ -465,12 +466,13 @@ export class SetLintingEnabledCommand extends Command {
  * Sent by the BPMN webview after every **in-page** lint pass so the host can
  * feed its own chrome — the VS Code Problems panel and status bar — from results
  * the webview computed. Fired whenever the host activated in-page linting via
- * {@link BpmnlintInPageQuery}, in either tier: the payload-free #1373 default or
- * the #1384 workspace-config in-page run. An escalated workspace session lints
- * host-side instead and never receives this. `unresolved` carries the rules the
- * browser resolver could not honour (informational for the default tier; the
- * escalation trigger for the #1384 workspace tier — a non-empty list flips the
- * session to the Node linter). Hosts without a Problems surface (the IntelliJ
+ * {@link BpmnlintInPageQuery}, in either tier: the payload-free zero-config
+ * default or the covered workspace-config in-page run. An escalated workspace
+ * session lints host-side instead and never receives this. `unresolved` carries
+ * the rules the browser resolver could not honour (informational for the default
+ * tier; the escalation trigger for the covered workspace tier — a non-empty list
+ * flips the session to the Node linter). Hosts without a Problems surface (the
+ * IntelliJ
  * bridge) accept it and update whatever chrome they have.
  *
  * `configToken` echoes the token the driving {@link BpmnlintInPageQuery} carried

--- a/libs/shared/src/lib/processVariables.ts
+++ b/libs/shared/src/lib/processVariables.ts
@@ -89,7 +89,7 @@ const SPIN_ASSIGNMENT_RE = /(?<![.\w$])([A-Za-z_$][\w$]*)\s*=\s*(?:S|JSON)\s*\(/
 
 /**
  * Returns the variable names written by `setVariable`/`setVariableLocal` string
- * literals in a script body. Exported for unit testing the regex in isolation.
+ * literals in a script body.
  */
 export function collectSetVariableNames(script: string): string[] {
     const names: string[] = [];
@@ -102,7 +102,7 @@ export function collectSetVariableNames(script: string): string[] {
 /**
  * Returns variable names whose value is a SPIN call (`S(...)`/`JSON(...)`), from
  * either `setVariable("x", S(...))` or `x = S(...)`. These resolve to the
- * `SpinJsonNode` TypeDef. Exported for unit testing the regexes in isolation.
+ * `SpinJsonNode` TypeDef.
  */
 export function collectSpinTypedNames(script: string): string[] {
     const names: string[] = [];
@@ -117,7 +117,7 @@ export function collectSpinTypedNames(script: string): string[] {
 
 /**
  * Returns the leading identifiers referenced by `${...}` / `#{...}` expressions,
- * minus reserved names. Exported for unit testing the regex in isolation.
+ * minus reserved names.
  */
 export function collectExpressionRefs(expression: string): string[] {
     const names: string[] = [];

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -7,8 +7,8 @@ clipboard, theming, and the Camunda element-template stack — with no VS Code /
 IntelliJ host required.
 
 > Extracted from the [miranum-ide](https://github.com/Miragon/miranum-ide)
-> modeler (epic #1293). `0.1.0` is the first standalone release; the public
-> surface is described by the TypeScript types shipped in `dist/index.d.ts`.
+> modeler. `0.1.0` is the first standalone release; the public surface is
+> described by the TypeScript types shipped in `dist/index.d.ts`.
 
 ## Install
 
@@ -93,14 +93,14 @@ Linting is an opinionated built-in with a tier ladder, selected via
 | `{ results: "external" }` | The modeler only *paints* results the host computes and pushes through `handle.applyLintResults(...)`; no in-webview linter runs. |
 
 The linting stack (`bpmn-js-bpmnlint`, `bpmnlint`, the rule plugin, and its CSS)
-is code-split into a lazily-loaded chunk (#1373): it is fetched only when an
+is code-split into a lazily-loaded chunk: it is fetched only when an
 instance actually lints, so `linting: false` keeps it out of your bundle's
 critical path entirely. Lint results surface through `onLintResults`, and the
 in-canvas enable/disable toggle through `onLintingToggled`.
 
 ## Clipboard wire format
 
-Copy/paste defaults to the native browser clipboard (#1374); a sandboxed host
+Copy/paste defaults to the native browser clipboard; a sandboxed host
 that cannot reach the system clipboard from the webview supplies a
 `ClipboardBridge` via `options.clipboard`.
 

--- a/packages/bpmn-modeler/src/architecture.spec.ts
+++ b/packages/bpmn-modeler/src/architecture.spec.ts
@@ -3,7 +3,7 @@ import { join, normalize } from "node:path";
 import { describe, expect, it } from "vitest";
 
 /**
- * Import-direction gate for `@miragon/bpmn-modeler` (epic #1293, ADR 0006/0007).
+ * Import-direction gate for `@miragon/bpmn-modeler`.
  *
  * The published package may reach only *downward* — relatives, the private
  * workspace libs it inlines at build time, and bare npm specifiers. It must
@@ -81,7 +81,7 @@ describe("bpmn-modeler import direction", () => {
     });
 
     it("package TS source reads no VS Code `<body>` theme classes", () => {
-        // Theme is host policy (#1377): the package resolves light/dark from
+        // Theme is host policy: the package resolves light/dark from
         // `prefers-color-scheme` or an injected mode, never by reading the host's
         // chrome. A `vscode-*` body class in TS source would mean the watcher
         // leaked back in. (CSS files legitimately style `body.vscode-dark`; this

--- a/packages/bpmn-modeler/src/bpmnlint/LintConfigService.spec.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/LintConfigService.spec.ts
@@ -7,7 +7,7 @@ const { runMock, ctorMock } = vi.hoisted(() => ({ runMock: vi.fn(), ctorMock: vi
 vi.mock("./browserLinter", () => ({
     // A class (not an arrow) so `new BrowserLinter()` constructs. `ctorMock`
     // records the (engine, config) args so a test can assert the handed-back
-    // config reaches the linter (#1384).
+    // config reaches the linter.
     BrowserLinter: class {
         constructor(...args: unknown[]) {
             ctorMock(...args);
@@ -217,7 +217,7 @@ describe("LintConfigService: startInPageLinting (host handback)", () => {
         expect(returned).toEqual(LINT_EVENT.results);
     });
 
-    it("builds the browser linter with the handed-back workspace config (#1384)", () => {
+    it("builds the browser linter with the handed-back workspace config", () => {
         ctorMock.mockClear();
         const { service } = makeService({ tier: "external", imported: true });
         const config = { extends: "bpmnlint:recommended" };

--- a/packages/bpmn-modeler/src/bpmnlint/LintConfigService.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/LintConfigService.ts
@@ -44,7 +44,7 @@ type Translate = (template: string) => string;
 
 /**
  * The per-instance tier decision, registered as the `lintTier` DI value by
- * {@link createLintModule}. `"external"` keeps today's host-pushed flow;
+ * {@link createLintModule}. `"external"` renders host-pushed results;
  * `"in-page"` runs {@link BrowserLinter} in the webview against the given
  * `engine` (and optional explicit `config`). `false`/off never reaches here — a
  * disabled instance registers no lint module at all.
@@ -106,20 +106,18 @@ function shallowCopyResults(results: LintResults): LintResults {
  *
  * It drives `bpmn-js-bpmnlint`'s `linting` module by overriding its `lint()` —
  * the module's own `update()` (fired on import, element changes, toggles) then
- * diffs and draws the overlays exactly as before, so no overlay/rendering code
- * changes across tiers. The override's body depends on the tier: `external`
- * returns the host's last-pushed results; `in-page` runs {@link BrowserLinter}
- * against the live tree and emits the raw result through `onLintResults`;
- * `in-page-disabled` returns nothing so the linter, which the vendor keeps
- * running even while inactive, does no real work.
+ * diffs and draws the overlays, so no overlay/rendering code changes across
+ * tiers. The override's body depends on the tier: `external` returns the host's
+ * last-pushed results; `in-page` runs {@link BrowserLinter} against the live
+ * tree and emits the raw result through `onLintResults`; `in-page-disabled`
+ * returns nothing so the linter, which the vendor keeps running even while
+ * inactive, does no real work.
  *
- * It also owns the in-canvas **disable affordance**: an "off" button beside the
+ * It also owns the in-canvas disable affordance: an "off" button beside the
  * lint summary pill, and a muted "Linting off" chip with an "Enable" action in
- * its place once disabled — the entry points a non-technical user needs, since
- * they may never open host settings. In the in-page tier the toggle is applied
+ * its place once disabled. In the in-page tier the toggle is applied
  * optimistically (the webview owns the linter); in the external tier it is
- * reported through `onLintingToggled` and the overlays wait for the host's push,
- * exactly as before.
+ * reported through `onLintingToggled` and the overlays wait for the host's push.
  */
 export class LintConfigService {
     static $inject = [
@@ -136,8 +134,8 @@ export class LintConfigService {
 
     // Present once the in-page tier is live; undefined for a purely external
     // instance. Mutable because the host can hand linting back to the webview
-    // after construction (#1373 Phase B) via {@link startInPageLinting}, which
-    // lazily builds it — the constructor only builds it for an up-front in-page tier.
+    // after construction via {@link startInPageLinting}, which lazily builds it —
+    // the constructor only builds it for an up-front in-page tier.
     private browserLinter?: BrowserLinter;
 
     // Kept from `tierInit` so a later {@link startInPageLinting} can construct a
@@ -147,10 +145,10 @@ export class LintConfigService {
 
     private readonly explicitConfig?: BpmnlintConfig;
 
-    // The config-version token of the last in-page instruction (#1384). Used to
-    // dedup a repeat covered instruction, but only while actually `"in-page"`:
-    // any disabled/external push in between leaves this stale, and the state
-    // guard below stops that stale token from dropping a genuine re-enable.
+    // The config-version token of the last in-page instruction. Used to dedup a
+    // repeat covered instruction, but only while actually `"in-page"`: any
+    // disabled/external push in between leaves this stale, and the state guard
+    // below stops that stale token from dropping a genuine re-enable.
     private lastConfigToken?: string;
 
     private results: LintResults = {};
@@ -196,10 +194,10 @@ export class LintConfigService {
     }
 
     /**
-     * Starts (or restarts) the in-page linter on host instruction — the #1373
-     * Phase B handback when the host finds no workspace `.bpmnlintrc`. Lazily
-     * builds the {@link BrowserLinter} (the constructor only builds it for an
-     * up-front in-page tier) and activates it if a diagram is already imported;
+     * Starts (or restarts) the in-page linter on host instruction — the handback
+     * when the host finds no workspace `.bpmnlintrc`. Lazily builds the
+     * {@link BrowserLinter} (the constructor only builds it for an up-front
+     * in-page tier) and activates it if a diagram is already imported;
      * otherwise the unconditional `import.done` listener activates it.
      *
      * No-ops when the user has disabled linting from the canvas — a host
@@ -236,7 +234,7 @@ export class LintConfigService {
     /**
      * Applies host-pushed results (external tier). Any push wins: an in-page
      * instance switches to `external` and its in-page run is suspended. `null`
-     * deactivates linting — the no-config experience, unchanged from before.
+     * deactivates linting — the no-config experience.
      */
     applyLintResults(results: LintResults | null): void {
         this.state = "external";
@@ -289,8 +287,7 @@ export class LintConfigService {
 
     /**
      * Renders `results`, or deactivates linting when `results` is `null` (no
-     * `.bpmnlintrc`, or a host read/lint failure) — keeping the no-config
-     * experience identical to before linting moved to the host.
+     * `.bpmnlintrc`, or a host read/lint failure).
      */
     private render(results: LintResults | null): void {
         this.hideDisabledChip();
@@ -336,7 +333,7 @@ export class LintConfigService {
      * Handles the off button. Reports the toggle to the host in every tier; in the
      * in-page tier it also flips the state and clears the overlays optimistically
      * (the webview owns the linter). In the external tier the render waits for the
-     * host's disabled push — today's behaviour.
+     * host's disabled push.
      */
     private handleOffClick(): void {
         this.callbacks.onLintingToggled?.(false);

--- a/packages/bpmn-modeler/src/bpmnlint/browserLinter.spec.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/browserLinter.spec.ts
@@ -7,8 +7,8 @@ type ModdleFactory = (ext?: Record<string, unknown>) => {
 };
 
 /**
- * The browser-compat gate for #1373: `@miragon/bpmnlint-plugin-rules` and
- * bpmnlint's `Linter` have only ever run in Node here. This drives the real stack
+ * The browser-compat gate: `@miragon/bpmnlint-plugin-rules` and bpmnlint's
+ * `Linter` have only ever run in Node here. This drives the real stack
  * (no mocks) over a parsed moddle tree in jsdom, so a rule reaching for a Node API
  * fails here — the earliest signal — rather than blank in a host webview. A rule
  * the bundled resolver cannot cover would degrade to `unresolved`, never throw.

--- a/packages/bpmn-modeler/src/bpmnlint/browserLinter.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/browserLinter.ts
@@ -12,13 +12,13 @@ import { RecordingBrowserResolver, staticUnresolvedModdleExtensions } from "./br
 /**
  * Runs bpmnlint against the *live* bpmn-js definitions tree, in the browser.
  *
- * This is the in-page tier of the #1373 lint ladder: instead of the host running
- * `NodeBpmnLinter` and pushing results down, the webview lints itself. The config
- * is either an explicit `{config}` a consumer supplied or the engine-aware
- * zero-config default (`getDefaultLintConfig({engine, preset: "modeling"})`,
- * matching the hosts' preset for later parity). Rules the bundled resolver cannot
- * cover degrade to no-ops and are reported via {@link LintRunEvent.unresolved},
- * so an unusual `{config}` is never fatal.
+ * This is the in-page tier: instead of the host running a linter and pushing
+ * results down, the webview lints itself. The config is either an explicit
+ * `{config}` a consumer supplied or the engine-aware zero-config default
+ * (`getDefaultLintConfig({engine, preset: "modeling"})`, matching the hosts'
+ * preset for parity). Rules the bundled resolver cannot cover degrade to no-ops
+ * and are reported via {@link LintRunEvent.unresolved}, so an unusual `{config}`
+ * is never fatal.
  *
  * The resolver is created once and reused; each {@link run} resets its recorded
  * misses so the emitted `unresolved` reflects that single lint. `moddleExtensions`

--- a/packages/bpmn-modeler/src/bpmnlint/browserResolver.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/browserResolver.ts
@@ -3,7 +3,7 @@ import { createBundledResolver, type Resolver } from "@miragon/bpmnlint-plugin-r
 
 // Re-exported so `browserLinter.ts` and `browserResolver.spec.ts` keep importing
 // it from here; the implementation moved to modeler-types so the host's
-// escalation pre-check shares the exact same logic (#1384).
+// escalation pre-check shares the exact same logic.
 export { staticUnresolvedModdleExtensions };
 
 /**
@@ -55,7 +55,6 @@ export class RecordingBrowserResolver implements Resolver {
         return NOOP_CONFIG;
     }
 
-    /** Clears the recorded misses so a fresh run starts from an empty list. */
     reset(): void {
         this.unresolved.length = 0;
     }

--- a/packages/bpmn-modeler/src/bpmnlint/index.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/index.ts
@@ -1,9 +1,9 @@
 /**
- * Lazy-loaded chunk entry for in-canvas bpmnlint (#1373, AC 6).
+ * Lazy-loaded chunk entry for in-canvas bpmnlint.
  *
  * This module — and only this module — statically imports the lint stack
  * (`bpmn-js-bpmnlint`, `bpmnlint`'s `Linter`, `@miragon/bpmnlint-plugin-rules`,
- * and the CSS). Because {@link BpmnModeler.create} reaches it through a dynamic
+ * and the CSS). Because the modeler reaches it through a dynamic
  * `import("./bpmnlint")`, the whole stack lands in a separate chunk that is
  * fetched only when an instance actually lints (`linting !== false`), keeping it
  * out of the main webview bundle.

--- a/packages/bpmn-modeler/src/bridgedClipboard.spec.ts
+++ b/packages/bpmn-modeler/src/bridgedClipboard.spec.ts
@@ -4,14 +4,14 @@ import { BpmnModdle } from "bpmn-moddle";
 import { createClipboardModules, type ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
 
 /**
- * Behavioural spec for the bridge-path clipboard module (`BridgedClipboard`,
- * #1374). The class is private to the lib, so it is exercised through the same
- * DI wiring the webview uses: `createClipboardModules` yields the module, and a
- * didi injector instantiates it against fake bpmn-js services + a real
- * `bpmn-moddle` (the reviver needs genuine type descriptors).
+ * Behavioural spec for the bridge-path clipboard module (`BridgedClipboard`).
+ * The class is private to the lib, so it is exercised through the same DI wiring
+ * the webview uses: `createClipboardModules` yields the module, and a didi
+ * injector instantiates it against fake bpmn-js services + a real `bpmn-moddle`
+ * (the reviver needs genuine type descriptors).
  *
  * The prefixed-JSON payload asserted here is byte-identical to upstream
- * `bpmn-js-native-copy-paste` — that wire compatibility is the point of #1374.
+ * `bpmn-js-native-copy-paste` — that wire compatibility is the point.
  */
 
 const CLIP_PREFIX = "bpmn-js-clip----";

--- a/packages/bpmn-modeler/src/canvasFocusIndicator.ts
+++ b/packages/bpmn-modeler/src/canvasFocusIndicator.ts
@@ -1,6 +1,6 @@
 /**
  * @internal Package-internal wiring — the green canvas focus reticle the
- * factory installs per instance. Not part of the designed public API (#1375).
+ * factory installs per instance. Not part of the public API.
  */
 
 /**
@@ -38,39 +38,27 @@ const FOCUS_WEAK_SVG = `<svg class="canvas-focus-indicator__off" viewBox="0 -960
 const FOCUS_STRONG_SVG = `<svg class="canvas-focus-indicator__on" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M200-120q-33 0-56.5-23.5T120-200v-160h80v160h160v80H200Zm400 0v-80h160v-160h80v160q0 33-23.5 56.5T760-120H600ZM120-600v-160q0-33 23.5-56.5T200-840h160v80H200v160h-80Zm640 0v-160H600v-80h160q33 0 56.5 23.5T840-760v160h-80ZM338.5-338.5Q280-397 280-480t58.5-141.5Q397-680 480-680t141.5 58.5Q680-563 680-480t-58.5 141.5Q563-280 480-280t-141.5-58.5Z"/></svg>`;
 
 /**
- * Installs a focus reticle in the canvas's top-right corner, beside the
- * "Open minimap" control, that lights up
- * brand-green with a solid center while the canvas holds keyboard focus *and*
- * no element is selected, and shows a faint hollow reticle otherwise. On
- * focus gain the glow briefly pulses (the "you're back" moment), then settles
- * to a steady glow — canvas-focused is the normal state users sit in for
- * minutes, so a perpetual pulse would be an attention magnet.
+ * Installs a focus reticle in the canvas's top-right corner, beside the "Open
+ * minimap" control: brand-green with a solid center while the canvas holds
+ * keyboard focus *and* nothing is selected, faint and hollow otherwise. On
+ * focus gain the glow pulses briefly, then settles to a steady glow.
  *
- * Selection gates the green state because clicking an element also puts DOM
- * focus on the canvas SVG — without the gate the reticle would light on every
- * selection, where the selection outline already shows that keystrokes target
- * the diagram. Green is reserved for the bare "canvas focus" state Escape
- * creates, which has no other visual marker.
+ * Selection gates the green state because clicking an element also focuses the
+ * canvas SVG; the selection outline already shows keystrokes target the diagram,
+ * so green is reserved for the bare "canvas focus" state Escape creates, which
+ * has no other marker. A reticle (not a bulb) because a bulb collides with the
+ * IDE-wide "quick fix available" lightbulb (VS Code/IntelliJ).
  *
- * A reticle (not a bulb or keyboard) because a bulb collides with the IDE-wide
- * "quick fix available" affordance (VS Code/IntelliJ lightbulb); the
- * weak/strong reticle pair literally depicts focus snapping onto the canvas.
+ * Subscribes to diagram-js's deduplicated `canvas.focus.changed` (fired from the
+ * canvas SVG's `focusin`/`focusout`) rather than a container-level `focusin` —
+ * the latter would false-positive when another widget inside the same
+ * `.djs-container` (e.g. the bpmnlint chip) takes focus.
  *
- * It is the visual counterpart to {@link installKeyboardFocus}. It subscribes
- * to diagram-js's own
- * deduplicated `canvas.focus.changed` signal (fired from the canvas SVG's
- * `focusin`/`focusout` listeners) rather than observing a container-level
- * `focusin` — the latter would false-positive when another floating widget
- * inside the same `.djs-container` (e.g. the bpmnlint chip) takes focus.
- *
- * Purely decorative: `aria-hidden` + `pointer-events: none`. The focus move
- * itself already conveys the state to assistive tech, and a clickable glyph
- * would need a tab stop and would steal canvas clicks.
+ * Purely decorative: `aria-hidden` + `pointer-events: none`.
  *
  * @param deps Injected parent/focus closures (see {@link CanvasFocusIndicatorDeps}).
- * @returns A disposer that removes the reticle from the DOM, so a destroyed
- *   modeler instance leaves no orphaned overlay in its (shared-page) container.
- *   The event subscriptions die with the modeler's own event bus on destroy.
+ * @returns A disposer that removes the reticle from the DOM. The event
+ *   subscriptions die with the modeler's own event bus on destroy.
  */
 export function installCanvasFocusIndicator(deps: CanvasFocusIndicatorDeps): () => void {
     const root = document.createElement("div");

--- a/packages/bpmn-modeler/src/clipboardModules.spec.ts
+++ b/packages/bpmn-modeler/src/clipboardModules.spec.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from "vitest";
 import { createClipboardModules, type ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
 
 /**
- * Contract of the clipboard-override factory (#1374). The two DI modules and
- * the value bindings are the whole surface bootstrap/createModeler rely on; the
- * `text ?? element` default is what lets the frozen single-bridge public API map
- * onto the two protocol channels a webview host actually needs.
+ * Contract of the clipboard-override factory. The two DI modules and the value
+ * bindings are the whole surface bootstrap/createModeler rely on; the
+ * `text ?? element` default is what lets the single-bridge public API map onto
+ * the two protocol channels a webview host actually needs.
  */
 
 function fakeBridge(): ClipboardBridge {

--- a/packages/bpmn-modeler/src/clipboardWireFormat.spec.ts
+++ b/packages/bpmn-modeler/src/clipboardWireFormat.spec.ts
@@ -5,8 +5,8 @@ import camundaModdle from "camunda-bpmn-moddle/resources/camunda.json";
 import zeebeModdle from "zeebe-bpmn-moddle/resources/zeebe.json";
 
 /**
- * Executable statement of the cross-engine clipboard policy (#1374): unsupported,
- * fails soft. The wire format is engine-agnostic — a Camunda-7 element pasted
+ * Executable statement of the cross-engine clipboard policy: unsupported, fails
+ * soft. The wire format is engine-agnostic — a Camunda-7 element pasted
  * into a Camunda-8 modeler revives its shared bpmn: base, and the reviver
  * silently drops every extension node whose `$type` the target moddle does not
  * know (`camunda:*` in a C8 moddle), replacing it with `null` rather than

--- a/packages/bpmn-modeler/src/createModeler.ts
+++ b/packages/bpmn-modeler/src/createModeler.ts
@@ -4,19 +4,18 @@ import type { ModelerOptions } from "./publicApi";
 import { BpmnModeler } from "./modeler";
 
 /**
- * Runtime options accepted by {@link createModeler}: the designed public
- * {@link ModelerOptions} plus one migration-only internal knob. The factory now
- * implements the designed type verbatim (#1376) — the only addition is
- * `handleGlobalEscape`, which stays `@internal` and out of `publicApi.ts`.
+ * Runtime options accepted by {@link createModeler}: the public
+ * {@link ModelerOptions} plus one internal knob (`handleGlobalEscape`), which
+ * stays `@internal` and out of `publicApi.ts`.
  */
 export interface CreateModelerOptions extends ModelerOptions {
     /**
      * When `true`, an Escape with nothing focused (`<body>`) re-homes this
-     * canvas. Default off; the single-instance bootstrap passes `true` to keep
-     * today's page-wide behaviour, while a multi-instance consumer leaves it off
-     * so each modeler only reacts to Escapes inside its own subtrees.
+     * canvas. Default off; the single-instance bootstrap passes `true` for
+     * page-wide behaviour, while a multi-instance consumer leaves it off so each
+     * modeler only reacts to Escapes inside its own subtrees.
      *
-     * @internal Not part of the designed public API (#1375).
+     * @internal Not part of the public API.
      */
     handleGlobalEscape?: boolean;
 }
@@ -27,8 +26,7 @@ export interface CreateModelerOptions extends ModelerOptions {
  * (element templates, settings, theme, locale) in the order the host expects.
  *
  * Async because {@link BpmnModeler.init} awaits the lazy bpmnlint chunk before
- * constructing bpmn-js. Engine selection is now up front (in `options.engine`),
- * collapsing the former two-step `create(engine)` into a single call.
+ * constructing bpmn-js.
  */
 export async function createModeler(
     container: HTMLElement,

--- a/packages/bpmn-modeler/src/diff/DiffLegend.ts
+++ b/packages/bpmn-modeler/src/diff/DiffLegend.ts
@@ -13,9 +13,6 @@ export interface DiffLegendCallbacks {
     onSwap?: () => void;
 }
 
-/**
- * Dictionary key rendered as a count slot's label.
- */
 type SlotKey = "Added" | "Removed" | "Changed" | "Moved";
 
 /**
@@ -122,12 +119,6 @@ export class DiffLegend {
         this.disposeI18n = i18n.onChange(() => this.renderLabels());
     }
 
-    /**
-     * Reveals the legend and renders the given context.  Disables the nav
-     * buttons when there are no changes at all; shows the filename subtitle
-     * when a `filename` is given and the swap button when `showSwap` is set
-     * (and an `onSwap` callback was supplied).
-     */
     update(context: DiffLegendContext): void {
         this.context = context;
         this.renderLabels();
@@ -182,11 +173,6 @@ export class DiffLegend {
         return btn;
     }
 
-    /**
-     * Redraws every translated label from the current {@link context} and
-     * {@link i18n} locale.  Called on init, on {@link update}, and whenever
-     * {@link i18n} notifies of a language switch.
-     */
     private renderLabels(): void {
         const { counts, filename } = this.context;
         const countFor: Record<SlotKey, number> = {
@@ -204,10 +190,6 @@ export class DiffLegend {
         this.filenameEl.textContent = filename ?? "";
     }
 
-    /**
-     * Unsubscribes the language-change listener and removes the legend from the
-     * DOM.  The instance must not be used afterwards.
-     */
     destroy(): void {
         this.disposeI18n();
         this.root.remove();

--- a/packages/bpmn-modeler/src/diff/DiffPaneCoordinator.ts
+++ b/packages/bpmn-modeler/src/diff/DiffPaneCoordinator.ts
@@ -66,12 +66,10 @@ export class DiffPaneCoordinator {
         }
     }
 
-    /** Advances the shared cursor to the next changed element on both panes. */
     next(): void {
         this.step(1);
     }
 
-    /** Advances the shared cursor to the previous changed element on both panes. */
     previous(): void {
         this.step(-1);
     }
@@ -80,7 +78,6 @@ export class DiffPaneCoordinator {
         return this._cursor;
     }
 
-    /** Unhooks the viewport-sync subscriptions.  Leaves the viewers intact. */
     destroy(): void {
         for (const dispose of this.disposers) {
             dispose();

--- a/packages/bpmn-modeler/src/diff/DiffViewer.ts
+++ b/packages/bpmn-modeler/src/diff/DiffViewer.ts
@@ -26,14 +26,7 @@ const DIFF_SELECTED_CLASS = "diff-selected";
  * Readonly BPMN canvas for one side of a diff view.
  *
  * Wraps `bpmn-js/lib/NavigatedViewer` so the pane supports mouse + keyboard
- * pan/zoom but not editing.  Exposes:
- *   - {@link importXML} — load the diagram and fit to viewport.
- *   - {@link applyHighlights} — mark elements with per-category CSS classes.
- *   - {@link getViewport} / {@link setViewport} — read/write canvas viewbox.
- *   - {@link onViewportChanged} — subscribe to user-driven viewport changes,
- *     with a suppression guard so programmatic `setViewport` calls don't
- *     re-emit (avoids feedback loops across synced panes).
- *   - {@link focusElement} — centre the viewport on a given element.
+ * pan/zoom but not editing.
  */
 export class DiffViewer {
     private readonly viewer: NavigatedViewer;

--- a/packages/bpmn-modeler/src/index.ts
+++ b/packages/bpmn-modeler/src/index.ts
@@ -1,19 +1,18 @@
 /**
- * `@miragon/bpmn-modeler` — the host-free, publishable BPMN modeler (epic #1293).
+ * `@miragon/bpmn-modeler` — the host-free, publishable BPMN modeler.
  *
- * The factory and the designed handle (#1375) are the supported surface; the
- * `@internal`-tagged exports below exist only for the in-repo `apps/bpmn-webview`
- * bootstrap and are removed once it becomes a thin adapter (#1377).
+ * The factory and the handle are the supported surface; the `@internal`-tagged
+ * exports below exist only for the in-repo `apps/bpmn-webview` adapter.
  */
 
-// Side-effect styles the modeler's own DOM depends on (the webview bootstrap
-// carried these before the extraction). A theme stylesheet is linked separately
-// by the consumer — see `styles.css` / `light-theme.css` / `dark-theme.css`.
+// Side-effect styles the modeler's own DOM depends on. A theme stylesheet is
+// linked separately by the consumer — see `styles.css` / `light-theme.css` /
+// `dark-theme.css`.
 import "./styles/default.css";
 import "./styles/diff.css";
 import "./styles/canvasFocusIndicator.css";
 
-// ── Public factory + designed API surface (#1375) ────────────────────────────
+// ── Public factory + API surface ─────────────────────────────────────────────
 export { createModeler } from "./createModeler";
 export type {
     ThemeMode,
@@ -44,7 +43,7 @@ export { ViewportManager } from "./viewport";
 export type { ViewportData } from "./viewport";
 export { SelectionManager } from "./selection";
 
-// ── Diff view — public rendering primitives + in-page coordinator (#1378) ─────
+// ── Diff view — public rendering primitives + in-page coordinator ─────────────
 // The data layer (`computeDiff`/`sideView` + result types) is the Node-safe
 // `@miragon/bpmn-modeler/diff` subpath; these are the browser-only primitives.
 export { DiffViewer } from "./diff/DiffViewer";

--- a/packages/bpmn-modeler/src/keyboardFocus.ts
+++ b/packages/bpmn-modeler/src/keyboardFocus.ts
@@ -1,6 +1,6 @@
 /**
  * @internal Package-internal wiring — the canvas-focus keyboard guard the
- * factory installs per instance. Not part of the designed public API (#1375).
+ * factory installs per instance. Not part of the public API.
  */
 
 /**

--- a/packages/bpmn-modeler/src/modeler.ts
+++ b/packages/bpmn-modeler/src/modeler.ts
@@ -66,9 +66,9 @@ const ALIGN_TO_ORIGIN_OPTIONS = {
  *
  * Per-instance by construction: it is bound to its own `container` and
  * `propertiesPanel.parent` (see {@link CreateModelerOptions}), so several
- * modelers can coexist on a page — the future in-page diff view wants two. Use
- * {@link createModeler} as the factory. All methods throw {@link NoModelerError}
- * if called before {@link init}, and {@link destroy} tears the instance down.
+ * modelers can coexist on a page. Use {@link createModeler} as the factory. All
+ * methods throw {@link NoModelerError} if called before {@link init}, and
+ * {@link destroy} tears the instance down.
  *
  * Viewport and selection concerns are delegated to {@link ViewportManager}
  * and {@link SelectionManager}, accessible via the corresponding getters
@@ -114,8 +114,6 @@ export class BpmnModeler {
 
     /**
      * Access the viewport manager after {@link init}.
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     get viewport(): ViewportManager {
         if (!this._viewport) {
@@ -126,8 +124,6 @@ export class BpmnModeler {
 
     /**
      * Access the selection manager after {@link init}.
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     get selection(): SelectionManager {
         if (!this._selection) {
@@ -140,8 +136,7 @@ export class BpmnModeler {
      * Access the root element manager after {@link init}.
      *
      * @internal Host-adapter surface (drill-down state restore); not part of the
-     *   designed public handle (#1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     *   public handle.
      */
     get rootElement(): RootElementManager {
         if (!this._rootElement) {
@@ -161,7 +156,7 @@ export class BpmnModeler {
      * installs first.
      *
      * @internal Construction step invoked by {@link createModeler}; not part of
-     *   the designed public handle (#1375).
+     *   the public handle.
      * @throws {UnsupportedEngineError} If the engine string is not recognised.
      */
     async init(): Promise<void> {
@@ -187,7 +182,7 @@ export class BpmnModeler {
         ];
         const capModules = capabilityModules(engine, this.options.capabilities);
         // Clipboard is a [B] built-in: omitting `clipboard` registers nothing, so
-        // bpmn-js's native (browser) clipboard stays in charge (#1374); a host that
+        // bpmn-js's native (browser) clipboard stays in charge; a host that
         // can't reach the system clipboard from its webview supplies a bridge.
         // A distinct `text` bridge routes label + contenteditable/FEEL surfaces
         // through the host's text channel; it defaults to the element bridge.
@@ -253,9 +248,6 @@ export class BpmnModeler {
 
         this.installFocusFeatures();
 
-        /**
-         * Apply default favourites immediately after creation.
-         */
         if (this.settings.favouriteBpmnElements) {
             const appendMenuOverride = this.getModeler().get<any>("appendMenuOverride", false);
             if (appendMenuOverride) {
@@ -273,8 +265,8 @@ export class BpmnModeler {
         }
 
         // The package-owned debounced content event: one full export per burst of
-        // model changes (300ms / 1000ms maxWait — the shape battle-tested in
-        // bootstrap). destroy() cancels a pending trailing export.
+        // model changes (300ms / 1000ms maxWait). destroy() cancels a pending
+        // trailing export.
         const onContentSaved = this.options.onContentSaved;
         if (onContentSaved) {
             this.contentSaved = asyncDebounce(
@@ -288,9 +280,9 @@ export class BpmnModeler {
 
     /**
      * Resolves the bpmnlint DI module(s) for the chosen tier, importing the lint
-     * chunk only when linting is not disabled (#1373, AC 6). `linting: false`
-     * returns no modules — the chunk, and the whole bpmnlint/rules stack, is never
-     * fetched. Every other value dynamically imports {@link createLintModule} and
+     * chunk only when linting is not disabled. `linting: false` returns no
+     * modules — the chunk, and the whole bpmnlint/rules stack, is never fetched.
+     * Every other value dynamically imports {@link createLintModule} and
      * registers one instance-scoped module carrying the tier, engine, explicit
      * config, and the facade callbacks.
      */
@@ -327,8 +319,6 @@ export class BpmnModeler {
      * Any push switches an in-page instance to the external tier. `null`
      * deactivates linting (no `.bpmnlintrc` / read failure). A no-op with a warning
      * when the instance was created with `linting: false` (no lint service).
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     applyLintResults(results: LintResults | null): void {
         const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
@@ -342,8 +332,6 @@ export class BpmnModeler {
     /**
      * Renders the host's user-disabled lint state (external tier): clears overlays
      * and shows the re-enable chip. A no-op with a warning when `linting: false`.
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     applyLintingDisabled(): void {
         const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
@@ -357,14 +345,12 @@ export class BpmnModeler {
     }
 
     /**
-     * Starts (or restarts) the in-page linter on host instruction — the #1373
-     * Phase B handback when the host finds no workspace `.bpmnlintrc`. Mirrors
+     * Starts (or restarts) the in-page linter on host instruction — the handback
+     * when the host finds no workspace `.bpmnlintrc`. Mirrors
      * {@link applyLintResults}: a no-op with a warning when the instance was
      * created with `linting: false` (no lint service). Never re-enables a
      * user-disabled linter (the service guards that); any later host push still
      * wins over the in-page run.
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     startInPageLinting(config?: BpmnlintConfig, configToken?: string): void {
         const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
@@ -461,9 +447,8 @@ export class BpmnModeler {
      * Subscribes to the `commandStack.changed` event on the modeler's event bus.
      *
      * @internal Raw change hook. The designed API exposes the debounced
-     *   `onContentSaved` event instead; this stays for the host adapter (#1375).
+     *   `onContentSaved` event instead; this stays for the host adapter.
      * @param cb Callback invoked whenever the command stack changes.
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     onCommandStackChanged(cb: () => void): void {
         this.getModeler().get<any>("eventBus").on("commandStack.changed", cb);
@@ -473,8 +458,6 @@ export class BpmnModeler {
      * Returns the live moddle definitions tree (`bpmn:Definitions` root) so
      * callers can walk the in-memory model — e.g. to extract process variables
      * for script IntelliSense — without round-tripping through XML.
-     *
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     getDefinitions(): any {
         return this.getModeler().getDefinitions();
@@ -486,41 +469,24 @@ export class BpmnModeler {
      * scan and filtering rules live in {@link collectInlineScriptTasks} so the
      * bulk path and the single-open path stay in agreement.
      *
-     * @internal Host-adapter surface (inline-scripting capability, #1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     * @internal Host-adapter surface (inline-scripting capability).
      */
     collectInlineScriptTasks(): ScriptTaskScript[] {
         return collectInlineScriptTasks(this.getModeler().get<any>("elementRegistry"));
     }
 
-    /**
-     * Creates a new, empty BPMN diagram in the modeler.
-     *
-     * @returns {@link ImportXMLResult} with any warnings produced during import.
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     */
     async newDiagram(): Promise<ImportXMLResult> {
         const result = await this.getModeler().createDiagram();
         this.applyEnginesFromDefinitions();
         return result;
     }
 
-    /**
-     * Loads the given BPMN XML into the modeler, replacing any current diagram.
-     *
-     * @param bpmn Raw BPMN 2.0 XML string.
-     * @returns {@link ImportXMLResult} with any warnings produced during import.
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     * @throws {Error} If the XML cannot be parsed.
-     */
     async loadDiagram(bpmn: string): Promise<ImportXMLResult> {
         try {
             return await this.getModeler()
                 .importXML(bpmn)
                 .then((result: ImportXMLResult) => {
-                    /**
-                     * Transaction boundaries are only available for the C7 modeler.
-                     */
+                    // Transaction boundaries are a C7-only feature.
                     if (this.engine === "c7" && this.settings.showTransactionBoundaries) {
                         this.getModeler().get<any>("transactionBoundaries").show();
                     }
@@ -538,13 +504,6 @@ export class BpmnModeler {
         }
     }
 
-    /**
-     * Serialises the current diagram to a BPMN 2.0 XML string.
-     *
-     * @returns Formatted XML string.
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     * @throws {Error} If the diagram cannot be serialised.
-     */
     async exportDiagram(): Promise<string> {
         const result: SaveXMLResult = await this.getModeler().saveXML({ format: true });
         if (result.xml) {
@@ -555,58 +514,32 @@ export class BpmnModeler {
         throw new Error("Failed to save changes made to the diagram!");
     }
 
-    /**
-     * Exports the current diagram as an SVG string.
-     *
-     * @returns SVG markup string.
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     */
     async getDiagramSvg(): Promise<string> {
         const result = await this.getModeler().saveSVG();
         return result.svg;
     }
 
-    /**
-     * Pushes a new set of element templates (as data) to the modeler's template
-     * loader.
-     *
-     * @param templates Array of element template objects.
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     */
     setElementTemplates(templates: object[]): void {
         this.getModeler().get<any>("elementTemplatesLoader").setTemplates(templates);
     }
 
-    /**
-     * Applies a partial settings update.
-     *
-     * @param settings Partial settings object to merge, or `undefined` (no-op).
-     * @throws {NoModelerError} If the modeler has not been created yet.
-     */
     setSettings(settings: Partial<BpmnModelerSetting> | undefined): void {
         if (!settings) {
             return;
         }
-        // Ensure the modeler exists before applying any settings.
         this.getModeler();
         this.settings = { ...this.settings, ...settings };
 
         // `colorTheme` is deliberately not applied here: the page theme is host
-        // policy driven through `theme` / {@link setTheme} (#1377). It stays in
-        // the settings type/defaults but is inert on this path.
+        // policy driven through `theme` / {@link setTheme}. It stays in the
+        // settings type/defaults but is inert on this path.
 
-        /**
-         * Apply transaction boundary visibility change immediately for C7.
-         */
         if (this.engine === "c7") {
             const tb = this.getModeler().get<any>("transactionBoundaries");
             // eslint-disable-next-line @typescript-eslint/no-unused-expressions
             this.settings.showTransactionBoundaries ? tb.show() : tb.hide();
         }
 
-        /**
-         * Apply favourite BPMN elements to the append menu.
-         */
         if (settings.favouriteBpmnElements !== undefined) {
             const appendMenuOverride = this.getModeler().get<any>("appendMenuOverride", false);
             if (appendMenuOverride) {
@@ -619,9 +552,7 @@ export class BpmnModeler {
      * Triggers the align-to-origin plugin if the setting is enabled.
      *
      * @internal Host-adapter surface (invoked on save by the VS Code editor
-     *   controller); folded behind the `alignToOrigin` setting in the designed
-     *   API (#1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     *   controller); folded behind the `alignToOrigin` setting in the public API.
      */
     alignElementsToOrigin(): void {
         if (this.settings.alignToOrigin) {
@@ -632,13 +563,12 @@ export class BpmnModeler {
     /**
      * Returns a service from the modeler's dependency injection container.
      *
-     * @remarks Unstable escape hatch — kept public deliberately (see the
-     *   ADR 0007, `docs/adr`) so advanced integrations are not blocked, but
-     *   not covered by semver: DI service names can change across minor
-     *   versions. Prefer a typed option/method where one exists.
+     * @remarks Unstable escape hatch — kept public deliberately so advanced
+     *   integrations are not blocked, but not covered by semver: DI service names
+     *   can change across minor versions. Prefer a typed option/method where one
+     *   exists.
      * @param name The DI service name (e.g. `"customTranslator"`).
      * @returns The service instance.
-     * @throws {NoModelerError} If the modeler has not been created yet.
      */
     getService<T = any>(name: string): T {
         return this.getModeler().get<T>(name);
@@ -654,8 +584,7 @@ export class BpmnModeler {
      * - `execution-listener` / `task-listener`: writes to the listener's
      *   nested `camunda:Script.scriptFormat`.
      *
-     * @internal Host-adapter surface (inline-scripting capability, #1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     * @internal Host-adapter surface (inline-scripting capability).
      */
     updateScriptFormat(
         elementId: string,
@@ -705,8 +634,7 @@ export class BpmnModeler {
      *   `listenerIndex` within the parent's filtered list of that listener
      *   type, then writes to its nested `camunda:Script` element's `value`.
      *
-     * @internal Host-adapter surface (inline-scripting capability, #1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     * @internal Host-adapter surface (inline-scripting capability).
      */
     updateScriptContent(
         elementId: string,
@@ -757,7 +685,7 @@ export class BpmnModeler {
      * modules are not registered for C8, so the service is resolved defensively
      * and the call is a no-op there.
      *
-     * @internal Host-adapter surface (inline-scripting capability, #1375).
+     * @internal Host-adapter surface (inline-scripting capability).
      */
     applyOpenScriptEditors(refs: OpenScriptEditorRef[]): void {
         this.getModeler().get<OpenScriptEditorsStore>("openScriptEditorsStore", false)?.set(refs);
@@ -768,7 +696,7 @@ export class BpmnModeler {
      * singleton (one `#theme-link`), so `"automatic"` follows the OS/browser
      * `prefers-color-scheme` live while `"light"`/`"dark"` force a fixed
      * stylesheet. A host that themes off its own chrome maps that signal to a
-     * forced mode at the adapter (#1377).
+     * forced mode at the adapter.
      */
     setTheme(theme: ThemeMode): void {
         setThemeMode(theme);
@@ -784,8 +712,7 @@ export class BpmnModeler {
      * omits the codeLink capability registers no `codeLinkMapClient`, and a
      * stray status push must then be a no-op rather than throw.
      *
-     * @internal Host-adapter surface (code-link capability, #1375).
-     * @throws {NoModelerError} If the modeler has not been created yet.
+     * @internal Host-adapter surface (code-link capability).
      */
     applyImplementationStatus(resolved: Record<string, boolean>): void {
         this.getModeler().get<CodeLinkMapClient>("codeLinkMapClient", false)?.applyStatus(resolved);

--- a/packages/bpmn-modeler/src/propertiesPanelClipboard.ts
+++ b/packages/bpmn-modeler/src/propertiesPanelClipboard.ts
@@ -1,7 +1,7 @@
 /**
  * @internal Host-adapter surface — routes the panel's plain-text copy/paste
- * through the extension-host clipboard bridge. Not part of the designed public
- * API (#1375); folded behind the `clipboard` option's bridge.
+ * through the extension-host clipboard bridge. Not part of the public API;
+ * folded behind the `clipboard` option's bridge.
  */
 import { isTextEditingSurface } from "@miragon/bpmn-modeler-types";
 

--- a/packages/bpmn-modeler/src/publicApi.spec.ts
+++ b/packages/bpmn-modeler/src/publicApi.spec.ts
@@ -14,23 +14,19 @@ import type {
 } from "./publicApi";
 
 /**
- * Type-level conformance + scenario spec for the designed public API (#1375).
+ * Type-level conformance + scenario spec for the public API.
  *
  * The assertions below are compile-checked (this file is type-checked by
  * `tsconfig.spec.json`); the single runtime `it` exists only so the test runner
  * has something to execute — esbuild strips the types without checking them, so
- * the guarantee is the `tsc` pass, not the vitest run. Each block encodes one
- * deliverable: (a) the current facade already satisfies the stable subset;
- * (b) the three bpm-iq scenarios type-check; (c) a demo-webapp-shaped literal.
+ * the guarantee is the `tsc` pass, not the vitest run.
  *
  * `satisfies` is used instead of a plain annotation so the checks cannot be
  * widened away by an over-broad target type.
  */
 
-// (a) Conformance: the current BpmnModeler class now satisfies the *full*
-// designed handle — `setTheme` landed and `setElementTemplates` widened to
-// `object[]` with #1376. If a future refactor reshapes one of these members,
-// this line stops compiling.
+// Conformance: the BpmnModeler class satisfies the full handle. If a future
+// refactor reshapes one of these members, this line stops compiling.
 const _conformance = (modeler: BpmnModeler): BpmnModelerHandle => modeler;
 void _conformance;
 
@@ -40,7 +36,7 @@ type _HandleIsSuperset = BpmnModelerHandle extends StableModelerSurface ? true :
 const _handleSuperset: _HandleIsSuperset = true;
 void _handleSuperset;
 
-// (b1) bpm-iq scenario 1 — element templates arrive as fetched data, not a path.
+// Element templates arrive as fetched data, not a path.
 const _scenarioTemplates = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -48,8 +44,8 @@ const _scenarioTemplates = {
 } satisfies ModelerOptions;
 void _scenarioTemplates;
 
-// (b2) bpm-iq scenario 2 — an async ModelNavigationPort (GitHub-API resolution
-// before opening a tab). The widened return type must accept `async`.
+// An async ModelNavigationPort (GitHub-API resolution before opening a tab).
+// The return type must accept `async`.
 const _asyncNavigation: ModelNavigationPort = {
     async openReference({ id, kind }) {
         await Promise.resolve();
@@ -64,9 +60,9 @@ const _scenarioAsyncNav = {
 } satisfies ModelerOptions;
 void _scenarioAsyncNav;
 
-// (b3) bpm-iq scenario 3 — graceful `{ config }` linting. The literal type-checks
-// against the BpmnlintConfig mirror; unresolvable rules degrade at runtime and
-// surface via onLintResults({ results, unresolved }).
+// Graceful `{ config }` linting. The literal type-checks against the
+// BpmnlintConfig mirror; unresolvable rules degrade at runtime and surface via
+// onLintResults({ results, unresolved }).
 const _scenarioLintConfig = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -92,16 +88,16 @@ const _clipboard: ClipboardOptions = {
 };
 // A host with two protocol channels (VS Code) supplies a separate `text`
 // bridge; the package forwards it to createClipboardModules' text binding and
-// drives the contenteditable polyfill from it (#1377).
+// drives the contenteditable polyfill from it.
 const _clipboardWithText: ClipboardOptions = {
     bridge: { requestClipboard: () => Promise.resolve(""), writeClipboard: () => undefined },
     text: { requestClipboard: () => Promise.resolve(""), writeClipboard: () => undefined },
 };
 void _clipboardWithText;
 // The runtime factory accepts the same clipboard override — omit it for the
-// native browser clipboard (#1374), or pass `{ bridge }` to route through a
-// host. The runtime options now implement the designed {@link ModelerOptions}
-// (engine + nested `propertiesPanel`), plus the internal `handleGlobalEscape`.
+// native browser clipboard, or pass `{ bridge }` to route through a host. The
+// runtime options extend {@link ModelerOptions} (engine + nested
+// `propertiesPanel`), plus the internal `handleGlobalEscape`.
 const _createWithClipboard = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -125,13 +121,12 @@ const _builtinsShape = {
 } satisfies ModelerOptions;
 void _builtinsShape;
 
-// The designed async factory signature is nameable and distinct from today's
-// synchronous `createModeler` (which #1376 collapses into this shape).
+// The async factory signature is nameable.
 type _FactoryReturn = ReturnType<CreateModeler>;
 const _factoryReturns: _FactoryReturn extends Promise<BpmnModelerHandle> ? true : never = true;
 void _factoryReturns;
 
-// (c) demo-webapp-shaped literal — model navigation only, no code-link/scripting.
+// Demo-webapp-shaped literal — model navigation only, no code-link/scripting.
 const _demoShape = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -146,7 +141,7 @@ const _demoShape = {
 } satisfies ModelerOptions;
 void _demoShape;
 
-describe("public API skeleton (#1375)", () => {
+describe("public API conformance", () => {
     it("is a type-only conformance spec; the guarantee is the tsc pass", () => {
         expect(true).toBe(true);
     });

--- a/packages/bpmn-modeler/src/publicApi.ts
+++ b/packages/bpmn-modeler/src/publicApi.ts
@@ -12,20 +12,14 @@ import type { ViewportManager } from "./viewport";
 import type { SelectionManager } from "./selection";
 
 /**
- * The designed public TypeScript surface of the future `@miragon/bpmn-modeler`
- * npm package (#1375, epic #1293). This file is a **type-only skeleton**: it
- * fixes the shape of `createModeler(container, options)`, the instance handle,
- * and the outbound event model *before* the package is extracted, so the
- * extraction moves code into a designed API instead of freezing today's
- * accidental facade. No runtime lives here — the current {@link BpmnModeler}
- * satisfies the stable subset (proved in `publicApi.spec.ts`), and #1373/#1376
- * grow the runtime up to the rest of this shape.
+ * The public TypeScript surface of the `@miragon/bpmn-modeler` package:
+ * `createModeler(container, options)`, the instance handle, and the outbound
+ * event model.
  *
  * ## Feature taxonomy
  *
  * Every capability the modeler exposes falls into exactly one of three
- * categories, and each declaration below is tagged with its category so the
- * ADR's taxonomy table has a machine-anchored home:
+ * categories, and each declaration below is tagged with its category:
  *
  * - **[A] Engine-intrinsic** — the diagram surface itself. Always present; not
  *   a toggle. Loading/exporting XML, the viewport, the selection, the engine.
@@ -46,13 +40,13 @@ import type { SelectionManager } from "./selection";
  * [B] Theme selection for a single instance. `"automatic"` follows the
  * OS/browser `prefers-color-scheme` live; `"light"`/`"dark"` force a fixed
  * stylesheet. A host that themes off its own chrome (VS Code `<body>` classes)
- * maps that signal to a forced mode in its adapter — the package no longer reads
- * host chrome (#1377).
+ * maps that signal to a forced mode in its adapter — the package does not read
+ * host chrome.
  */
 export type ThemeMode = "light" | "dark" | "automatic";
 
 /**
- * [B] Linting configuration, adopting #1373's tier ladder verbatim:
+ * [B] Linting configuration tiers:
  *
  * - `undefined` — linting on with the bundled default ruleset.
  * - `false` — linting off entirely (no chip, no overlay).
@@ -73,9 +67,9 @@ export type LintingOptions =
 
 /**
  * [B] Clipboard override. Default (option omitted) is the native browser
- * clipboard (#1374). A sandboxed host that cannot reach the system clipboard
- * from the webview supplies a {@link ClipboardBridge} to route copy/paste
- * through its extension host.
+ * clipboard. A sandboxed host that cannot reach the system clipboard from the
+ * webview supplies a {@link ClipboardBridge} to route copy/paste through its
+ * extension host.
  */
 export interface ClipboardOptions {
     /** Bridge for diagram-element copy/paste; also the default for `text`. */
@@ -91,10 +85,10 @@ export interface ClipboardOptions {
 
 /**
  * Outbound content notification. Debounced and owned by the package (300ms,
- * 1000ms maxWait — the shape battle-tested in `bootstrap`), because every
- * consumer needs exactly that debounce; raw `commandStack.changed` stays
- * reachable through the {@link BpmnModelerHandle.getService} escape hatch for
- * the rare consumer that wants it un-debounced.
+ * 1000ms maxWait), because every consumer needs exactly that debounce; raw
+ * `commandStack.changed` stays reachable through the
+ * {@link BpmnModelerHandle.getService} escape hatch for the rare consumer that
+ * wants it un-debounced.
  */
 export interface ContentSavedEvent {
     readonly xml: string;
@@ -109,23 +103,20 @@ export interface ContentSavedEvent {
 export interface ModelerOptions {
     // ── [A] Engine-intrinsic ────────────────────────────────────────────────
     /**
-     * [A] Camunda engine version. Required and known up front in the target
-     * shape (the current two-step `create(engine)` is the internal migration
-     * path; #1373/#1376 collapse it). Switching engines = `destroy()` + a new
+     * [A] Camunda engine version. Switching engines = `destroy()` + a new
      * instance.
      */
     engine: Engine;
 
     /**
      * [A] The panel host. Each instance owns its own properties-panel parent so
-     * several modelers can coexist on one page (rename of today's flat
-     * `propertiesPanelParent`).
+     * several modelers can coexist on one page.
      */
     propertiesPanel: { parent: HTMLElement };
 
     /**
-     * [A] Initial element templates as **data**, never a path (bpm-iq scenario
-     * 1): the host fetches the JSON and hands it in. Live updates go through
+     * [A] Initial element templates as **data**, never a path: the host fetches
+     * the JSON and hands it in. Live updates go through
      * {@link BpmnModelerHandle.setElementTemplates}.
      */
     elementTemplates?: object[];
@@ -135,8 +126,8 @@ export interface ModelerOptions {
 
     /**
      * [A] Escape hatch: extra bpmn-js DI modules. Unstable/advanced — the
-     * supported knobs are the typed options above. Renamed from the current
-     * `extraModules` to match bpmn-js's own `additionalModules`.
+     * supported knobs are the typed options above. Matches bpmn-js's own
+     * `additionalModules`.
      */
     additionalModules?: unknown[];
 
@@ -144,13 +135,13 @@ export interface ModelerOptions {
     /** [B] Linting tier — see {@link LintingOptions}. Omit for the bundled default. */
     linting?: LintingOptions;
 
-    /** [B] Clipboard override — omit for the native clipboard (#1374). */
+    /** [B] Clipboard override — omit for the native clipboard. */
     clipboard?: ClipboardOptions;
 
     /** [B] Colour theme — defaults to `"automatic"`. */
     theme?: ThemeMode;
 
-    /** [B] UI locale (BCP-47-ish tag) — defaults to `"en"`. Absorbs the page-level `TranslateModule` + `i18n.setLanguage` wiring. */
+    /** [B] UI locale (BCP-47-ish tag) — defaults to `"en"`. */
     locale?: string;
 
     // ── [C] Host capabilities ───────────────────────────────────────────────
@@ -165,10 +156,10 @@ export interface ModelerOptions {
     /** Debounced diagram content — see {@link ContentSavedEvent}. */
     onContentSaved?: (event: ContentSavedEvent) => void;
 
-    /** One lint pass completed — findings + gracefully-degraded rules (#1373). */
+    /** One lint pass completed — findings + gracefully-degraded rules. */
     onLintResults?: (event: LintRunEvent) => void;
 
-    /** The in-canvas lint chip was toggled on/off (absorbs today's `lintingHost`, #1373). */
+    /** The in-canvas lint chip was toggled on/off. */
     onLintingToggled?: (enabled: boolean) => void;
 
     /** A non-fatal warning (element-not-found, missing inline script) for the host log. */
@@ -179,13 +170,7 @@ export interface ModelerOptions {
 }
 
 /**
- * The instance handle {@link createModeler} resolves to — the designed
- * replacement for today's {@link BpmnModeler} class surface. Members are the
- * union of the **stable subset** (already implemented and frozen in shape) and
- * the **target-only** addition (`setTheme`) that #1376 adds
- * (`applyLintResults` / `applyLintingDisabled` landed with #1373's tier
- * ladder). `publicApi.spec.ts` asserts the current facade satisfies the stable
- * subset; the additions are documented in the ADR's rename/reshape map.
+ * The instance handle {@link createModeler} resolves to.
  */
 export interface BpmnModelerHandle {
     // ── [A] Engine-intrinsic ────────────────────────────────────────────────
@@ -221,23 +206,22 @@ export interface BpmnModelerHandle {
     destroy(): void;
 
     // ── [B] Opinionated built-ins ───────────────────────────────────────────
-    /** [B] Switch the colour theme live (target-only; #1376/#1377). */
+    /** [B] Switch the colour theme live. */
     setTheme(theme: ThemeMode): void;
 
     /**
-     * [B] Render host-computed lint results, or clear them with `null`
-     * (#1373's `results: "external"` tier).
+     * [B] Render host-computed lint results, or clear them with `null`.
      */
     applyLintResults(results: LintResults | null): void;
 
-    /** [B] Turn off the in-webview linter and clear its overlay (#1373). */
+    /** [B] Turn off the in-webview linter and clear its overlay. */
     applyLintingDisabled(): void;
 
     /**
-     * [B] Start (or restart) the in-webview linter — the host's no-workspace-config
-     * handback (#1373 Phase B). Optional `config` overrides the engine-aware
-     * default; optional `configToken` (#1384) lets a repeat instruction with the
-     * same version dedup while linting is live. Never re-enables a user-disabled
+     * [B] Start (or restart) the in-webview linter with the host's
+     * no-workspace-config handback. Optional `config` overrides the engine-aware
+     * default; optional `configToken` lets a repeat instruction with the same
+     * version dedup while linting is live. Never re-enables a user-disabled
      * linter.
      */
     startInPageLinting(config?: BpmnlintConfig, configToken?: string): void;
@@ -246,8 +230,8 @@ export interface BpmnModelerHandle {
     /**
      * Unstable escape hatch: reach a bpmn-js DI service by name. Not covered by
      * semver — plugin authors accept breakage across minor versions. Kept
-     * public deliberately (ADR decision) so advanced integrations are not
-     * blocked while the typed surface catches up.
+     * public deliberately so advanced integrations are not blocked while the
+     * typed surface catches up.
      *
      * @remarks Unstable. Prefer a typed option/method; open an issue if one is missing.
      */
@@ -255,15 +239,10 @@ export interface BpmnModelerHandle {
 }
 
 /**
- * [A] The designed package entry point: stand up one modeler bound to
- * `container` and resolve its {@link BpmnModelerHandle}. Async because #1373's
- * lazy lint chunk forces a construction await anyway; a host that learns the
- * engine late simply calls this late (today's `bootstrap` already constructs
- * after the file handshake).
- *
- * Type-only in this spike — the runtime factory is still
- * {@link createModeler} + the two-step `create(engine)`; #1376 collapses the
- * two into this signature.
+ * [A] The package entry point: stand up one modeler bound to `container` and
+ * resolve its {@link BpmnModelerHandle}. Async because the lazy lint chunk
+ * forces a construction await; a host that learns the engine late simply calls
+ * this late.
  */
 export type CreateModeler = (
     container: HTMLElement,
@@ -271,12 +250,8 @@ export type CreateModeler = (
 ) => Promise<BpmnModelerHandle>;
 
 /**
- * The stable subset of {@link BpmnModelerHandle}: the members the current
- * {@link BpmnModeler} already implements with target-final signatures, so their
- * shape is frozen and the extraction cannot silently reshape them.
- * `setElementTemplates` is intentionally excluded — its param widens from
- * `JSON[] | undefined` to `object[]` (see the ADR's reshape map), so it is not
- * yet stable.
+ * The subset of {@link BpmnModelerHandle} whose signatures are frozen, asserted
+ * against the runtime handle in `publicApi.spec.ts`.
  */
 export type StableModelerSurface = Pick<
     BpmnModelerHandle,

--- a/packages/bpmn-modeler/src/rootElement.ts
+++ b/packages/bpmn-modeler/src/rootElement.ts
@@ -1,14 +1,9 @@
 /**
  * @internal Host-adapter surface — drill-down root tracking used for canvas
- * view-state restore. Not part of the designed public API (#1375).
+ * view-state restore. Not part of the public API.
  */
 
-/**
- * Function type for accessing a service from the bpmn-js DI container.
- *
- * @template T The service type to retrieve.
- * @param name The DI service name.
- */
+/** Accessor for a service from the bpmn-js DI container, by name. */
 type ServiceAccessor = <T>(name: string) => T;
 
 /**
@@ -25,8 +20,7 @@ const IMPLICIT_ROOT_PREFIX = "__implicitroot";
  * The root element determines which plane is visible — the top-level
  * process or a collapsed sub-process drill-down. Decoupled from the
  * modeler through a {@link ServiceAccessor} so the concern can be tested
- * and composed independently, following the same pattern as
- * {@link ViewportManager} and {@link SelectionManager}.
+ * and composed independently.
  */
 export class RootElementManager {
     constructor(private readonly getService: ServiceAccessor) {}

--- a/packages/bpmn-modeler/src/selection.ts
+++ b/packages/bpmn-modeler/src/selection.ts
@@ -1,9 +1,4 @@
-/**
- * Function type for accessing a service from the bpmn-js DI container.
- *
- * @template T The service type to retrieve.
- * @param name The DI service name.
- */
+/** Accessor for a service from the bpmn-js DI container, by name. */
 type ServiceAccessor = <T>(name: string) => T;
 
 /**
@@ -15,9 +10,6 @@ type ServiceAccessor = <T>(name: string) => T;
 export class SelectionManager {
     constructor(private readonly getService: ServiceAccessor) {}
 
-    /**
-     * Returns the IDs of the currently selected elements.
-     */
     getSelectedElementIds(): string[] {
         return this.getService<any>("selection")
             .get()
@@ -25,12 +17,8 @@ export class SelectionManager {
     }
 
     /**
-     * Selects elements by their IDs.
-     *
      * Silently skips IDs that no longer exist in the diagram (e.g. element
      * was deleted before the tab switch).
-     *
-     * @param ids Element IDs to select.
      */
     selectElementsByIds(ids: string[]): void {
         const registry = this.getService<any>("elementRegistry");
@@ -40,11 +28,6 @@ export class SelectionManager {
         }
     }
 
-    /**
-     * Subscribes to selection changes on the event bus.
-     *
-     * @param cb Callback invoked with the IDs of the newly selected elements.
-     */
     onSelectionChanged(cb: (elementIds: string[]) => void): void {
         this.getService<any>("eventBus").on("selection.changed", (event: any) => {
             const ids = (event.newSelection ?? []).map((el: any) => el.id);

--- a/packages/bpmn-modeler/src/styles/dark-theme/diagram-js.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/diagram-js.css
@@ -81,8 +81,8 @@
  * scoping each rule to the known value. A blanket `*` override would beat — via
  * `!important` — the inline style bpmn-js writes for a user's "Set color" choice.
  * Value-scoping also handles two cases for free: `fill: none` (bpmn:Group, text
- * annotations) matches nothing and stays transparent (#1056), and filled throw
- * markers are covered by the rules below (#1017).
+ * annotations) matches nothing and stays transparent, and filled throw markers
+ * are covered by the rules below.
  */
 
 /* defaultFillColor (white) → dark surface */

--- a/packages/bpmn-modeler/src/theme.spec.ts
+++ b/packages/bpmn-modeler/src/theme.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
- * Page theme controller (#1377). The module is a page singleton (a `currentMode`
+ * Page theme controller. The module is a page singleton (a `currentMode`
  * plus one live `prefers-color-scheme` listener), so each test reloads it via
  * `vi.resetModules()` to start from the initial `"automatic"` state. Because the
  * initial mode is already `"automatic"`, the same-mode guard means a fresh

--- a/packages/bpmn-modeler/src/theme.ts
+++ b/packages/bpmn-modeler/src/theme.ts
@@ -8,9 +8,9 @@
  *
  * A host's own light/dark chrome (e.g. VS Code's `<body>` classes) is host
  * policy: the host adapter maps that signal to a forced `setTheme("light")` /
- * `setTheme("dark")` — the package never reads host chrome (#1377).
+ * `setTheme("dark")` — the package never reads host chrome.
  *
- * @internal Not part of the designed public handle; reached only through
+ * @internal Not part of the public handle; reached only through
  *   {@link BpmnModeler.setTheme}.
  */
 import type { ThemeMode } from "./publicApi";
@@ -49,8 +49,7 @@ export function applyResolvedTheme(kind: "light" | "dark"): void {
  * theme switch is reflected live; a forced `"light"`/`"dark"` stops that
  * listener so the fixed choice is not overwritten on the next scheme change.
  *
- * A no-op when the mode is unchanged — same guard the module singleton carried
- * before the extraction, so a hosted session that never sets `theme` is untouched.
+ * A no-op when the mode is unchanged.
  */
 export function setThemeMode(mode: ThemeMode): void {
     if (mode === currentMode) {
@@ -87,9 +86,6 @@ function startFollowingPreferredScheme(): void {
     mediaQuery.addEventListener("change", mediaListener);
 }
 
-/**
- * Disconnects the `prefers-color-scheme` listener.
- */
 function stopFollowingPreferredScheme(): void {
     if (mediaQuery && mediaListener) {
         mediaQuery.removeEventListener("change", mediaListener);

--- a/packages/bpmn-modeler/src/types/bpmnlint.d.ts
+++ b/packages/bpmn-modeler/src/types/bpmnlint.d.ts
@@ -7,7 +7,7 @@ declare module "bpmn-js-bpmnlint" {
 }
 
 /**
- * `bpmnlint` ships no type declarations. The in-page linter (#1373) drives only
+ * `bpmnlint` ships no type declarations. The in-page linter drives only
  * `Linter` directly — it builds the rule/config resolver from
  * `@miragon/bpmnlint-plugin-rules` (which is typed), so this shim needs only the
  * one class the webview constructs. Rule/config shapes are opaque, passed

--- a/packages/bpmn-modeler/src/viewport.ts
+++ b/packages/bpmn-modeler/src/viewport.ts
@@ -16,12 +16,7 @@ export interface ViewportData {
     scale?: number;
 }
 
-/**
- * Function type for accessing a service from the bpmn-js DI container.
- *
- * @template T The service type to retrieve.
- * @param name The DI service name.
- */
+/** Accessor for a service from the bpmn-js DI container, by name. */
 type ServiceAccessor = <T>(name: string) => T;
 
 // Zoom floor when focusing an element, so a far-zoomed-out view still shows it


### PR DESCRIPTION
## Issue

N/A — follow-up cleanup after the package extraction (#1393–#1397).

## Description

Removes GitHub issue/epic/ADR references and migration-planning narrative from the comments in `packages/bpmn-modeler`, left over from the extraction. Comments now carry only non-obvious why-context: restating docblocks were deleted, long design narratives trimmed, and one test name lost its embedded ticket number. Comment-only change — no runtime behavior touched; all 141 package tests pass.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
