### PR TITLE
feat(bpmn-modeler): export detectEngine(xml) engine-detection helper

### DIFF
--- a/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
+++ b/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
@@ -92,8 +92,15 @@ async function waitForFrame(
     throw new Error("waitForFrame timed out");
 }
 
+// A host lint delivering actual findings. Requires non-null `results`: a
+// `.bpmnlintrc` write is truncate-then-write, so the watcher can fire mid-write
+// and read an empty file, whose failed JSON.parse degrades to a
+// BpmnlintResultsQuery(null) deactivation frame. That transient must not satisfy
+// a wait for the real host run (it crashes Object.keys and races the re-lint).
 const isLintResultsFrame = (frame: any): boolean =>
-    frame.method === "editor/postMessage" && frame.params?.message?.type === "BpmnlintResultsQuery";
+    frame.method === "editor/postMessage" &&
+    frame.params?.message?.type === "BpmnlintResultsQuery" &&
+    frame.params?.message?.results != null;
 
 const isInPageInstructionFrame = (frame: any): boolean =>
     frame.method === "editor/postMessage" && frame.params?.message?.type === "BpmnlintInPageQuery";

--- a/libs/modeler-core/src/shared/domain/BpmnDocument.spec.ts
+++ b/libs/modeler-core/src/shared/domain/BpmnDocument.spec.ts
@@ -25,6 +25,12 @@ const c7XmlNoVersion = `<?xml version="1.0" encoding="UTF-8"?>
   <bpmn:process id="Process_0" isExecutable="true" />
 </bpmn:definitions>`;
 
+// Has the executionPlatform name but no version attribute.
+const c8XmlNameOnly = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:modeler="http://camunda.org/schema/modeler/1.0" modeler:executionPlatform="Camunda Cloud">
+  <bpmn:process id="Process_0" isExecutable="true" />
+</bpmn:definitions>`;
+
 // No platform signal at all.
 const unknownXml = `<?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:modeler="http://camunda.org/schema/modeler/1.0">
@@ -98,6 +104,10 @@ describe("BpmnDocument.detectPlatform", () => {
 
     it("should detect C7 from xmlns:camunda namespace when version attribute is absent", () => {
         expect(new BpmnDocument(c7XmlNoVersion).detectPlatform()).toBe("c7");
+    });
+
+    it("should detect the platform from the executionPlatform name when version is absent", () => {
+        expect(new BpmnDocument(c8XmlNameOnly).detectPlatform()).toBe("c8");
     });
 
     it("should throw ExecutionPlatformNotDetectedError when no platform signal exists", () => {

--- a/libs/modeler-core/src/shared/domain/BpmnDocument.ts
+++ b/libs/modeler-core/src/shared/domain/BpmnDocument.ts
@@ -7,7 +7,7 @@
  * `BpmnDocument` instead of mutating `this.xml`.
  */
 
-import { Engine } from "@miragon/bpmn-modeler-types";
+import { detectEngine, Engine } from "@miragon/bpmn-modeler-types";
 
 import { ExecutionPlatformNotDetectedError } from "./errors";
 
@@ -64,17 +64,16 @@ export class BpmnDocument {
     /**
      * Detects the Camunda execution platform from the XML.
      *
-     * Checks `modeler:executionPlatformVersion` first, then falls back to
-     * namespace declarations (`xmlns:camunda` for C7, `xmlns:zeebe` for C8).
+     * Delegates to the shared {@link detectEngine} helper for the spec-defined
+     * `modeler:*` signals, then falls back to namespace declarations
+     * (`xmlns:camunda` for C7, `xmlns:zeebe` for C8).
      *
      * @throws {ExecutionPlatformNotDetectedError} When no platform signal is found.
      */
     detectPlatform(): Engine {
-        const regexVersion = /modeler:executionPlatformVersion="([78])\.\d+\.\d+"/;
-        const match = this.xml.match(regexVersion);
-
-        if (match) {
-            return match[1] === "7" ? "c7" : "c8";
+        const detected = detectEngine(this.xml);
+        if (detected) {
+            return detected;
         }
 
         if (this.xml.match(/xmlns:camunda=".*"/)) {

--- a/libs/modeler-types/src/engine.spec.ts
+++ b/libs/modeler-types/src/engine.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { detectEngine } from "./engine";
+
+describe("detectEngine", () => {
+    it("detects c7 from the Camunda Platform execution-platform name", () => {
+        expect(detectEngine('modeler:executionPlatform="Camunda Platform"')).toBe("c7");
+    });
+
+    it("detects c8 from the Camunda Cloud execution-platform name", () => {
+        expect(detectEngine('modeler:executionPlatform="Camunda Cloud"')).toBe("c8");
+    });
+
+    it("falls back to the version major digit when no platform name is present", () => {
+        expect(detectEngine('modeler:executionPlatformVersion="7.23.0"')).toBe("c7");
+        expect(detectEngine('modeler:executionPlatformVersion="8.6.0"')).toBe("c8");
+    });
+
+    it("prefers the platform name over a contradicting version", () => {
+        const xml =
+            'modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="8.6.0"';
+        expect(detectEngine(xml)).toBe("c7");
+    });
+
+    it("returns undefined for an unrecognised platform name and no usable version", () => {
+        expect(detectEngine('modeler:executionPlatform="Some Other Platform"')).toBeUndefined();
+    });
+
+    it("returns undefined when there is no platform metadata", () => {
+        expect(detectEngine("<bpmn:definitions />")).toBeUndefined();
+    });
+
+    it("returns undefined for an empty string", () => {
+        expect(detectEngine("")).toBeUndefined();
+    });
+});

--- a/libs/modeler-types/src/engine.ts
+++ b/libs/modeler-types/src/engine.ts
@@ -28,3 +28,37 @@ export const ENGINE_EXECUTION_PLATFORM: Record<Engine, string> = {
     c7: "Camunda Platform",
     c8: "Camunda Cloud",
 };
+
+/**
+ * Result of {@link detectEngine}: the engine, or `undefined` when the XML
+ * carries no recognisable platform metadata.
+ */
+export type DetectedEngine = Engine | undefined;
+
+/**
+ * Detects the Camunda engine from raw BPMN XML using the spec-defined
+ * `modeler:*` metadata, so hosts can pick the engine before instantiating a
+ * modeler.
+ *
+ * Strict signals, most authoritative first:
+ * 1. `modeler:executionPlatform` name (`"Camunda Platform"` → c7,
+ *    `"Camunda Cloud"` → c8).
+ * 2. else the `modeler:executionPlatformVersion` major digit (7 → c7, 8 → c8).
+ *
+ * Returns `undefined` for engine-neutral diagrams — the caller owns the
+ * fallback policy. No `xmlns:camunda`/`xmlns:zeebe` heuristic here.
+ */
+export function detectEngine(xml: string): DetectedEngine {
+    for (const engine of Object.keys(ENGINE_EXECUTION_PLATFORM) as Engine[]) {
+        if (xml.includes(`modeler:executionPlatform="${ENGINE_EXECUTION_PLATFORM[engine]}"`)) {
+            return engine;
+        }
+    }
+
+    const versionMatch = xml.match(/modeler:executionPlatformVersion="([78])\./);
+    if (versionMatch) {
+        return versionMatch[1] === "7" ? "c7" : "c8";
+    }
+
+    return undefined;
+}

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -102,6 +102,22 @@ const modeler = await createModeler(canvas, {
 });
 ```
 
+### Detecting the engine from XML
+
+`createModeler` needs an explicit `engine`. When a host opens an existing
+diagram, `detectEngine(xml)` reads the spec-defined `modeler:executionPlatform`
+(and, as a secondary signal, `modeler:executionPlatformVersion`) to pick it:
+
+```ts
+import { createModeler, detectEngine } from "@miragon/bpmn-modeler";
+
+const engine = detectEngine(xml) ?? "c7"; // undefined = no platform metadata; the host picks the fallback
+const modeler = await createModeler(container, { engine, propertiesPanel: { parent: panel } });
+```
+
+It returns `undefined` for engine-neutral diagrams that carry no platform
+metadata, so the caller owns the fallback policy.
+
 ## Linting tiers
 
 Linting is an opinionated built-in with a tier ladder, selected via

--- a/packages/bpmn-modeler/src/detectEngine.ts
+++ b/packages/bpmn-modeler/src/detectEngine.ts
@@ -1,0 +1,19 @@
+import { detectEngine as detectEngineCore, type DetectedEngine } from "@miragon/bpmn-modeler-types";
+
+export type { DetectedEngine };
+
+/**
+ * Detects the Camunda engine from raw BPMN XML using the spec-defined
+ * `modeler:executionPlatform` / `modeler:executionPlatformVersion` metadata, so
+ * a host can pick the {@link createModeler} `engine` before instantiating a
+ * modeler.
+ *
+ * Returns `undefined` for engine-neutral diagrams that carry no platform
+ * metadata — the caller owns the fallback policy.
+ *
+ * Thin local wrapper over the shared helper so the rolled-up `.d.ts` emits a
+ * clean ambient signature instead of inlining the implementation body.
+ */
+export function detectEngine(xml: string): DetectedEngine {
+    return detectEngineCore(xml);
+}

--- a/packages/bpmn-modeler/src/index.ts
+++ b/packages/bpmn-modeler/src/index.ts
@@ -37,6 +37,8 @@ export type {
     LintRunEvent,
 } from "@miragon/bpmn-modeler-types";
 export { NoModelerError } from "@miragon/bpmn-modeler-types";
+export { detectEngine } from "./detectEngine";
+export type { DetectedEngine } from "./detectEngine";
 export type { ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
 
 // ── Viewport / selection — public, referenced by the designed handle ─────────


### PR DESCRIPTION
## Summary

Step 3 of epic #1409's roadmap; closes #1404 (step 1 of the issue — the optional-`engine`-on-`createModeler` follow-up stays deferred until #1196's fallback-policy decision).

External hosts (bpm-iq) had to hand-roll XML sniffing to pick `engine: "c7" | "c8"` before calling `createModeler`, even though the signal is spec-defined and detected internally already.

## Changes

- **`libs/modeler-types/src/engine.ts`** — new `detectEngine(xml): DetectedEngine` next to `Engine` / `ENGINE_EXECUTION_PLATFORM` (single-sourced spec strings). Strict signals only: `modeler:executionPlatform` name first, then the `modeler:executionPlatformVersion` major digit; `undefined` otherwise — **no** `xmlns:camunda`/`xmlns:zeebe` heuristic, so the caller owns the fallback policy and #1196's planned "no platform metadata = design mode" marker stays clean.
- **`packages/bpmn-modeler`** — `detectEngine` + `DetectedEngine` exported from the root index via a thin local wrapper (`src/detectEngine.ts`); a direct re-export fails `check:dts` because the rollup would inline the implementation body.
- **`libs/modeler-core` convergence** — `BpmnDocument.detectPlatform()` now delegates to the shared helper for the `modeler:*` signals, keeping its xmlns fallback and `ExecutionPlatformNotDetectedError` on top. All six modeler-core detection call sites route through `BpmnDocument`, so this converges the hand-rolled logic in one place. The logic lives in `libs/modeler-types` (not package-local) because the architecture tests forbid `libs/*` importing the package.
- **README** — new "Detecting the engine from XML" subsection under Escape hatches.

## Verification

- `corepack yarn test` — 182 files / 2120 tests passed, including the new `engine.spec.ts` (name detection, version-digit fallback, name-wins-over-version precedence, undefined cases) and the extended `BpmnDocument.spec.ts`.
- `corepack yarn workspace @miragon/bpmn-modeler build` — typecheck, `check:dts` (both rolled-up d.ts clean), diff-node smoke pass.
- `corepack yarn lint` — 0 errors; no warnings in changed files.