### PR TITLE
feat(bpmn-modeler): allow passing custom moddleExtensions to createModeler

### DIFF
--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -80,6 +80,28 @@ const modeler = await createModeler(canvas, {
 });
 ```
 
+## Escape hatches
+
+For advanced hosts, two options pass straight through to bpmn-js:
+
+- `additionalModules` — extra DI modules layered onto the bundled ones.
+- `moddleExtensions` — extra moddle descriptors for a host's own BPMN
+  namespace, so custom-namespaced XML parses into typed moddle objects (and
+  the DI modules that depend on those types work). They are **merged onto** the
+  engine's bundled `camunda`/`zeebe`/`modeler` moddles; a prefix colliding with
+  one of those is **last-wins** (your descriptor overrides the engine's — don't
+  do that).
+
+```ts
+const modeler = await createModeler(canvas, {
+    engine: "c7",
+    propertiesPanel: { parent: panel },
+    moddleExtensions: {
+        bpmiq: { name: "bpmiq", uri: "http://bpmiq/schema", prefix: "bpmiq", types: [] },
+    },
+});
+```
+
 ## Linting tiers
 
 Linting is an opinionated built-in with a tier ladder, selected via

--- a/packages/bpmn-modeler/src/modeler.ts
+++ b/packages/bpmn-modeler/src/modeler.ts
@@ -209,6 +209,7 @@ export class BpmnModeler {
             container: this.container,
             propertiesPanel: { parent: this.options.propertiesPanel.parent },
             alignToOrigin: ALIGN_TO_ORIGIN_OPTIONS,
+            moddleExtensions: this.options.moddleExtensions,
         };
 
         this.engine = engine;

--- a/packages/bpmn-modeler/src/publicApi.spec.ts
+++ b/packages/bpmn-modeler/src/publicApi.spec.ts
@@ -44,6 +44,18 @@ const _scenarioTemplates = {
 } satisfies ModelerOptions;
 void _scenarioTemplates;
 
+// [A] Escape hatches: extra DI modules alongside a custom moddle extension for
+// a host's own BPMN namespace (bpmiq's sticky-note case).
+const _scenarioEscapeHatches = {
+    engine: "c7",
+    propertiesPanel: { parent: document.createElement("div") },
+    additionalModules: [{ __init__: [] }],
+    moddleExtensions: {
+        bpmiq: { name: "bpmiq", uri: "http://bpmiq/schema", prefix: "bpmiq", types: [] },
+    },
+} satisfies ModelerOptions;
+void _scenarioEscapeHatches;
+
 // An async ModelNavigationPort (GitHub-API resolution before opening a tab).
 // The return type must accept `async`.
 const _asyncNavigation: ModelNavigationPort = {

--- a/packages/bpmn-modeler/src/publicApi.ts
+++ b/packages/bpmn-modeler/src/publicApi.ts
@@ -131,6 +131,13 @@ export interface ModelerOptions {
      */
     additionalModules?: unknown[];
 
+    /**
+     * [A] Escape hatch: extra moddle extensions, merged onto the engine's
+     * bundled camunda/zeebe moddles (last-wins on a colliding namespace
+     * prefix). Matches bpmn-js's own `moddleExtensions`.
+     */
+    moddleExtensions?: Record<string, object>;
+
     // ── [B] Opinionated built-ins ───────────────────────────────────────────
     /** [B] Linting tier — see {@link LintingOptions}. Omit for the bundled default. */
     linting?: LintingOptions;


### PR DESCRIPTION
## Issue

Closes #1403

## Description

Adds an optional `moddleExtensions` passthrough on `ModelerOptions`, mirroring bpmn-js's own option and completing the `[A]` escape-hatch pair with `additionalModules`. The option is spread into the options handed to `BpmnModeler7`/`BpmnModeler8`, which already merge caller extensions over the bundled camunda/zeebe moddles — a colliding namespace prefix is last-wins, documented in the JSDoc and README. Includes a type-conformance scenario in `publicApi.spec.ts` and a new README "Escape hatches" section.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A — optional field within the existing escape-hatch category of ADR 0007)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A — additive package option, unused by in-repo hosts)
