### PR TITLE
fix(append-menu): restore flat menu entries under camunda-bpmn-js 5.33

### DIFF
--- a/libs/append-menu/src/AppendMenuOverride.ts
+++ b/libs/append-menu/src/AppendMenuOverride.ts
@@ -113,7 +113,10 @@ class AppendMenuOverride {
                 container.remove();
             };
 
-            const handleSelect = (action: PopupMenuEntryAction, event: Event) => {
+            const handleSelect = (
+                action: PopupMenuEntryAction | undefined,
+                event: Event,
+            ) => {
                 close();
                 customMenuOpen = false;
                 closeCustomMenu = null;

--- a/libs/append-menu/src/AppendMenuOverride.ts
+++ b/libs/append-menu/src/AppendMenuOverride.ts
@@ -113,10 +113,7 @@ class AppendMenuOverride {
                 container.remove();
             };
 
-            const handleSelect = (
-                action: PopupMenuEntryAction | undefined,
-                event: Event,
-            ) => {
+            const handleSelect = (action: PopupMenuEntryAction | undefined, event: Event) => {
                 close();
                 customMenuOpen = false;
                 closeCustomMenu = null;

--- a/libs/append-menu/src/components/AppendMenuOverlay.tsx
+++ b/libs/append-menu/src/components/AppendMenuOverlay.tsx
@@ -35,7 +35,7 @@ interface AppendMenuOverlayProps {
     favourites: string[];
     position: { x: number; y: number };
     canvasBounds: { right: number; bottom: number };
-    onSelect: (action: PopupMenuEntryAction, event: Event) => void;
+    onSelect: (action: PopupMenuEntryAction | undefined, event: Event) => void;
     onCancel: () => void;
 }
 
@@ -239,7 +239,7 @@ export function AppendMenuOverlay({
     // With a multi-type template selected, creates the element via the template's
     // action; otherwise creates a plain BPMN element.
     const handleBpmnSelect = useCallback(
-        (action: PopupMenuEntryAction, event: Event) => {
+        (action: PopupMenuEntryAction | undefined, event: Event) => {
             if (selectedTemplate) {
                 onSelect(selectedTemplate.entry.action, event);
             } else {

--- a/libs/append-menu/src/components/BpmnElementPalette.tsx
+++ b/libs/append-menu/src/components/BpmnElementPalette.tsx
@@ -19,7 +19,7 @@ interface BpmnElementPaletteProps {
     onToggleExpand: () => void;
     /** Reports hover-peek state so the parent can transiently expand the palette on hover. */
     onPeekChange?: (peek: boolean) => void;
-    onSelect: (action: PopupMenuEntryAction, event: Event) => void;
+    onSelect: (action: PopupMenuEntryAction | undefined, event: Event) => void;
 }
 
 /**

--- a/libs/append-menu/src/index.ts
+++ b/libs/append-menu/src/index.ts
@@ -18,4 +18,14 @@ import "./append-menu.css";
 export const AppendMenuModule = {
     __init__: ["appendMenuOverride"],
     appendMenuOverride: ["type", AppendMenuOverride],
+    // camunda-bpmn-js ≥5.33 adds popup-menu providers that regroup
+    // bpmn-append/bpmn-create into a drill-in category tree (and, on C8, tab
+    // metadata) the custom overlay can't consume. Redefining the provider DI
+    // names as inert values keeps those providers from ever constructing, so
+    // they never register — restoring the flat entry stream the overlay reads.
+    // bpmn-replace is left untouched (its default menu is not intercepted).
+    createGroupsProvider: ["value", null],
+    appendGroupsProvider: ["value", null],
+    createTabsProvider: ["value", null],
+    appendTabsProvider: ["value", null],
 };

--- a/libs/append-menu/src/types.spec.ts
+++ b/libs/append-menu/src/types.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { classifyEntries, executeEntryAction } from "./types";
+import type { PopupMenuEntry } from "./types";
+
+const noop = (): void => {};
+
+/** Builds a flat leaf entry with a `group` marker. */
+function leaf(label: string, group: { id: string; name: string }): PopupMenuEntry {
+    return { label, group, action: noop };
+}
+
+describe("classifyEntries", () => {
+    it("groups flat entries by their group marker", () => {
+        const tasks = { id: "tasks", name: "Tasks" };
+        const gateways = { id: "gateways", name: "Gateways" };
+
+        const { bpmnGroups, templates } = classifyEntries({
+            "append.user-task": leaf("User Task", tasks),
+            "append.service-task": leaf("Service Task", tasks),
+            "append.exclusive-gateway": leaf("Exclusive Gateway", gateways),
+        });
+
+        expect(templates).toHaveLength(0);
+        expect(bpmnGroups).toHaveLength(2);
+
+        const taskGroup = bpmnGroups.find((g) => g.id === "tasks");
+        expect(taskGroup?.name).toBe("Tasks");
+        expect(taskGroup?.entries.map((e) => e.id)).toEqual([
+            "append.user-task",
+            "append.service-task",
+        ]);
+        expect(bpmnGroups.find((g) => g.id === "gateways")?.entries).toHaveLength(1);
+    });
+
+    it("flattens camunda-5.33 drill-in categories, synthesizing a group from the category", () => {
+        // Children lost their `group` marker when the upstream provider nested
+        // them; the category entry carries no `action`.
+        const { bpmnGroups } = classifyEntries({
+            "append-tasks": {
+                label: "Tasks",
+                className: "bpmn-icon-task",
+                entries: {
+                    "append.user-task": { label: "User Task", action: noop },
+                    "append.service-task": { label: "Service Task", action: noop },
+                },
+            },
+        });
+
+        expect(bpmnGroups).toHaveLength(1);
+        expect(bpmnGroups[0]).toMatchObject({ id: "append-tasks", name: "Tasks" });
+        expect(bpmnGroups[0].entries.map((e) => e.id)).toEqual([
+            "append.user-task",
+            "append.service-task",
+        ]);
+    });
+
+    it("routes nested template-category children to the templates panel", () => {
+        const template = {
+            id: "my-template",
+            appliesTo: [],
+        } as never;
+
+        const { templates, bpmnGroups } = classifyEntries(
+            {
+                "append-templates": {
+                    label: "Templates",
+                    entries: {
+                        "append.template-my-template": {
+                            label: "My Template",
+                            action: noop,
+                        },
+                    },
+                },
+            },
+            [template],
+        );
+
+        expect(bpmnGroups).toHaveLength(0);
+        expect(templates).toHaveLength(1);
+        expect(templates[0].id).toBe("append.template-my-template");
+        expect(templates[0].template).toBe(template);
+    });
+
+    it("drops entries that have neither an action nor children", () => {
+        const { bpmnGroups, templates } = classifyEntries({
+            "bpmn-tab": { label: "BPMN" },
+            "append.user-task": leaf("User Task", { id: "tasks", name: "Tasks" }),
+        });
+
+        expect(templates).toHaveLength(0);
+        expect(bpmnGroups).toHaveLength(1);
+        expect(bpmnGroups[0].entries).toHaveLength(1);
+        expect(bpmnGroups[0].entries[0].id).toBe("append.user-task");
+    });
+});
+
+describe("executeEntryAction", () => {
+    it("does not throw for an undefined action", () => {
+        expect(() => executeEntryAction(undefined, new Event("click"))).not.toThrow();
+    });
+
+    it("invokes a plain function action", () => {
+        const action = vi.fn();
+        const event = new Event("click");
+        executeEntryAction(action, event);
+        expect(action).toHaveBeenCalledWith(event);
+    });
+
+    it("invokes the click handler of an object action", () => {
+        const click = vi.fn();
+        const event = new Event("click");
+        executeEntryAction({ click }, event);
+        expect(click).toHaveBeenCalledWith(event);
+    });
+});

--- a/libs/append-menu/src/types.ts
+++ b/libs/append-menu/src/types.ts
@@ -171,10 +171,7 @@ export function classifyEntries(
  * Handles both the plain function form and the `{ click, dragstart }` object
  * form used by different providers.
  */
-export function executeEntryAction(
-    action: PopupMenuEntryAction | undefined,
-    event: Event,
-): void {
+export function executeEntryAction(action: PopupMenuEntryAction | undefined, event: Event): void {
     if (!action) {
         return;
     }

--- a/libs/append-menu/src/types.ts
+++ b/libs/append-menu/src/types.ts
@@ -32,10 +32,16 @@ export interface PopupMenuEntry {
     group?: { id: string; name: string };
     search?: string[];
     rank?: number;
-    action: PopupMenuEntryAction;
+    action?: PopupMenuEntryAction;
     imageUrl?: string;
     documentationRef?: string;
     disabled?: boolean;
+    /**
+     * Present on drill-in category entries produced by camunda-bpmn-js ≥5.33
+     * grouping providers. Such entries carry no `action`; their leaf children
+     * live here (and typically lost their own `group` marker).
+     */
+    entries?: Record<string, PopupMenuEntry>;
 }
 
 /**
@@ -105,7 +111,22 @@ export function classifyEntries(
         templateIndex.set(t.id, t);
     }
 
-    for (const [key, entry] of Object.entries(entries)) {
+    // Classifies a single entry. `inheritedGroup` is the group synthesized from
+    // an enclosing camunda-5.33 drill-in category, applied to children that lost
+    // their own `group` marker when the upstream provider nested them.
+    const classify = (
+        key: string,
+        entry: PopupMenuEntry,
+        inheritedGroup?: { id: string; name: string },
+    ): void => {
+        if (entry.entries) {
+            const categoryGroup = { id: key, name: entry.label };
+            for (const [childKey, child] of Object.entries(entry.entries)) {
+                classify(childKey, child, categoryGroup);
+            }
+            return;
+        }
+
         if (isTemplateEntry(key, entry)) {
             const templateId = extractTemplateId(key);
             templates.push({
@@ -113,17 +134,29 @@ export function classifyEntries(
                 entry,
                 template: templateId ? templateIndex.get(templateId) : undefined,
             });
-        } else {
-            const groupId = entry.group?.id ?? "other";
-            const groupName = entry.group?.name ?? "Other";
-
-            let group = groupMap.get(groupId);
-            if (!group) {
-                group = { id: groupId, name: groupName, entries: [] };
-                groupMap.set(groupId, group);
-            }
-            group.entries.push({ id: key, entry });
+            return;
         }
+
+        // A non-template entry with neither an action nor children is a tab
+        // header or other non-selectable artifact — skip it.
+        if (!entry.action) {
+            return;
+        }
+
+        const group = entry.group ?? inheritedGroup;
+        const groupId = group?.id ?? "other";
+        const groupName = group?.name ?? "Other";
+
+        let bpmnGroup = groupMap.get(groupId);
+        if (!bpmnGroup) {
+            bpmnGroup = { id: groupId, name: groupName, entries: [] };
+            groupMap.set(groupId, bpmnGroup);
+        }
+        bpmnGroup.entries.push({ id: key, entry });
+    };
+
+    for (const [key, entry] of Object.entries(entries)) {
+        classify(key, entry);
     }
 
     return {
@@ -138,7 +171,13 @@ export function classifyEntries(
  * Handles both the plain function form and the `{ click, dragstart }` object
  * form used by different providers.
  */
-export function executeEntryAction(action: PopupMenuEntryAction, event: Event): void {
+export function executeEntryAction(
+    action: PopupMenuEntryAction | undefined,
+    event: Event,
+): void {
+    if (!action) {
+        return;
+    }
     if (typeof action === "function") {
         action(event);
     } else if (action.click) {


### PR DESCRIPTION
## Issue

The bpmn-js/camunda-bpmn-js bump in #1414 broke the custom append/create menu: BPMN elements were hidden behind dead "Tasks"/"Gateways" rows and clicking one threw `TypeError: Cannot read properties of undefined (reading 'click')`.

## Description

camunda-bpmn-js 5.33 added popup-menu providers (`CreateAppendGroupsProvider`, plus `CreateAppendTabsProvider` on C8) that regroup the flat `bpmn-append`/`bpmn-create` entries into a drill-in category tree whose category entries carry no `action`, which our overlay misclassified as leaves. This PR neutralises those providers via DI value overrides in `AppendMenuModule` (the overlay does its own grouping; `bpmn-replace` stays untouched), restoring the flat entry stream. As defence in depth, `classifyEntries` now flattens nested category entries (children inherit the category as their group) and skips non-selectable entries, and `executeEntryAction` guards against a missing action — covered by a new `types.spec.ts`.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
