### PR TITLE
feat(bpmn-modeler): theme per instance via data-bpmn-theme attribute

### DIFF
--- a/.agent/skills/bpmn-js/SKILL.md
+++ b/.agent/skills/bpmn-js/SKILL.md
@@ -161,11 +161,15 @@ Applied via `bpmnModeler.setSettings()`, which merges the partial settings and i
 
 ## Theme Handling
 
-The webview detects the VS Code theme (light/dark) and swaps stylesheets:
-- Light: `lightTheme.css`
-- Dark: `darkTheme.css`
-
-Theme detection uses `document.body.classList` — checking for `vscode-dark` or `vscode-high-contrast` classes that VS Code injects on every webview's `<body>`. A `MutationObserver` on the body's `class` attribute reacts to live theme changes.
+The BPMN webview themes each modeler **instance** through `@miragon/bpmn-modeler`
+(ADR 0012), not by swapping a page stylesheet. The theme CSS (unscoped light base
++ `[data-bpmn-theme="dark"]`-scoped dark overrides) ships inside the main bundle,
+and the package toggles a `data-bpmn-theme` attribute on the instance's container
++ properties-panel parent. `apps/bpmn-webview/src/hostTheme.ts` resolves the IDE
+kind from the VS Code body classes (`vscode-dark` / `vscode-high-contrast`,
+watched by a `MutationObserver`) and drives both the page-level scope and the
+instance's `setTheme`. (DMN still swaps `lightTheme.css` / `darkTheme.css` via
+`#theme-link` — its dmn-js CSS is not in the package.)
 
 ## Key Files
 

--- a/.agent/skills/vscode-ux-guidelines/SKILL.md
+++ b/.agent/skills/vscode-ux-guidelines/SKILL.md
@@ -185,9 +185,9 @@ channels because `createClipboardModules` defaults `text` to `element`.
 
 Webviews **must** respect the user's VS Code theme:
 
-- BPMN/DMN webviews ship `lightTheme.css` and `darkTheme.css`
-- Theme detection via VS Code's body classes — `document.body.classList.contains("vscode-dark")` / `"vscode-high-contrast"` (`libs/shared/src/lib/theme.ts`), watched by a `MutationObserver` on the body `class` attribute
-- Initial HTML loads light theme; JS swaps stylesheet on init
+- Theme detection via VS Code's body classes — `document.body.classList.contains("vscode-dark")` / `"vscode-high-contrast"`, watched by a `MutationObserver` on the body `class` attribute
+- BPMN themes per-instance via `@miragon/bpmn-modeler`'s `data-bpmn-theme` attribute (theme CSS is in the bundle, no `#theme-link`; adapter in `apps/bpmn-webview/src/hostTheme.ts`) — see ADR 0012
+- DMN still ships `lightTheme.css` / `darkTheme.css` and swaps the `#theme-link` (`libs/modeler-types/src/theme.ts`); initial HTML loads light, JS swaps on init
 - Use VS Code CSS custom properties (`--vscode-*`) for colors when possible
 - Test with light, dark, and high-contrast themes
 - See the vscode-webviews skill for implementation details

--- a/.agent/skills/vscode-webviews/SKILL.md
+++ b/.agent/skills/vscode-webviews/SKILL.md
@@ -19,7 +19,7 @@ Webview HTML is generated at runtime by functions in the infrastructure layer, n
 
 2. **Nonce generation** — A random nonce is generated per HTML render and embedded in both the CSP meta tag and script tags. Only scripts with the matching nonce can execute.
 
-3. **Theme stylesheet** — The initial HTML loads `lightTheme.css`. The webview's JavaScript detects the actual VS Code theme at startup and swaps the stylesheet link if needed.
+3. **Theme** — The **BPMN** webview themes per-instance: the theme CSS ships inside the main `index.css` bundle and its host adapter (`apps/bpmn-webview/src/hostTheme.ts`) sets a `data-bpmn-theme` attribute from the VS Code body classes — no `#theme-link`. The **DMN** webview still loads `lightTheme.css` and swaps the `#theme-link` href at startup (dmn-js CSS is not in the package). See ADR 0012.
 
 ### Deployment Webview (`DeploymentWebviewHtml.ts`)
 
@@ -226,17 +226,28 @@ VS Code adds a theme **class** to `document.body` (not a `data-` attribute):
 - `vscode-dark` — dark theme
 - `vscode-high-contrast` — high contrast
 
-`libs/shared/src/lib/theme.ts` reads these with
+Both host adapters read these with
 `document.body.classList.contains("vscode-dark")` /
-`"vscode-high-contrast")` and installs a `MutationObserver` on the body
+`"vscode-high-contrast")` and install a `MutationObserver` on the body
 `class` attribute to re-apply the theme when the user switches it live.
 
-### Stylesheet Swap
+### BPMN: per-instance `data-bpmn-theme` attribute
 
-The webview ships two CSS files (`lightTheme.css`, `darkTheme.css`). On initialization:
+The BPMN webview themes each modeler **instance** through `@miragon/bpmn-modeler`
+(ADR 0012). The theme CSS (unscoped light base + `[data-bpmn-theme="dark"]`-scoped
+dark overrides) is folded into the main `index.css` bundle, so there is no
+`#theme-link`. `apps/bpmn-webview/src/hostTheme.ts` resolves the IDE kind from the
+body classes and drives two sinks: the page-level scope on `<html>` (host chrome
++ the viewer/diff branch) and the modeler instance's `setTheme`.
+
+### DMN: `#theme-link` stylesheet swap
+
+The DMN webview still ships two CSS files (`lightTheme.css`, `darkTheme.css`) and
+swaps them, because dmn-js theme CSS is not in the package. `libs/modeler-types/src/theme.ts`
+is the retained DMN-only adapter. On initialization:
 
 1. Read the body theme classes (`classList.contains("vscode-dark")` / `"vscode-high-contrast"`)
-2. Set the `<link>` element's `href` to the matching stylesheet
+2. Set the `#theme-link` element's `href` to the matching stylesheet
 3. The initial HTML always references `lightTheme.css`; the JS swaps if needed
 4. A `MutationObserver` on the body `class` attribute repeats the swap on live theme changes
 

--- a/apps/bpmn-webview/index.html
+++ b/apps/bpmn-webview/index.html
@@ -3,11 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link
-            href="../../packages/bpmn-modeler/src/styles/light-theme/index.css"
-            id="theme-link"
-            rel="stylesheet"
-        />
         <meta content="width=device-width, initial-scale=1.0" name="viewport" />
         <title>BPMN Modeler</title>
     </head>
@@ -34,16 +29,13 @@
     Dev-only theme switch for the standalone browser preview (`yarn ... serve`).
     Hosts (VS Code / IntelliJ / Theia) inject their own HTML and never load this
     shell, so this affects local preview only. Open `?theme=dark` to exercise the
-    dark stylesheet — the only way to hit dark-mode regressions (e.g. #1199)
-    without launching a host, since FakeHost otherwise forces the light theme.
-    Runs before the deferred module below, so initTheme() sees `vscode-dark`.
+    dark theme — the only way to hit dark-mode regressions (e.g. #1199) without
+    launching a host, since FakeHost otherwise forces the light theme. Runs before
+    the deferred module below, so the host theme adapter sees `vscode-dark`.
 -->
         <script>
             if (new URLSearchParams(location.search).get("theme") === "dark") {
                 document.body.classList.add("vscode-dark");
-                const link = document.getElementById("theme-link");
-                if (link)
-                    link.href = link.getAttribute("href").replace("light-theme", "dark-theme");
             }
         </script>
         <script src="/src/main.ts" type="module"></script>

--- a/apps/bpmn-webview/src/bootstrap.spec.ts
+++ b/apps/bpmn-webview/src/bootstrap.spec.ts
@@ -34,10 +34,8 @@ vi.mock("@miragon/bpmn-modeler-types", async (importOriginal) => {
     return {
         ...actual,
         initResizer: mocks.initResizer,
-        initTheme: vi.fn(),
         installPanelShortcuts: vi.fn(),
         observeCanvasSize: vi.fn(),
-        setColorThemeMode: vi.fn(),
     };
 });
 
@@ -218,6 +216,7 @@ describe("bootstrap host document initialization", () => {
             onWarning: vi.fn(),
             setElementTemplates: vi.fn(),
             setSettings: vi.fn(),
+            setTheme: vi.fn(),
             getService: vi.fn(() => canvas),
             viewport: { centerOnElement: vi.fn() },
         };
@@ -369,6 +368,7 @@ describe("bootstrap host document initialization", () => {
             onCommandStackChanged: vi.fn(),
             setElementTemplates: vi.fn(),
             setSettings: vi.fn(),
+            setTheme: vi.fn(),
             getService: vi.fn(() => canvas),
             viewport: { centerOnElement: vi.fn() },
         };
@@ -465,6 +465,7 @@ describe("bootstrap host document initialization", () => {
             }),
             setElementTemplates: vi.fn(),
             setSettings: vi.fn(),
+            setTheme: vi.fn(),
             getService: vi.fn(() => canvas),
             getDefinitions: vi.fn(() => ({})),
             viewport: { centerOnElement },

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -54,12 +54,16 @@ import {
     asyncDebounce,
     formatErrors,
     initResizer,
-    initTheme,
     installPanelShortcuts,
     observeCanvasSize,
     serializeAsync,
-    setColorThemeMode,
 } from "@miragon/bpmn-modeler-types";
+import {
+    type HostThemeAdapter,
+    applyPageThemeScope,
+    createHostThemeAdapter,
+    resolveHostThemeKind,
+} from "./hostTheme";
 import { i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
 import { BpmnModeler, createModeler, UnsupportedEngineError } from "@miragon/bpmn-modeler";
 import type { ClipboardOptions, LintingOptions, ModelerCapabilities } from "@miragon/bpmn-modeler";
@@ -154,6 +158,9 @@ function startSession(
     let latestBpmnFileQuery: BpmnFileQuery | undefined;
     let refreshDiagramWhenReady = false;
     let modelerEngine: Engine | undefined;
+    // Host theme adapter (VS Code `<body>` class → page scope + instance theme).
+    // Created in run(); the settings handler switches its mode on `colorTheme`.
+    let themeAdapter: HostThemeAdapter | undefined;
     let engineReloadPending = false;
     let pendingSessionActionDrain: Promise<void> | undefined;
     let cancelPendingVariablePublish: (() => void) | undefined;
@@ -465,7 +472,16 @@ function startSession(
         // legend, whose keys ship in the base @miragon/bpmn-modeler-i18n package
         // — not the overlay — so it needs no extend here.
 
-        initTheme();
+        // Theme is host policy: drive the page-level scope (host chrome + the
+        // viewer/diff branch, which has no modeler) and the modeler instance's
+        // own theme off the VS Code `<body>`-class signal. The instance is also
+        // born correct via `theme: resolveHostThemeKind()` below, so this mainly
+        // covers the page chrome and later live theme switches.
+        themeAdapter = createHostThemeAdapter((kind) => {
+            applyPageThemeScope(kind);
+            bpmnModeler?.setTheme(kind);
+        });
+        themeAdapter.setMode("automatic");
 
         // Viewer mode (one side of a diff view) skips the resizer + properties
         // panel + palette, so we don't call initResizer() here — the chrome is
@@ -597,6 +613,10 @@ function startSession(
         try {
             bpmnModeler = await createModeler(canvasEl, {
                 engine,
+                // Born in the IDE's theme so the first frame paints correctly.
+                // The body class is the IDE signal (a media query would follow
+                // the OS, not the IDE), so a forced kind — not "automatic".
+                theme: resolveHostThemeKind(),
                 propertiesPanel: { parent: propertiesPanelParent },
                 additionalModules: extraModules,
                 clipboard,
@@ -983,10 +1003,10 @@ function startSession(
             case queryOrCommand.type === "BpmnModelerSettingQuery": {
                 const query = message.data as BpmnModelerSettingQuery;
                 try {
-                    // Theme is host policy: the adapter drives the page theme off
-                    // the VS Code `<body>`-class watcher (initTheme) here, because
-                    // the package's setSettings does not apply `colorTheme`.
-                    setColorThemeMode(query.setting.colorTheme);
+                    // Theme is host policy: the adapter drives the page scope +
+                    // instance theme off the VS Code `<body>`-class watcher here,
+                    // because the package's setSettings does not apply `colorTheme`.
+                    themeAdapter?.setMode(query.setting.colorTheme);
                     bpmnModeler.setSettings(query.setting);
                 } catch (error: any) {
                     host.postMessage(new LogErrorCommand(errorPrefix + error.message));

--- a/apps/bpmn-webview/src/hostTheme.ts
+++ b/apps/bpmn-webview/src/hostTheme.ts
@@ -1,0 +1,92 @@
+/**
+ * VS Code `<body>`-class theme adapter for the BPMN webview host.
+ *
+ * `@miragon/bpmn-modeler` themes each modeler instance through its
+ * `data-bpmn-theme` attribute and never reads host chrome. This adapter is the
+ * host half of that contract: it resolves the IDE's light/dark signal from the
+ * `vscode-*` body classes (VS Code injects them; the IntelliJ host impersonates
+ * them) and drives two sinks — the page-level scope on `<html>` (for the host
+ * chrome and the viewer/diff branch, which has no modeler instance) and the
+ * modeler instance's own `setTheme`.
+ *
+ * App code may read `vscode-*` classes; the package's architecture gate only
+ * forbids them inside the published package source.
+ */
+
+export type HostThemeKind = "light" | "dark";
+type HostThemeMode = "automatic" | "light" | "dark";
+
+/** Resolves the IDE theme from the VS Code `<body>` classes. */
+export function resolveHostThemeKind(): HostThemeKind {
+    const isDark =
+        document.body.classList.contains("vscode-dark") ||
+        document.body.classList.contains("vscode-high-contrast");
+    return isDark ? "dark" : "light";
+}
+
+/**
+ * Sets the page-level `data-bpmn-theme` on `<html>`, scoping the host chrome
+ * (page background, panel dividers) and — until #1405 gives it an instance — the
+ * viewer/diff branch.
+ */
+export function applyPageThemeScope(kind: HostThemeKind): void {
+    document.documentElement.setAttribute("data-bpmn-theme", kind);
+}
+
+export interface HostThemeAdapter {
+    /**
+     * `"automatic"` follows the VS Code `<body>` class live via a
+     * MutationObserver; a forced `"light"`/`"dark"` stops the observer so the
+     * fixed choice is not overwritten on the next `<body>`-class mutation.
+     */
+    setMode(mode: HostThemeMode): void;
+    dispose(): void;
+}
+
+/**
+ * Builds an adapter that invokes `apply` with the resolved kind whenever the
+ * mode or (in automatic mode) the live `<body>` class changes. `mode` starts
+ * `undefined`, so a first `setMode("automatic")` engages rather than
+ * short-circuiting on the same-mode guard.
+ */
+export function createHostThemeAdapter(apply: (kind: HostThemeKind) => void): HostThemeAdapter {
+    let currentMode: HostThemeMode | undefined;
+    let observer: MutationObserver | undefined;
+
+    const startObserver = (): void => {
+        if (observer) {
+            return;
+        }
+        observer = new MutationObserver(() => {
+            if (currentMode === "automatic") {
+                apply(resolveHostThemeKind());
+            }
+        });
+        observer.observe(document.body, { attributes: true, attributeFilter: ["class"] });
+    };
+
+    const stopObserver = (): void => {
+        observer?.disconnect();
+        observer = undefined;
+    };
+
+    return {
+        setMode(mode: HostThemeMode): void {
+            if (mode === currentMode) {
+                return;
+            }
+            currentMode = mode;
+
+            if (mode === "automatic") {
+                apply(resolveHostThemeKind());
+                startObserver();
+            } else {
+                stopObserver();
+                apply(mode);
+            }
+        },
+        dispose(): void {
+            stopObserver();
+        },
+    };
+}

--- a/apps/bpmn-webview/vite.config.mts
+++ b/apps/bpmn-webview/vite.config.mts
@@ -44,16 +44,12 @@ export default defineConfig({
         outDir: "../../dist/webview-staging/bpmn-webview",
         emptyOutDir: true,
         rollupOptions: {
+            // No separate lightTheme/darkTheme entries: theming is per-instance
+            // via the package's `data-bpmn-theme` attribute, and the theme CSS is
+            // folded into the main bundle through the package's `themes.css`
+            // import — the host shells no longer link a `#theme-link`.
             input: {
                 index: resolve(__dirname, "src/main.ts"),
-                lightTheme: resolve(
-                    __dirname,
-                    "../../packages/bpmn-modeler/src/styles/light-theme/index.css",
-                ),
-                darkTheme: resolve(
-                    __dirname,
-                    "../../packages/bpmn-modeler/src/styles/dark-theme/index.css",
-                ),
             },
             output: {
                 entryFileNames: `[name].js`,

--- a/apps/demo-webapp/bpmn/dual.html
+++ b/apps/demo-webapp/bpmn/dual.html
@@ -3,11 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link
-            href="../../../packages/bpmn-modeler/src/styles/light-theme/index.css"
-            id="theme-link"
-            rel="stylesheet"
-        />
         <meta content="width=device-width, initial-scale=1.0" name="viewport" />
         <title>Miragon Modeler — Dual Instance Demo</title>
         <style>

--- a/apps/demo-webapp/bpmn/dual.ts
+++ b/apps/demo-webapp/bpmn/dual.ts
@@ -40,6 +40,28 @@ const C8_XML = `<?xml version="1.0" encoding="UTF-8"?>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>`;
 
+/**
+ * A per-pane light/dark toggle wired to that instance's `handle.setTheme(...)`.
+ * This is the living regression check for per-instance theming: flipping one
+ * pane must not touch the other (the `data-bpmn-theme` attribute is scoped to
+ * each instance's container + panel, not the page).
+ */
+function mountThemeToggle(
+    container: HTMLElement,
+    modeler: { setTheme(t: "light" | "dark"): void },
+): void {
+    let dark = false;
+    const button = document.createElement("button");
+    button.textContent = "◐ theme";
+    button.style.cssText =
+        "position:absolute;top:8px;right:8px;z-index:10;padding:4px 8px;cursor:pointer";
+    button.addEventListener("click", () => {
+        dark = !dark;
+        modeler.setTheme(dark ? "dark" : "light");
+    });
+    container.appendChild(button);
+}
+
 /** Stands up one modeler bound to the given canvas + panel elements. */
 async function mount(
     canvasId: string,
@@ -62,6 +84,7 @@ async function mount(
         propertiesPanel: { parent: propertiesPanelParent },
     });
     await modeler.loadDiagram(xml);
+    mountThemeToggle(container, modeler);
 }
 
 // Left pane: the bundled C7 demo model. Right pane: the inline C8 diagram.

--- a/apps/demo-webapp/bpmn/index.html
+++ b/apps/demo-webapp/bpmn/index.html
@@ -3,11 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link
-            href="../../../packages/bpmn-modeler/src/styles/light-theme/index.css"
-            id="theme-link"
-            rel="stylesheet"
-        />
         <meta content="width=device-width, initial-scale=1.0" name="viewport" />
         <title>Miragon Modeler Demo</title>
     </head>

--- a/apps/demo-webapp/src/demoHeader.ts
+++ b/apps/demo-webapp/src/demoHeader.ts
@@ -32,16 +32,6 @@ export function mountDemoHeader(page: DemoPage, links: Partial<DemoHeaderLinks> 
     // default bpmn model so users always land somewhere sensible.
     const modelerHref = isDiff ? DEFAULT_MODELER_HREF : modelHref(getActiveModel(page));
 
-    // The webview shells strip the shell's #theme-link; add a no-op so the
-    // shared applyTheme() lookup succeeds silently (the demo is light-only).
-    if (!document.getElementById("theme-link")) {
-        const themeLink = document.createElement("link");
-        themeLink.id = "theme-link";
-        themeLink.rel = "stylesheet";
-        themeLink.href = "data:text/css,";
-        document.head.appendChild(themeLink);
-    }
-
     const style = document.createElement("style");
     // Colour tokens mirror Miragon/corporate-identity (brand/tokens.json).
     style.textContent = `

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WebviewServer.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WebviewServer.kt
@@ -132,14 +132,17 @@ class WebviewServer : Disposable {
      */
     private fun indexHtml(): String {
         val signal = service<IdeThemeSignal>()
+        // Page-level theme scope baked in so the first frame paints correctly (no
+        // light flash). Theming is per-instance via `data-bpmn-theme`; the theme
+        // CSS ships inside `/index.css`, so there is no `#theme-link` to swap.
+        val themeKind = if (signal.isDark()) "dark" else "light"
         return listOf(
             "<!DOCTYPE html>",
-            "<html lang=\"en\">",
+            "<html lang=\"en\" data-bpmn-theme=\"$themeKind\">",
             "<head>",
             "  <meta charset=\"UTF-8\"/>",
             "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"/>",
             "  <link href=\"/index.css\" rel=\"stylesheet\"/>",
-            "  <link href=\"/lightTheme.css\" rel=\"stylesheet\" id=\"theme-link\"/>",
             "  <title>BPMN Modeler</title>",
             "  <style>html, body { margin: 0; height: 100%; } #app { height: 100vh; }</style>",
             "  <style id=\"ide-theme-vars\">${signal.themeVarsCss()}</style>",

--- a/apps/vscode-plugin/src/shared/infrastructure/WebviewHtml.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/WebviewHtml.ts
@@ -9,9 +9,9 @@ const FORM_WEBVIEW_PATH = "form-webview";
 
 /**
  * Generates the HTML for the BPMN modeler webview, resolving asset URIs relative
- * to the extension's install directory. The initial theme stylesheet is always
- * `lightTheme.css`; the webview's own `initTheme()` swaps it to the correct
- * theme at runtime from VS Code's body CSS classes.
+ * to the extension's install directory. Theming is per-instance: the theme CSS
+ * ships inside the main `index.css` bundle and the webview's host adapter sets
+ * `data-bpmn-theme` from VS Code's body CSS classes — no `#theme-link` here.
  *
  * `initialPanelVisible` is the host's global properties-panel default seeding a
  * first-ever open: when `false`, the panel and its resizer render with the
@@ -29,7 +29,6 @@ export function bpmnEditorUi(
 
     const scriptUri = webview.asWebviewUri(Uri.joinPath(baseUri, "index.js"));
     const styleUri = webview.asWebviewUri(Uri.joinPath(baseUri, "index.css"));
-    const themeUri = webview.asWebviewUri(Uri.joinPath(baseUri, "lightTheme.css"));
 
     const nonce = getNonce();
     const panelClass = initialPanelVisible
@@ -48,7 +47,6 @@ export function bpmnEditorUi(
                 <meta charset="UTF-8"/>
                 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
                 <link href="${styleUri}" rel="stylesheet"/>
-                <link href="${themeUri}" rel="stylesheet" id="theme-link"/>
                 <title>BPMN Modeler</title>
             </head>
             <body>

--- a/docs/adr/0012-container-scoped-theming.md
+++ b/docs/adr/0012-container-scoped-theming.md
@@ -1,0 +1,77 @@
+# 0012 — Container-scoped theming via a per-instance `data-bpmn-theme` attribute
+
+- Status: accepted (#1406)
+- Date: 2026-09-01
+- Category: bpmn-webview
+
+Step 4 of the modeler-roadmap epic (#1409). Per-instance theming is the
+foundation the upcoming viewer (#1405) and design mode (#1196) sit on.
+
+## Context
+
+`@miragon/bpmn-modeler` themed the page by mutating a **global**
+`<link id="theme-link">` — a regex swap of `lightTheme.css` ↔ `darkTheme.css`
+in its href. This shape had three problems:
+
+- **A page singleton contradicting a per-instance API.** `theme` /
+  `setTheme` are documented per-instance, but one `#theme-link` can only hold
+  one theme, so two modelers on a page could never differ.
+- **Broken for single-file hosts.** With no external files (data-URI or inlined
+  hrefs) the swap silently no-ops, and an absent `#theme-link` logged a
+  `console.error` — the exact failure the demo shell papered over with a no-op
+  data-URI shim.
+- **Dead code in-repo.** No host passed `options.theme`; hosts ran a *duplicate*
+  swapper in `libs/modeler-types` off the VS Code `<body>` classes.
+
+## Decision
+
+**A `data-bpmn-theme="light" | "dark"` attribute is the authoritative
+mechanism.** A per-instance `ThemeController` toggles it on the instance's scope
+roots (canvas container + `propertiesPanel.parent`); the dark stylesheet's rules
+are all scoped under `[data-bpmn-theme="dark"]`, so theming one instance never
+leaks onto another. `createModeler` always engages theming
+(`options.theme ?? "automatic"`), so an instance carries the attribute from the
+first frame.
+
+- **One authored CSS source, two shapes.** The dark overrides are authored
+  *scoped* under `[data-bpmn-theme="dark"]`. `themes.css` (folded into
+  `dist/bpmn-modeler.css` via `src/index.ts`) merges the unscoped upstream light
+  base with those scoped overrides — so loading `styles.css` is all a consumer
+  needs, no extra `<link>`. The legacy split `lightTheme.css` / `darkTheme.css`
+  are derived by a PostCSS plugin (`postcss-strip-theme-scope.mjs`) that strips
+  the scope from the same source, keeping a single source of truth.
+- **The `#theme-link` swap stays as a permanent legacy fallback.** It is still
+  mirrored when present, but is now a **silent** no-op when absent (no
+  `console.error`) — the attribute mechanism stands on its own.
+- **Overlays that leave the themed subtree copy the attribute.** The append-menu
+  (mounts on `document.body`) and element-template-chooser (mounts on the canvas
+  parent) overlays copy `data-bpmn-theme` from
+  `closest("[data-bpmn-theme]")` onto their own root at creation.
+- **Page chrome is the host's job.** The `html`/`body` background, panel
+  resizers, and `.properties-panel-parent` border key off the root attribute a
+  **host adapter** (`apps/bpmn-webview/hostTheme.ts`) sets on
+  `document.documentElement` — not the package. That adapter also themes the
+  viewer/diff branch, which has no modeler instance until #1405.
+- **DMN is unchanged.** dmn-js theme CSS does not ship inside the package, so the
+  DMN webview keeps the `libs/modeler-types` `#theme-link` adapter verbatim.
+
+## Alternatives considered
+
+- **`color-scheme` / `light-dark()` CSS.** The cleanest long-term shape, but
+  deferred: it needs Chromium ≥123, and the IntelliJ host's JCEF is not yet
+  there. The `--dt-*` custom-property + `[data-bpmn-theme]` approach works on
+  every host today and can migrate later.
+- **Two hand-authored sheets (scoped + legacy split).** Rejected — it doubles
+  the ~750 lines of dark overrides and invites drift. Deriving the legacy split
+  by stripping the scope keeps one source.
+- **Deleting the `#theme-link` swap outright.** Rejected — it would break
+  out-of-repo consumers that link the split sheets. Kept as a permanent,
+  un-deprecated fallback.
+
+## Consequences
+
+- Theming now always engages: consumers who pinned a dark `#theme-link` and
+  omitted `theme` relied on the old default being a no-op — they now get
+  `"automatic"`. Passing `theme: "light"` / `"dark"` pins a fixed kind.
+- A page that sets `data-bpmn-theme` on a **root** element *and* mixes
+  per-instance themes would leak the root value; no in-repo host does this.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,3 +49,4 @@ contributor-facing record, not user documentation.
 | [0008](0008-public-diff-api.md) | Public diff API: serializable `computeDiff` data layer, promoted primitives, in-page coordinator | accepted |
 | [0010](0010-expose-reference-availability-through-navigation-port.md) | Expose reference availability through the model navigation port | accepted |
 | [0011](0011-stable-core-service-contract.md) | Freeze a typed, semver-covered contract for the seven core bpmn-js services reached via `getService` | accepted |
+| [0012](0012-container-scoped-theming.md) | Container-scoped theming via a per-instance `data-bpmn-theme` attribute; `#theme-link` swap kept as permanent legacy fallback | accepted |

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -26,7 +26,10 @@
         // Pack-and-install smoke test: copied into a scratch dir and run by
         // publish-npm-modeler.yml (`node smoke-consumer.mjs`), never imported and
         // not a package.json script, so knip reads it as unused.
-        "packages/bpmn-modeler/scripts/smoke-consumer.mjs"
+        "packages/bpmn-modeler/scripts/smoke-consumer.mjs",
+        // Type declarations for the postcss plugin .mjs; reached only through
+        // TS declaration resolution (sibling lookup), which knip does not track.
+        "packages/bpmn-modeler/scripts/postcss-strip-theme-scope.d.mts"
     ],
     "ignoreWorkspaces": ["apps/standalone"],
     "workspaces": {

--- a/libs/append-menu/src/AppendMenuOverride.ts
+++ b/libs/append-menu/src/AppendMenuOverride.ts
@@ -106,6 +106,15 @@ class AppendMenuOverride {
             // the properties panel (which is a sibling of the canvas).
             const container = document.createElement("div");
             container.className = "am-overlay-root";
+            // The overlay leaves the instance's themed subtree, so copy the
+            // instance's `data-bpmn-theme` onto its own root — otherwise a dark
+            // instance would show a light append menu.
+            const themeKind = canvasContainer
+                .closest("[data-bpmn-theme]")
+                ?.getAttribute("data-bpmn-theme");
+            if (themeKind) {
+                container.setAttribute("data-bpmn-theme", themeKind);
+            }
             document.body.appendChild(container);
 
             const close = () => {

--- a/libs/element-template-chooser/src/ElementTemplateChooser.ts
+++ b/libs/element-template-chooser/src/ElementTemplateChooser.ts
@@ -60,6 +60,15 @@ class ElementTemplateChooser {
             const container = document.createElement("div");
             container.className = "etc-overlay-root";
             const canvasContainer: HTMLElement = canvas.getContainer();
+            // The overlay mounts on the canvas parent, outside the instance's
+            // themed container, so copy the instance's `data-bpmn-theme` onto its
+            // own root — otherwise a dark instance would show a light chooser.
+            const themeKind = canvasContainer
+                .closest("[data-bpmn-theme]")
+                ?.getAttribute("data-bpmn-theme");
+            if (themeKind) {
+                container.setAttribute("data-bpmn-theme", themeKind);
+            }
             canvasContainer.parentElement!.appendChild(container);
 
             const close = () => {

--- a/libs/modeler-types/src/theme.ts
+++ b/libs/modeler-types/src/theme.ts
@@ -1,21 +1,19 @@
 /**
- * Manages the BPMN modeler color theme based on VS Code theme or user preference.
+ * DMN-only legacy `#theme-link` adapter, driven by VS Code `<body>` classes.
  *
  * Supports three modes:
  * - `"automatic"`: follows the VS Code theme via a MutationObserver on `<body>`.
- * - `"light"`: always uses the default bpmn-js light theme.
- * - `"dark"`: always forces the dark theme (the injected per-instance `theme`
- *   option).
+ * - `"light"`: always uses the default dmn-js light theme.
+ * - `"dark"`: always forces the dark theme.
  *
  * VS Code injects `vscode-dark`, `vscode-light`, or `vscode-high-contrast`
  * onto `<body>` in every webview.
  *
  * @internal Host-specific and module-singleton — reads VS Code `<body>` classes
- *   and mutates a single `#theme-link`, so it is not part of the modeler public
- *   API. It is the VS Code body-class watcher the bpmn/dmn host adapters own: the
- *   adapter maps the `<body>` class to a forced light/dark and hands that to the
- *   modeler, so the publishable `@miragon/bpmn-modeler` package never reads host
- *   chrome itself.
+ *   and mutates a single `#theme-link`. This is retained **only** for the DMN
+ *   webview, whose dmn-js theme CSS does not ship inside `@miragon/bpmn-modeler`.
+ *   The BPMN webview no longer uses it: it themes each modeler instance through
+ *   the package's `data-bpmn-theme` attribute (see `apps/bpmn-webview/hostTheme.ts`).
  */
 
 let currentMode: "automatic" | "light" | "dark" = "automatic";

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -38,16 +38,36 @@ await modeler.loadDiagram(existingXml); // or modeler.newDiagram()
 const xml = await modeler.exportDiagram();
 ```
 
-Link **one** theme stylesheet and tag it `id="theme-link"`:
+### Theming
 
-```html
-<link id="theme-link" rel="stylesheet" href="/node_modules/@miragon/bpmn-modeler/dist/light-theme.css" />
+Theming is **per-instance** and needs no extra `<link>`: importing
+`@miragon/bpmn-modeler/styles.css` (above) already ships both looks. The modeler
+toggles a `data-bpmn-theme="light" | "dark"` attribute on its container and
+properties-panel parent, and the dark rules are scoped under
+`[data-bpmn-theme="dark"]`, so two modelers on one page can hold different
+themes. `theme` defaults to `"automatic"` (follows `prefers-color-scheme` live);
+pass `theme: "light"` / `"dark"` to pin one, or call `modeler.setTheme(...)`
+later.
+
+```ts
+const modeler = await createModeler(canvas, {
+    engine: "c7",
+    propertiesPanel: { parent: panel },
+    theme: "automatic", // "automatic" (default) | "light" | "dark"
+});
 ```
 
-`@miragon/bpmn-modeler/light-theme.css` and `.../dark-theme.css` are the two
-themes. The default `theme: "automatic"` swaps the `#theme-link` href between
-them, so that element **must** exist for automatic theming to work; pass
-`theme: "light"` / `"dark"` to pin one.
+**Legacy `#theme-link` fallback.** If you still link a theme stylesheet tagged
+`id="theme-link"`, the modeler keeps swapping its href between
+`@miragon/bpmn-modeler/light-theme.css` and `.../dark-theme.css` as before — a
+permanent, page-global compatibility path. It is optional; a missing
+`#theme-link` is a silent no-op. Because it is page-global, it cannot express
+per-instance themes — prefer the attribute mechanism (i.e. just `styles.css`).
+
+> Caveat: setting `data-bpmn-theme` on a page **root** element (`<html>`) themes
+> everything below it. Mixing that with two instances that hold *different*
+> per-instance themes would let the root value leak; a single-instance page or
+> one that never sets the root attribute is unaffected.
 
 ## Capabilities & default overrides
 

--- a/packages/bpmn-modeler/package.json
+++ b/packages/bpmn-modeler/package.json
@@ -100,6 +100,8 @@
         "didi": "11.0.0",
         "jsdom": "30.0.1",
         "npm-run-all": "4.1.5",
+        "postcss": "8.5.12",
+        "postcss-selector-parser": "7.1.1",
         "typescript": "6.0.3",
         "unplugin-dts": "1.0.3",
         "vite": "8.2.2",

--- a/packages/bpmn-modeler/package.json
+++ b/packages/bpmn-modeler/package.json
@@ -100,7 +100,7 @@
         "didi": "11.0.0",
         "jsdom": "30.0.1",
         "npm-run-all": "4.1.5",
-        "postcss": "8.5.12",
+        "postcss": "8.5.26",
         "postcss-selector-parser": "7.1.1",
         "typescript": "6.0.3",
         "unplugin-dts": "1.0.3",

--- a/packages/bpmn-modeler/scripts/postcss-strip-theme-scope.d.mts
+++ b/packages/bpmn-modeler/scripts/postcss-strip-theme-scope.d.mts
@@ -1,0 +1,5 @@
+import type { PluginCreator } from "postcss";
+
+/** Strips the `[data-bpmn-theme="dark"]` scope so the legacy split sheet stays un-scoped. */
+declare const stripThemeScope: PluginCreator<void>;
+export default stripThemeScope;

--- a/packages/bpmn-modeler/scripts/postcss-strip-theme-scope.mjs
+++ b/packages/bpmn-modeler/scripts/postcss-strip-theme-scope.mjs
@@ -1,0 +1,54 @@
+import selectorParser from "postcss-selector-parser";
+
+/**
+ * PostCSS plugin that strips the `[data-bpmn-theme="dark"]` scope from every
+ * selector, turning the single scoped source (`dark-theme/*.css`) back into the
+ * legacy un-scoped `darkTheme.css` shape linked via `#theme-link`.
+ *
+ * Two cases, matching the authored scoping conventions:
+ *   - the attribute stands alone in its compound (`[data-bpmn-theme="dark"] S`)
+ *     → replace it with `:root`, preserving the descendant relationship;
+ *   - the attribute is compounded onto another simple selector
+ *     (`:root[data-bpmn-theme="dark"]`, `.am-overlay-root[data-bpmn-theme="dark"]`)
+ *     → delete just the attribute node, leaving the rest of the compound.
+ *
+ * A no-op on selectors that never mention the attribute (e.g. the light input).
+ */
+const ATTRIBUTE = "data-bpmn-theme";
+
+function isCombinator(node) {
+    return node?.type === "combinator";
+}
+
+/** The non-combinator nodes sharing `attr`'s compound (contiguous, no combinator). */
+function compoundSize(attr) {
+    const siblings = attr.parent.nodes;
+    const index = siblings.indexOf(attr);
+    let count = 1;
+    for (let i = index - 1; i >= 0 && !isCombinator(siblings[i]); i--) count++;
+    for (let i = index + 1; i < siblings.length && !isCombinator(siblings[i]); i++) count++;
+    return count;
+}
+
+const transform = selectorParser((selectors) => {
+    selectors.walkAttributes((attr) => {
+        if (attr.attribute !== ATTRIBUTE) return;
+        if (compoundSize(attr) === 1) {
+            attr.replaceWith(selectorParser.pseudo({ value: ":root" }));
+        } else {
+            attr.remove();
+        }
+    });
+});
+
+export default function stripThemeScope() {
+    return {
+        postcssPlugin: "strip-theme-scope",
+        Rule(rule) {
+            if (!rule.selector.includes(ATTRIBUTE)) return;
+            rule.selector = transform.processSync(rule.selector);
+        },
+    };
+}
+
+stripThemeScope.postcss = true;

--- a/packages/bpmn-modeler/src/architecture.spec.ts
+++ b/packages/bpmn-modeler/src/architecture.spec.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, normalize } from "node:path";
+import postcss from "postcss";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -96,6 +97,30 @@ describe("bpmn-modeler import direction", () => {
         expect(
             offenders,
             `package TS source must not read VS Code body theme classes:\n${offenders.join("\n")}`,
+        ).toEqual([]);
+    });
+
+    it("every top-level dark-theme selector is scoped under data-bpmn-theme", () => {
+        // The dark sheet is authored scoped so per-instance theming never leaks
+        // across instances (and the legacy split is derived by stripping the
+        // scope). A top-level rule that forgot the attribute would paint every
+        // instance dark. Nested rules are exempt — their parent carries the scope.
+        const DARK_DIR = join(PKG_SRC, "styles", "dark-theme");
+        const offenders: string[] = [];
+        for (const entry of readdirSync(DARK_DIR)) {
+            if (!entry.endsWith(".css")) continue;
+            const root = postcss.parse(readFileSync(join(DARK_DIR, entry), "utf8"));
+            root.walkRules((rule) => {
+                if (rule.parent?.type !== "root") return; // nested rule: parent scopes it
+                if (!rule.selector.includes("data-bpmn-theme")) {
+                    offenders.push(`${entry}: ${rule.selector}`);
+                }
+            });
+        }
+        expect(
+            offenders,
+            `every top-level dark-theme rule must be scoped under ` +
+                `[data-bpmn-theme="dark"]:\n${offenders.join("\n")}`,
         ).toEqual([]);
     });
 

--- a/packages/bpmn-modeler/src/createModeler.ts
+++ b/packages/bpmn-modeler/src/createModeler.ts
@@ -46,9 +46,9 @@ export async function createModeler(
     if (options.settings) {
         modeler.setSettings(options.settings);
     }
-    if (options.theme) {
-        modeler.setTheme(options.theme);
-    }
+    // Always engage theming so the per-instance `data-bpmn-theme` attribute is
+    // set from the first frame; `"automatic"` then follows `prefers-color-scheme`.
+    modeler.setTheme(options.theme ?? "automatic");
     // The i18n instance is a page-global singleton, so a locale set here is
     // page-wide; only touch it when the caller is explicit, or a default call
     // would stomp a language the host already set. Per-instance locales are a

--- a/packages/bpmn-modeler/src/index.ts
+++ b/packages/bpmn-modeler/src/index.ts
@@ -5,12 +5,15 @@
  * exports below exist only for the in-repo `apps/bpmn-webview` adapter.
  */
 
-// Side-effect styles the modeler's own DOM depends on. A theme stylesheet is
-// linked separately by the consumer — see `styles.css` / `light-theme.css` /
-// `dark-theme.css`.
+// Side-effect styles the modeler's own DOM depends on. `themes.css` (imported
+// last) folds in the upstream light base + the `[data-bpmn-theme="dark"]`-scoped
+// dark overrides, so loading `styles.css` is all a consumer needs for
+// per-instance theming. The legacy split `light-theme.css` / `dark-theme.css`
+// exports remain for the `#theme-link` fallback.
 import "./styles/default.css";
 import "./styles/diff.css";
 import "./styles/canvasFocusIndicator.css";
+import "./styles/themes.css";
 
 // ── Public factory + API surface ─────────────────────────────────────────────
 export { createModeler } from "./createModeler";

--- a/packages/bpmn-modeler/src/modeler.ts
+++ b/packages/bpmn-modeler/src/modeler.ts
@@ -16,7 +16,7 @@ import { CreateAppendC7ElementTemplatesModule } from "@miragon/create-append-c7"
 import { createClipboardModules } from "@miragon/bpmn-modeler-clipboard";
 import { TranslateModule } from "@miragon/bpmn-modeler-i18n";
 import { installContentEditableClipboardPolyfill } from "./propertiesPanelClipboard";
-import { setThemeMode } from "./theme";
+import { ThemeController } from "./theme";
 import {
     asyncDebounce,
     type AsyncDebounced,
@@ -100,6 +100,10 @@ export class BpmnModeler {
     // The debounced content-saved emitter, live only when `onContentSaved` was
     // supplied. Held so {@link destroy} can cancel a pending trailing export.
     private contentSaved?: AsyncDebounced<() => Promise<void>>;
+
+    // Per-instance theme controller, created lazily on the first setTheme. Scopes
+    // `data-bpmn-theme` to this instance's container + panel parent.
+    private themeController?: ThemeController;
 
     /**
      * @param container The canvas host element (bpmn-js `container`).
@@ -207,7 +211,13 @@ export class BpmnModeler {
 
         const modelerOptions = {
             container: this.container,
-            propertiesPanel: { parent: this.options.propertiesPanel.parent },
+            propertiesPanel: {
+                parent: this.options.propertiesPanel.parent,
+                // Mount the FEEL expression popup inside the instance container
+                // (it defaults to document.body, outside this instance's theme
+                // scope). Safe because the popup is `position: fixed`.
+                feelPopupContainer: this.container,
+            },
             alignToOrigin: ALIGN_TO_ORIGIN_OPTIONS,
             moddleExtensions: this.options.moddleExtensions,
         };
@@ -436,6 +446,7 @@ export class BpmnModeler {
      */
     destroy(): void {
         this.contentSaved?.cancel();
+        this.themeController?.dispose();
         this.disposeFocusFeatures();
         this.modeler?.destroy();
         this.modeler = undefined;
@@ -696,14 +707,22 @@ export class BpmnModeler {
     }
 
     /**
-     * Switches the colour theme live. Page-level theme state is a module
-     * singleton (one `#theme-link`), so `"automatic"` follows the OS/browser
-     * `prefers-color-scheme` live while `"light"`/`"dark"` force a fixed
-     * stylesheet. A host that themes off its own chrome maps that signal to a
-     * forced mode at the adapter.
+     * Switches the colour theme live. Toggles `data-bpmn-theme` on this
+     * instance's container + panel parent (the authoritative, per-instance
+     * mechanism) and mirrors the choice to the legacy page-global `#theme-link`
+     * when one is present. `"automatic"` follows the OS/browser
+     * `prefers-color-scheme` live while `"light"`/`"dark"` force a fixed kind. A
+     * host that themes off its own chrome maps that signal to a forced mode at
+     * the adapter.
      */
     setTheme(theme: ThemeMode): void {
-        setThemeMode(theme);
+        if (!this.themeController) {
+            this.themeController = new ThemeController([
+                this.container,
+                this.options.propertiesPanel.parent,
+            ]);
+        }
+        this.themeController.setMode(theme);
     }
 
     /**

--- a/packages/bpmn-modeler/src/postcss-strip-theme-scope.spec.ts
+++ b/packages/bpmn-modeler/src/postcss-strip-theme-scope.spec.ts
@@ -1,0 +1,65 @@
+import postcss from "postcss";
+import { describe, expect, it } from "vitest";
+
+import stripThemeScope from "../scripts/postcss-strip-theme-scope.mjs";
+
+/**
+ * The plugin derives the legacy un-scoped `darkTheme.css` from the single
+ * `[data-bpmn-theme="dark"]`-scoped source. It must remove every mention of the
+ * attribute while preserving the selector's structure, so the split sheet keeps
+ * matching the same elements a bare `#theme-link` swap always did.
+ */
+function strip(css: string): string {
+    return postcss([stripThemeScope()]).process(css, { from: undefined }).css;
+}
+
+describe("postcss-strip-theme-scope", () => {
+    const cases: ReadonlyArray<[name: string, input: string, expected: string]> = [
+        [
+            "attribute alone → :root",
+            `[data-bpmn-theme="dark"] { color: red }`,
+            `:root { color: red }`,
+        ],
+        [
+            "descendant compound → :root descendant",
+            `[data-bpmn-theme="dark"] .djs-parent { color: red }`,
+            `:root .djs-parent { color: red }`,
+        ],
+        [
+            "compounded on :root → :root",
+            `:root[data-bpmn-theme="dark"] .panel-resizer { color: red }`,
+            `:root .panel-resizer { color: red }`,
+        ],
+        [
+            "compounded on a class → the class alone",
+            `.am-overlay-root[data-bpmn-theme="dark"] { color: red }`,
+            `.am-overlay-root { color: red }`,
+        ],
+        [
+            "both overlay forms collapse",
+            `[data-bpmn-theme="dark"] .etc-overlay-root, .etc-overlay-root[data-bpmn-theme="dark"] { color: red }`,
+            `:root .etc-overlay-root, .etc-overlay-root { color: red }`,
+        ],
+        [
+            "child combinator preserved",
+            `[data-bpmn-theme="dark"] .djs-popup-header-group > li > button { color: red }`,
+            `:root .djs-popup-header-group > li > button { color: red }`,
+        ],
+        [
+            "unscoped selector untouched",
+            `.djs-container { color: red }`,
+            `.djs-container { color: red }`,
+        ],
+    ];
+
+    it.each(cases)("%s", (_name, input, expected) => {
+        expect(strip(input)).toBe(expected);
+    });
+
+    it("leaves no data-bpmn-theme in the output", () => {
+        const out = strip(
+            `[data-bpmn-theme="dark"] .a, :root[data-bpmn-theme="dark"] .b, .c[data-bpmn-theme="dark"] { color: red }`,
+        );
+        expect(out).not.toContain("data-bpmn-theme");
+    });
+});

--- a/packages/bpmn-modeler/src/publicApi.ts
+++ b/packages/bpmn-modeler/src/publicApi.ts
@@ -44,11 +44,15 @@ import type { SelectionManager } from "./selection";
  */
 
 /**
- * [B] Theme selection for a single instance. `"automatic"` follows the
- * OS/browser `prefers-color-scheme` live; `"light"`/`"dark"` force a fixed
- * stylesheet. A host that themes off its own chrome (VS Code `<body>` classes)
- * maps that signal to a forced mode in its adapter — the package does not read
- * host chrome.
+ * [B] Theme selection for a single instance. The modeler toggles a
+ * `data-bpmn-theme` attribute on its container + panel parent (the authoritative
+ * mechanism — dark rules are scoped under `[data-bpmn-theme="dark"]`, so two
+ * instances on one page can hold different themes) and mirrors the choice onto a
+ * legacy page-global `#theme-link` when the consumer still links one.
+ * `"automatic"` follows the OS/browser `prefers-color-scheme` live;
+ * `"light"`/`"dark"` force a fixed kind. A host that themes off its own chrome
+ * (VS Code `<body>` classes) maps that signal to a forced mode in its adapter —
+ * the package does not read host chrome.
  */
 export type ThemeMode = "light" | "dark" | "automatic";
 
@@ -150,7 +154,11 @@ export interface ModelerOptions {
     /** [B] Clipboard override — omit for the native clipboard. */
     clipboard?: ClipboardOptions;
 
-    /** [B] Colour theme — defaults to `"automatic"`. */
+    /**
+     * [B] Colour theme — defaults to `"automatic"`. Theming always engages: the
+     * instance gets a `data-bpmn-theme` attribute from the first frame regardless
+     * of whether this is set.
+     */
     theme?: ThemeMode;
 
     /** [B] UI locale (BCP-47-ish tag) — defaults to `"en"`. */
@@ -218,7 +226,11 @@ export interface BpmnModelerHandle {
     destroy(): void;
 
     // ── [B] Opinionated built-ins ───────────────────────────────────────────
-    /** [B] Switch the colour theme live. */
+    /**
+     * [B] Switch the colour theme live. Toggles this instance's
+     * `data-bpmn-theme` attribute and mirrors it to a legacy `#theme-link` when
+     * present.
+     */
     setTheme(theme: ThemeMode): void;
 
     /**

--- a/packages/bpmn-modeler/src/styles/dark-theme/append-menu.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/append-menu.css
@@ -11,7 +11,11 @@
  */
 @import "colors.css";
 
-.am-overlay-root {
+/* The overlay mounts on document.body, outside its instance's container, so it
+ * copies `data-bpmn-theme` onto its own root at creation; the descendant form
+ * covers a page root that carries the attribute. */
+[data-bpmn-theme="dark"] .am-overlay-root,
+.am-overlay-root[data-bpmn-theme="dark"] {
     /* ── Backgrounds ──────────────────────────────────────────────────── */
     --am-bg:               var(--dt-surface-a10);
     --am-bg-elevated:      var(--dt-surface-a20);

--- a/packages/bpmn-modeler/src/styles/dark-theme/colors.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/colors.css
@@ -1,4 +1,4 @@
-:root {
+[data-bpmn-theme="dark"] {
     /** Base colors */
     --dt-dark-a0: #000000;
     --dt-light-a0: #ffffff;

--- a/packages/bpmn-modeler/src/styles/dark-theme/diagram-js.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/diagram-js.css
@@ -10,6 +10,12 @@
     --bendpoint-fill-color: var(--dt-primary-a30);
     --bendpoint-stroke-color: var(--canvas-fill-color);
 
+    --breadcrumbs-item-color: var(--dt-color-blue-a50);
+    --breadcrumbs-arrow-color: var(--dt-surface-a70);
+    --breadcrumbs-background-color: var(--dt-surface-a10);
+    --breadcrumbs-border-color: var(--dt-surface-tonal-a40);
+    --breadcrumbs-focus-outline-color: var(--dt-color-blue-a50);
+
     --context-pad-entry-background-color: var(--dt-surface-a0);
     --context-pad-entry-hover-background-color: var(--dt-surface-a30);
 
@@ -67,6 +73,17 @@
     --tooltip-error-background-color: var(--dt-color-red-a10);
     --tooltip-error-border-color: var(--dt-color-red-a20);
     --tooltip-error-color: var(--dt-color-red-a20);
+}
+
+/* Current (non-link) crumb inherits the host body colour; pin it to the theme. */
+[data-bpmn-theme="dark"] .bjs-breadcrumbs {
+    color: var(--dt-surface-a70);
+}
+
+/* The separator arrow is a data-URL SVG with an implicit black fill;
+   --breadcrumbs-arrow-color can't recolour it, so invert it. */
+[data-bpmn-theme="dark"] .bjs-breadcrumbs li:not(:first-child)::before {
+    filter: invert(1);
 }
 
 /**

--- a/packages/bpmn-modeler/src/styles/dark-theme/diagram-js.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/diagram-js.css
@@ -1,6 +1,6 @@
 @import "colors.css";
 
-:root .djs-parent {
+[data-bpmn-theme="dark"] .djs-parent {
     --canvas-fill-color: var(--dt-surface-a10);
 
     --bpmn-shape-fill-color: var(--dt-surface-a10);
@@ -72,7 +72,7 @@
 /**
  * The canvas
  */
-.djs-container {
+[data-bpmn-theme="dark"] .djs-container {
     background-color: var(--canvas-fill-color) !important;
 }
 
@@ -86,25 +86,25 @@
  */
 
 /* defaultFillColor (white) → dark surface */
-.djs-shape > .djs-visual > [style*="fill: white"] {
+[data-bpmn-theme="dark"] .djs-shape > .djs-visual > [style*="fill: white"] {
     fill: var(--bpmn-shape-fill-color) !important;
 }
 
 /* defaultStrokeColor used as a fill (filled throw markers, arrowheads) → light */
-.djs-shape > .djs-visual > [style*="fill: rgb(34, 36, 42)"],
-defs marker > [style*="fill: rgb(34, 36, 42)"] {
+[data-bpmn-theme="dark"] .djs-shape > .djs-visual > [style*="fill: rgb(34, 36, 42)"],
+[data-bpmn-theme="dark"] defs marker > [style*="fill: rgb(34, 36, 42)"] {
     fill: var(--bpmn-shape-stroke-color) !important;
 }
 
 /* defaultStrokeColor (rgb(34, 36, 42)) → light stroke */
-.djs-shape > .djs-visual > [style*="stroke: rgb(34, 36, 42)"],
-.djs-connection > .djs-visual > [style*="stroke: rgb(34, 36, 42)"],
-defs marker > [style*="stroke: rgb(34, 36, 42)"] {
+[data-bpmn-theme="dark"] .djs-shape > .djs-visual > [style*="stroke: rgb(34, 36, 42)"],
+[data-bpmn-theme="dark"] .djs-connection > .djs-visual > [style*="stroke: rgb(34, 36, 42)"],
+[data-bpmn-theme="dark"] defs marker > [style*="stroke: rgb(34, 36, 42)"] {
     stroke: var(--bpmn-shape-stroke-color) !important;
 }
 
 /* Throw markers pair a filled body with a white outline → dark-surface outline. */
-.djs-shape > .djs-visual > [style*="fill: rgb(34, 36, 42)"][style*="stroke: white"] {
+[data-bpmn-theme="dark"] .djs-shape > .djs-visual > [style*="fill: rgb(34, 36, 42)"][style*="stroke: white"] {
     stroke: var(--bpmn-shape-fill-color) !important;
 }
 
@@ -117,20 +117,20 @@ defs marker > [style*="stroke: rgb(34, 36, 42)"] {
  */
 
 /* neutral fill (white) → dark surface */
-.bjs-container.simulation .djs-shape > .djs-visual > [style*="fill: rgb(255, 255, 255)"] {
+[data-bpmn-theme="dark"] .bjs-container.simulation .djs-shape > .djs-visual > [style*="fill: rgb(255, 255, 255)"] {
     fill: var(--bpmn-shape-fill-color) !important;
 }
 
 /* neutral stroke used as a fill (filled throw markers, arrowheads) → light */
-.bjs-container.simulation .djs-shape > .djs-visual > [style*="fill: rgb(33, 33, 33)"],
-.bjs-container.simulation defs marker > [style*="fill: rgb(33, 33, 33)"] {
+[data-bpmn-theme="dark"] .bjs-container.simulation .djs-shape > .djs-visual > [style*="fill: rgb(33, 33, 33)"],
+[data-bpmn-theme="dark"] .bjs-container.simulation defs marker > [style*="fill: rgb(33, 33, 33)"] {
     fill: var(--bpmn-shape-stroke-color) !important;
 }
 
 /* neutral stroke → light stroke (shapes, connections/flows, arrowhead markers) */
-.bjs-container.simulation .djs-shape > .djs-visual > [style*="stroke: rgb(33, 33, 33)"],
-.bjs-container.simulation .djs-connection > .djs-visual > [style*="stroke: rgb(33, 33, 33)"],
-.bjs-container.simulation defs marker > [style*="stroke: rgb(33, 33, 33)"] {
+[data-bpmn-theme="dark"] .bjs-container.simulation .djs-shape > .djs-visual > [style*="stroke: rgb(33, 33, 33)"],
+[data-bpmn-theme="dark"] .bjs-container.simulation .djs-connection > .djs-visual > [style*="stroke: rgb(33, 33, 33)"],
+[data-bpmn-theme="dark"] .bjs-container.simulation defs marker > [style*="stroke: rgb(33, 33, 33)"] {
     stroke: var(--bpmn-shape-stroke-color) !important;
 }
 
@@ -139,55 +139,55 @@ defs marker > [style*="stroke: rgb(34, 36, 42)"] {
  * element's stroke colour (no `defaultLabelColor` configured), so a coloured
  * shape's dark label already reads against its light fill; don't force it light.
  */
-.djs-shape > .djs-visual > text[style*="fill: rgb(34, 36, 42)"] {
+[data-bpmn-theme="dark"] .djs-shape > .djs-visual > text[style*="fill: rgb(34, 36, 42)"] {
     fill: var(--bpmn-label-color) !important;
 }
 
 /* External labels sit on the dark canvas, so always light — even when coloured. */
-.djs-label .djs-visual text {
+[data-bpmn-theme="dark"] .djs-label .djs-visual text {
     fill: var(--bpmn-label-color) !important;
 }
 
 /* Grid — the element has class="layer djs-grid" (two classes) */
-.layer-djs-grid {
+[data-bpmn-theme="dark"] .layer-djs-grid {
     opacity: 0.5;
 }
 
-.djs-direct-editing-parent {
+[data-bpmn-theme="dark"] .djs-direct-editing-parent {
     color: var(--dt-primary-a20) !important;
 }
 
-.djs-direct-editing-content {
+[data-bpmn-theme="dark"] .djs-direct-editing-content {
     background-color: var(--dt-surface-a10) !important;
 }
 
 /**
  * Context pad
  */
-.djs-context-pad {
+[data-bpmn-theme="dark"] .djs-context-pad {
     color: var(--dt-primary-a50) !important;
 }
 
 /**
  * Search Box
  */
-.djs-search-container .djs-search-result {
+[data-bpmn-theme="dark"] .djs-search-container .djs-search-result {
     color: var(--dt-surface-a40) !important;
     background-color: var(--dt-surface-a10) !important;
 }
 
-.djs-search-icon {
+[data-bpmn-theme="dark"] .djs-search-icon {
     filter: invert(0.7);
 }
 
 /**
  * Popup
  */
-.djs-popup-title {
+[data-bpmn-theme="dark"] .djs-popup-title {
     color: var(--dt-surface-a70) !important;
 }
 
-.djs-popup-header-group > li > button {
+[data-bpmn-theme="dark"] .djs-popup-header-group > li > button {
     color: var(--dt-primary-a50) !important;
 }
 
@@ -198,7 +198,6 @@ defs marker > [style*="stroke: rgb(34, 36, 42)"] {
  * `fill="currentColor"`, so the logo is nearly invisible on dark backgrounds.
  * Override with a light muted grey that stays subtle but readable.
  */
-.bjs-powered-by {
+[data-bpmn-theme="dark"] .bjs-powered-by {
     color: var(--dt-surface-a50) !important;
 }
-

--- a/packages/bpmn-modeler/src/styles/dark-theme/element-template-chooser.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/element-template-chooser.css
@@ -11,7 +11,11 @@
  */
 @import "colors.css";
 
-.etc-overlay-root {
+/* The overlay mounts outside its instance's container (onto the canvas parent),
+ * so it copies `data-bpmn-theme` onto its own root at creation; the descendant
+ * form covers a page root that carries the attribute. */
+[data-bpmn-theme="dark"] .etc-overlay-root,
+.etc-overlay-root[data-bpmn-theme="dark"] {
     /* ── Backgrounds ──────────────────────────────────────────────────── */
     --etc-bg:               var(--dt-surface-a10);
     --etc-bg-elevated:      var(--dt-surface-a20);

--- a/packages/bpmn-modeler/src/styles/dark-theme/index.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/index.css
@@ -1,10 +1,4 @@
 @import "camunda-bpmn-js/dist/assets/camunda-platform-modeler.css";
 @import "camunda-bpmn-js/dist/assets/camunda-cloud-modeler.css";
 @import "bpmn-js-token-simulation/assets/css/bpmn-js-token-simulation.css";
-@import "./colors.css";
-@import "./diagram-js.css";
-@import "./properties-panel.css";
-@import "./element-template-chooser.css";
-@import "./append-menu.css";
-@import "./token-sim.css";
-@import "./minimap.css";
+@import "./overrides.css";

--- a/packages/bpmn-modeler/src/styles/dark-theme/minimap.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/minimap.css
@@ -1,12 +1,12 @@
 @import "colors.css";
 
-.djs-minimap {
+[data-bpmn-theme="dark"] .djs-minimap {
     background-color: var(--dt-surface-a10) !important;
     color: var(--dt-primary-a50) !important;
     border-color: var(--dt-surface-tonal-a50) !important;
     cursor: pointer;
 }
 
-.djs-minimap:hover {
+[data-bpmn-theme="dark"] .djs-minimap:hover {
     background-color: var(--dt-surface-tonal-a20) !important;
 }

--- a/packages/bpmn-modeler/src/styles/dark-theme/overrides.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/overrides.css
@@ -1,0 +1,15 @@
+/**
+ * The dark-theme override rules only — every selector scoped under
+ * `[data-bpmn-theme="dark"]`. This is the single authored source: `themes.css`
+ * imports it (after the unscoped light base) for the merged in-bundle sheet, and
+ * `index.css` imports it after the 3 upstream defaults to build the legacy
+ * `darkTheme.css` split (the scope is stripped from that output by
+ * `scripts/postcss-strip-theme-scope.mjs`).
+ */
+@import "./colors.css";
+@import "./diagram-js.css";
+@import "./properties-panel.css";
+@import "./element-template-chooser.css";
+@import "./append-menu.css";
+@import "./token-sim.css";
+@import "./minimap.css";

--- a/packages/bpmn-modeler/src/styles/dark-theme/properties-panel.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/properties-panel.css
@@ -1,6 +1,6 @@
 @import "colors.css";
 
-:root .bio-properties-panel {
+[data-bpmn-theme="dark"] .bio-properties-panel {
     --text-base-color: var(--dt-surface-a70);
     --text-error-color: var(--dt-color-red-a10);
     --link-color: var(--dt-color-blue-a50);
@@ -90,7 +90,7 @@
     --feelers-select-color: var(--dt-primary-a40);
 }
 
-.bio-properties-panel-popup {
+[data-bpmn-theme="dark"] .bio-properties-panel-popup {
     --popup-background-color: var(--dt-surface-a20);
     --popup-header-background-color: var(--dt-surface-a10);
     --popup-font-color: var(--dt-surface-a70);
@@ -100,32 +100,32 @@
     --feel-popup-gutters-background-color: var(--dt-surface-a20);
 }
 
-.bio-properties-panel-container {
+[data-bpmn-theme="dark"] .bio-properties-panel-container {
     background-color: var(--dt-surface-a10) !important;
 }
 
-.bio-properties-panel-textarea textarea,
-.bio-properties-panel-textfield input,
-.bio-properties-panel-numberfield input,
-.bio-properties-panel-feel-entry input,
-.bio-properties-panel-feel-entry textarea {
+[data-bpmn-theme="dark"] .bio-properties-panel-textarea textarea,
+[data-bpmn-theme="dark"] .bio-properties-panel-textfield input,
+[data-bpmn-theme="dark"] .bio-properties-panel-numberfield input,
+[data-bpmn-theme="dark"] .bio-properties-panel-feel-entry input,
+[data-bpmn-theme="dark"] .bio-properties-panel-feel-entry textarea {
     color: var(--dt-surface-a60) !important;
 }
 
-.bio-properties-panel-textarea > textarea:focus,
-.bio-properties-panel-textfield > input:focus,
-.bio-properties-panel-numberfield > input:focus,
-.bio-properties-panel-feel-entry input:focus,
-.bio-properties-panel-feel-entry textarea:focus {
+[data-bpmn-theme="dark"] .bio-properties-panel-textarea > textarea:focus,
+[data-bpmn-theme="dark"] .bio-properties-panel-textfield > input:focus,
+[data-bpmn-theme="dark"] .bio-properties-panel-numberfield > input:focus,
+[data-bpmn-theme="dark"] .bio-properties-panel-feel-entry input:focus,
+[data-bpmn-theme="dark"] .bio-properties-panel-feel-entry textarea:focus {
     color: var(--dt-surface-a70) !important;
 }
 
-.bio-properties-panel-checkbox > input[type="checkbox"] {
+[data-bpmn-theme="dark"] .bio-properties-panel-checkbox > input[type="checkbox"] {
     accent-color: var(--dt-primary-a10) !important;
 }
 
-.bio-properties-panel-select-template-button,
-.bio-properties-panel-applied-template-button > button {
+[data-bpmn-theme="dark"] .bio-properties-panel-select-template-button,
+[data-bpmn-theme="dark"] .bio-properties-panel-applied-template-button > button {
     background-color: var(--dt-primary-a20) !important;
     color: var(--dt-surface-a20) !important;
     cursor: pointer;
@@ -135,16 +135,16 @@
     }
 }
 
-.bio-properties-panel-select-template-button:hover,
-.bio-properties-panel-applied-template-button > button:hover {
+[data-bpmn-theme="dark"] .bio-properties-panel-select-template-button:hover,
+[data-bpmn-theme="dark"] .bio-properties-panel-applied-template-button > button:hover {
     background-color: var(--dt-primary-a40) !important;
 }
 
-.bio-properties-panel-select > select {
+[data-bpmn-theme="dark"] .bio-properties-panel-select > select {
     color: var(--dt-surface-a60) !important;
 }
 
-.bio-properties-panel-select > select:focus {
+[data-bpmn-theme="dark"] .bio-properties-panel-select > select:focus {
     color: var(--dt-surface-a70) !important;
 }
 
@@ -155,58 +155,58 @@
  * unreadable on a dark background.  Override all text colors inside the
  * editor so content remains legible.
  */
-.bio-properties-panel-feel-editor-container .cm-editor {
+[data-bpmn-theme="dark"] .bio-properties-panel-feel-editor-container .cm-editor {
     color: var(--dt-surface-a70) !important;
     caret-color: var(--dt-surface-a70) !important;
 }
 
-.bio-properties-panel-feel-editor-container .cm-editor .cm-cursor,
-.bio-properties-panel-feel-editor-container .cm-editor .cm-dropCursor,
-.bio-properties-panel-feel-editor-container .cm-editor .cm-content {
+[data-bpmn-theme="dark"] .bio-properties-panel-feel-editor-container .cm-editor .cm-cursor,
+[data-bpmn-theme="dark"] .bio-properties-panel-feel-editor-container .cm-editor .cm-dropCursor,
+[data-bpmn-theme="dark"] .bio-properties-panel-feel-editor-container .cm-editor .cm-content {
     border-left-color: var(--dt-surface-a70) !important;
     caret-color: var(--dt-surface-a70) !important;
 }
 
 /* Open-popup icon — SVG path has no fill attribute, defaults to black */
-.bio-properties-panel-open-feel-popup svg {
+[data-bpmn-theme="dark"] .bio-properties-panel-open-feel-popup svg {
     fill: var(--dt-surface-a70) !important;
 }
 
-.bio-properties-panel-feel-editor-container .cm-editor .cm-line,
-.bio-properties-panel-feel-editor-container .cm-editor .cm-line span {
+[data-bpmn-theme="dark"] .bio-properties-panel-feel-editor-container .cm-editor .cm-line,
+[data-bpmn-theme="dark"] .bio-properties-panel-feel-editor-container .cm-editor .cm-line span {
     color: inherit !important;
 }
 
 /* Autocomplete & tooltip popups */
-.cm-tooltip {
+[data-bpmn-theme="dark"] .cm-tooltip {
     background-color: var(--dt-surface-a0) !important;
     border: 1px solid var(--dt-surface-a30) !important;
     color: var(--dt-surface-a70) !important;
 }
 
-.cm-tooltip-autocomplete > ul > li {
+[data-bpmn-theme="dark"] .cm-tooltip-autocomplete > ul > li {
     color: var(--dt-surface-a60) !important;
 }
 
-.cm-tooltip-autocomplete > ul > li[aria-selected] {
+[data-bpmn-theme="dark"] .cm-tooltip-autocomplete > ul > li[aria-selected] {
     background-color: var(--dt-primary-a0) !important;
     color: var(--dt-surface-a70) !important;
 }
 
 /* Completion info panel (function signature / examples) */
-.cm-completionInfo {
+[data-bpmn-theme="dark"] .cm-completionInfo {
     background-color: var(--dt-surface-a0) !important;
     border: 1px solid var(--dt-surface-a30) !important;
     color: var(--dt-surface-a70) !important;
 }
 
 /* Diagnostics (lint errors/warnings) */
-.cm-diagnostic {
+[data-bpmn-theme="dark"] .cm-diagnostic {
     background-color: var(--dt-surface-a0) !important;
     color: var(--dt-surface-a70) !important;
 }
 
-.bio-properties-panel-dropdown-button__menu {
+[data-bpmn-theme="dark"] .bio-properties-panel-dropdown-button__menu {
     box-shadow: 0 1px 4px 0 var(--dt-surface-a40), 0 2px 16px 0 var(--dt-surface-a30) !important;
 
     button {
@@ -216,28 +216,34 @@
 
 /* Dark-theme layout overrides for the host page.
  *
+ * These style the host chrome that sits *outside* any single modeler instance
+ * (the page background and the panel dividers between canvas and panel), so they
+ * key off the root attribute the host adapter sets on `document.documentElement`
+ * — not the per-instance container attribute. `.properties-panel-parent` is both
+ * an instance scope root and page chrome, so it carries the attribute directly.
+ *
  * default.css paints html/body white and the panel dividers light grey.
  * Any 1-px rounding gap in the flex layout (e.g. when the properties panel
  * is collapsed to width 0) lets the white body show through, producing the
  * bright vertical strip that was reported on the dark theme. */
-html,
-body {
+:root[data-bpmn-theme="dark"],
+:root[data-bpmn-theme="dark"] body {
     background-color: var(--dt-surface-a0);
     color: var(--dt-surface-a70);
 }
 
-.panel-resizer {
+:root[data-bpmn-theme="dark"] .panel-resizer {
     border-left-color: var(--dt-surface-a20);
 }
 
-.panel-resizer:hover {
+:root[data-bpmn-theme="dark"] .panel-resizer:hover {
     background-color: var(--dt-primary-a0-opacity-30);
     border-left-color: var(--dt-primary-a10);
 }
 
 /* Dark-theme counterpart of the open-state halo suppression in default.css:
  * restore the resting divider colour while the button is hovered. */
-.panel-resizer:has(.panel-resizer-toggle:hover) {
+:root[data-bpmn-theme="dark"] .panel-resizer:has(.panel-resizer-toggle:hover) {
     background-color: transparent;
     border-left-color: var(--dt-surface-a20);
 }
@@ -246,35 +252,36 @@ body {
  * line segments. default.css exposes `--panel-resizer-accent-color` and
  * `--panel-resizer-accent-hover-color`, so overriding the custom properties
  * here wins regardless of stylesheet load order. */
-.panel-resizer.collapsed {
+:root[data-bpmn-theme="dark"] .panel-resizer.collapsed {
     --panel-resizer-accent-color: var(--dt-surface-a30);
     --panel-resizer-accent-hover-color: var(--dt-primary-a10);
 }
 
-.panel-resizer.collapsed:hover {
+:root[data-bpmn-theme="dark"] .panel-resizer.collapsed:hover {
     background-color: var(--dt-primary-a0-opacity-30);
 }
 
-.panel-resizer.collapsed:has(.panel-resizer-toggle:hover) {
+:root[data-bpmn-theme="dark"] .panel-resizer.collapsed:has(.panel-resizer-toggle:hover) {
     background-color: transparent;
 }
 
-.panel-resizer-toggle {
+:root[data-bpmn-theme="dark"] .panel-resizer-toggle {
     background-color: var(--dt-surface-a10);
     border-color: var(--dt-surface-a30);
     color: var(--dt-surface-a70);
 }
 
-.panel-resizer-toggle:hover {
+:root[data-bpmn-theme="dark"] .panel-resizer-toggle:hover {
     background-color: var(--dt-primary-a0-opacity-30);
     border-color: var(--dt-primary-a10);
     color: var(--dt-primary-a10);
 }
 
-.panel-resizer-toggle:focus-visible {
+:root[data-bpmn-theme="dark"] .panel-resizer-toggle:focus-visible {
     outline-color: var(--dt-primary-a10);
 }
 
-.properties-panel-parent {
+.properties-panel-parent[data-bpmn-theme="dark"],
+:root[data-bpmn-theme="dark"] .properties-panel-parent {
     border-left-color: var(--dt-surface-a30);
 }

--- a/packages/bpmn-modeler/src/styles/dark-theme/token-sim.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/token-sim.css
@@ -14,33 +14,33 @@
 }
 */
 
-.bjs-container.simulation .djs-container {
+[data-bpmn-theme="dark"] .bjs-container.simulation .djs-container {
     box-shadow: inset 0 0 0 4px var(--dt-primary-a0) !important;
 }
 
-.bts-toggle-mode {
+[data-bpmn-theme="dark"] .bts-toggle-mode {
     background-color: var(--dt-surface-a10) !important;
     color: var(--dt-primary-a50) !important;
 }
 
-.bts-toggle-mode:hover {
+[data-bpmn-theme="dark"] .bts-toggle-mode:hover {
     background-color: var(--dt-surface-tonal-a20) !important;
 }
 
-.bts-entry {
+[data-bpmn-theme="dark"] .bts-entry {
     color: var(--dt-primary-a30) !important;
     background-color: var(--dt-surface-a10) !important;
 }
 
-.bts-context-pad {
+[data-bpmn-theme="dark"] .bts-context-pad {
     background-color: var(--dt-surface-a50) !important;
 }
 
-.bts-context-pad:hover {
+[data-bpmn-theme="dark"] .bts-context-pad:hover {
     background-color: var(--dt-primary-a30) !important;
 }
 
-.bts-set-animation-speed {
+[data-bpmn-theme="dark"] .bts-set-animation-speed {
     background-color: var(--dt-surface-tonal-a20) !important;
 
     .bts-icon {
@@ -60,6 +60,6 @@
     }
 }
 
-.bts-log {
+[data-bpmn-theme="dark"] .bts-log {
     background-color: var(--dt-surface-a0) !important;
 }

--- a/packages/bpmn-modeler/src/styles/themes.css
+++ b/packages/bpmn-modeler/src/styles/themes.css
@@ -1,0 +1,10 @@
+/**
+ * The in-bundle theme sheet: the unscoped upstream bpmn-io defaults (the light
+ * look) plus the dark overrides scoped under `[data-bpmn-theme="dark"]`. Folded
+ * into `dist/bpmn-modeler.css` via `src/index.ts`, so a consumer that loads
+ * `styles.css` gets per-instance theming with no extra `<link>`. The legacy
+ * split `lightTheme.css` / `darkTheme.css` are built separately for the
+ * `#theme-link` fallback (see `vite.themes.config.mts`).
+ */
+@import "./light-theme/index.css";
+@import "./dark-theme/overrides.css";

--- a/packages/bpmn-modeler/src/theme.spec.ts
+++ b/packages/bpmn-modeler/src/theme.spec.ts
@@ -1,12 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { THEME_ATTRIBUTE, ThemeController } from "./theme";
+
 /**
- * Page theme controller. The module is a page singleton (a `currentMode`
- * plus one live `prefers-color-scheme` listener), so each test reloads it via
- * `vi.resetModules()` to start from the initial `"automatic"` state. Because the
- * initial mode is already `"automatic"`, the same-mode guard means a fresh
- * `setThemeMode("automatic")` is a no-op — every automatic assertion therefore
- * transitions through a forced mode first, exactly as a real host would.
+ * Per-instance theme controller. Each test constructs its own
+ * {@link ThemeController} over plain scope roots, so there is no page-singleton
+ * state to reset — unlike the old module-singleton, a fresh controller starts
+ * with `mode === undefined`, which is why a first `setMode("automatic")` engages
+ * rather than short-circuiting on the same-mode guard.
  */
 
 const THEME_BASE = "http://localhost/assets/";
@@ -22,6 +23,12 @@ function setThemeLink(css: "lightTheme.css" | "darkTheme.css"): HTMLLinkElement 
 
 function currentCss(link: HTMLLinkElement): string {
     return link.href.split("/").pop()!;
+}
+
+function makeRoot(): HTMLElement {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    return div;
 }
 
 /**
@@ -51,12 +58,7 @@ function stubMatchMedia(initialDark: boolean) {
     };
 }
 
-async function loadTheme() {
-    vi.resetModules();
-    return import("./theme");
-}
-
-describe("setThemeMode", () => {
+describe("ThemeController", () => {
     beforeEach(() => {
         document.head.innerHTML = "";
         document.body.innerHTML = "";
@@ -66,70 +68,106 @@ describe("setThemeMode", () => {
         vi.restoreAllMocks();
     });
 
-    it("forces the dark stylesheet", async () => {
-        const link = setThemeLink("lightTheme.css");
+    it("forces the dark attribute on every scope root", () => {
         stubMatchMedia(false);
-        const { setThemeMode } = await loadTheme();
+        const a = makeRoot();
+        const b = makeRoot();
+        const controller = new ThemeController([a, b]);
 
-        setThemeMode("dark");
+        controller.setMode("dark");
 
-        expect(currentCss(link)).toBe("darkTheme.css");
+        expect(a.getAttribute(THEME_ATTRIBUTE)).toBe("dark");
+        expect(b.getAttribute(THEME_ATTRIBUTE)).toBe("dark");
     });
 
-    it("forces the light stylesheet back from dark", async () => {
-        const link = setThemeLink("darkTheme.css");
+    it("forces the light attribute back from dark", () => {
         stubMatchMedia(false);
-        const { setThemeMode } = await loadTheme();
+        const root = makeRoot();
+        const controller = new ThemeController([root]);
 
-        setThemeMode("light");
+        controller.setMode("dark");
+        controller.setMode("light");
 
-        expect(currentCss(link)).toBe("lightTheme.css");
+        expect(root.getAttribute(THEME_ATTRIBUTE)).toBe("light");
     });
 
-    it("automatic applies the current prefers-color-scheme", async () => {
-        const link = setThemeLink("lightTheme.css");
+    it("engages on the first automatic call (no same-mode short-circuit)", () => {
         stubMatchMedia(true);
-        const { setThemeMode } = await loadTheme();
+        const root = makeRoot();
+        const controller = new ThemeController([root]);
 
-        setThemeMode("light");
-        setThemeMode("automatic");
+        controller.setMode("automatic");
 
-        expect(currentCss(link)).toBe("darkTheme.css");
+        expect(root.getAttribute(THEME_ATTRIBUTE)).toBe("dark");
     });
 
-    it("automatic reacts to a live scheme change", async () => {
-        const link = setThemeLink("lightTheme.css");
+    it("automatic reacts to a live scheme change", () => {
         const media = stubMatchMedia(false);
-        const { setThemeMode } = await loadTheme();
+        const root = makeRoot();
+        const controller = new ThemeController([root]);
 
-        setThemeMode("light");
-        setThemeMode("automatic");
-        expect(currentCss(link)).toBe("lightTheme.css");
+        controller.setMode("automatic");
+        expect(root.getAttribute(THEME_ATTRIBUTE)).toBe("light");
 
         media.emit(true);
-        expect(currentCss(link)).toBe("darkTheme.css");
+        expect(root.getAttribute(THEME_ATTRIBUTE)).toBe("dark");
     });
 
-    it("a forced mode detaches the scheme listener and stops reacting", async () => {
-        const link = setThemeLink("lightTheme.css");
+    it("a forced mode detaches the scheme listener and stops reacting", () => {
         const media = stubMatchMedia(false);
-        const { setThemeMode } = await loadTheme();
+        const root = makeRoot();
+        const controller = new ThemeController([root]);
 
-        setThemeMode("light");
-        setThemeMode("automatic");
-        setThemeMode("light");
+        controller.setMode("automatic");
+        controller.setMode("light");
 
         expect(media.listenerCount()).toBe(0);
         media.emit(true);
-        expect(currentCss(link)).toBe("lightTheme.css");
+        expect(root.getAttribute(THEME_ATTRIBUTE)).toBe("light");
     });
 
-    it("logs and does not throw when #theme-link is missing", async () => {
+    it("dispose detaches the listener and clears the attribute", () => {
+        const media = stubMatchMedia(true);
+        const root = makeRoot();
+        const controller = new ThemeController([root]);
+
+        controller.setMode("automatic");
+        controller.dispose();
+
+        expect(media.listenerCount()).toBe(0);
+        expect(root.hasAttribute(THEME_ATTRIBUTE)).toBe(false);
+    });
+
+    it("mirrors the resolved kind onto a legacy #theme-link when present", () => {
+        stubMatchMedia(false);
+        const link = setThemeLink("lightTheme.css");
+        const controller = new ThemeController([makeRoot()]);
+
+        controller.setMode("dark");
+
+        expect(currentCss(link)).toBe("darkTheme.css");
+    });
+
+    it("does not throw or log when no #theme-link is present", () => {
         stubMatchMedia(false);
         const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
-        const { setThemeMode } = await loadTheme();
+        const controller = new ThemeController([makeRoot()]);
 
-        expect(() => setThemeMode("dark")).not.toThrow();
-        expect(error).toHaveBeenCalled();
+        expect(() => controller.setMode("dark")).not.toThrow();
+        expect(error).not.toHaveBeenCalled();
+    });
+
+    it("keeps two controllers independent", () => {
+        stubMatchMedia(false);
+        const a = makeRoot();
+        const b = makeRoot();
+        const controllerA = new ThemeController([a]);
+        const controllerB = new ThemeController([b]);
+
+        controllerA.setMode("dark");
+        controllerB.setMode("light");
+
+        expect(a.getAttribute(THEME_ATTRIBUTE)).toBe("dark");
+        expect(b.getAttribute(THEME_ATTRIBUTE)).toBe("light");
     });
 });

--- a/packages/bpmn-modeler/src/theme.ts
+++ b/packages/bpmn-modeler/src/theme.ts
@@ -1,35 +1,122 @@
 /**
- * Page-singleton theme controller for the modeler's `#theme-link` stylesheet.
+ * Per-instance theme controller for the modeler.
  *
- * {@link setThemeMode} drives which of the consumer-linked `lightTheme.css` /
- * `darkTheme.css` the `#theme-link` element points at. `"automatic"` resolves
- * the kind from the OS/browser `prefers-color-scheme` and keeps following it
- * live; `"light"` / `"dark"` force a fixed stylesheet and stop following.
+ * The authoritative mechanism is a `data-bpmn-theme="light" | "dark"` attribute
+ * the controller toggles on the scope roots it is handed (a modeler's canvas
+ * container + its `propertiesPanel.parent`). The dark stylesheet's rules are all
+ * scoped under `[data-bpmn-theme="dark"]`, so theming one instance never leaks
+ * onto another on the same page.
  *
- * A host's own light/dark chrome (e.g. VS Code's `<body>` classes) is host
- * policy: the host adapter maps that signal to a forced `setTheme("light")` /
- * `setTheme("dark")` — the package never reads host chrome.
+ * {@link applyLegacyThemeLink} keeps the pre-attribute `#theme-link` href swap
+ * alive as a permanent, page-global compatibility fallback for consumers that
+ * still link `lightTheme.css` / `darkTheme.css` themselves. It is a silent no-op
+ * when no `#theme-link` is present — the attribute mechanism stands on its own.
  *
- * @internal Not part of the public handle; reached only through
- *   {@link BpmnModeler.setTheme}.
+ * `"automatic"` resolves the kind from the OS/browser `prefers-color-scheme` and
+ * keeps following it live; `"light"` / `"dark"` force a fixed kind and stop
+ * following. A host's own light/dark chrome (e.g. VS Code's `<body>` classes) is
+ * host policy: the host adapter maps that signal to a forced mode — the package
+ * never reads host chrome.
+ *
+ * @internal Not part of the public handle; reached through
+ *   {@link BpmnModeler.setTheme}, and reusable by the viewer/design-mode surfaces
+ *   that take plain scope roots rather than a modeler.
  */
 import type { ThemeMode } from "./publicApi";
 
-let currentMode: ThemeMode = "automatic";
-let mediaQuery: MediaQueryList | undefined;
-let mediaListener: ((event: MediaQueryListEvent) => void) | undefined;
+export type ResolvedThemeKind = "light" | "dark";
+
+/** The attribute the dark stylesheet's `[data-bpmn-theme="dark"]` rules key off. */
+export const THEME_ATTRIBUTE = "data-bpmn-theme";
+
+export class ThemeController {
+    // `undefined` (not `"automatic"`) until the first setMode so that an initial
+    // setMode("automatic") actually engages instead of hitting the same-mode
+    // early return.
+    private mode: ThemeMode | undefined;
+    private mediaQuery?: MediaQueryList;
+    private mediaListener?: (event: MediaQueryListEvent) => void;
+
+    constructor(private readonly scopeRoots: readonly HTMLElement[]) {}
+
+    /**
+     * Switches the theme mode. `"automatic"` applies the current
+     * `prefers-color-scheme` and installs a `change` listener so a later
+     * OS/browser theme switch is reflected live; a forced `"light"`/`"dark"`
+     * stops that listener so the fixed choice is not overwritten on the next
+     * scheme change. A no-op when the mode is unchanged.
+     */
+    setMode(mode: ThemeMode): void {
+        if (mode === this.mode) {
+            return;
+        }
+        this.mode = mode;
+
+        if (mode === "automatic") {
+            this.startFollowingPreferredScheme();
+        } else {
+            this.stopFollowingPreferredScheme();
+            this.apply(mode);
+        }
+    }
+
+    /** Detaches the scheme listener and removes the attribute from every root. */
+    dispose(): void {
+        this.stopFollowingPreferredScheme();
+        for (const root of this.scopeRoots) {
+            root.removeAttribute(THEME_ATTRIBUTE);
+        }
+    }
+
+    /** Sets the attribute on every scope root and mirrors it to the legacy link. */
+    private apply(kind: ResolvedThemeKind): void {
+        for (const root of this.scopeRoots) {
+            root.setAttribute(THEME_ATTRIBUTE, kind);
+        }
+        applyLegacyThemeLink(kind);
+    }
+
+    /**
+     * Applies the current `prefers-color-scheme` and installs a single live
+     * `change` listener for it (idempotent — a second automatic entry re-applies
+     * but does not stack listeners).
+     */
+    private startFollowingPreferredScheme(): void {
+        const query = window.matchMedia("(prefers-color-scheme: dark)");
+        this.apply(query.matches ? "dark" : "light");
+
+        if (this.mediaListener) {
+            return;
+        }
+        this.mediaQuery = query;
+        this.mediaListener = (event: MediaQueryListEvent) => {
+            if (this.mode === "automatic") {
+                this.apply(event.matches ? "dark" : "light");
+            }
+        };
+        this.mediaQuery.addEventListener("change", this.mediaListener);
+    }
+
+    private stopFollowingPreferredScheme(): void {
+        if (this.mediaQuery && this.mediaListener) {
+            this.mediaQuery.removeEventListener("change", this.mediaListener);
+        }
+        this.mediaQuery = undefined;
+        this.mediaListener = undefined;
+    }
+}
 
 /**
- * Swaps the `#theme-link` stylesheet between `lightTheme.css` and
+ * Swaps the legacy `#theme-link` stylesheet between `lightTheme.css` and
  * `darkTheme.css`, comparing the current href first to avoid a redundant DOM
- * mutation. Logs (does not throw) when the consumer linked no `#theme-link`.
+ * mutation. A silent no-op when no `#theme-link` is present — the attribute
+ * mechanism is authoritative, so a missing legacy link is not an error.
  *
  * @param kind `"dark"` to apply the dark stylesheet, `"light"` for the light one.
  */
-export function applyResolvedTheme(kind: "light" | "dark"): void {
+function applyLegacyThemeLink(kind: ResolvedThemeKind): void {
     const theme = document.querySelector<HTMLLinkElement>("#theme-link");
     if (!theme) {
-        console.error("Theme link element not found.");
         return;
     }
 
@@ -41,55 +128,4 @@ export function applyResolvedTheme(kind: "light" | "dark"): void {
     } else if (kind === "light" && css === "darkTheme.css") {
         theme.href = href.replace(/darkTheme\.css$/, "lightTheme.css");
     }
-}
-
-/**
- * Switches the page theme mode. `"automatic"` applies the current
- * `prefers-color-scheme` and installs a `change` listener so a later OS/browser
- * theme switch is reflected live; a forced `"light"`/`"dark"` stops that
- * listener so the fixed choice is not overwritten on the next scheme change.
- *
- * A no-op when the mode is unchanged.
- */
-export function setThemeMode(mode: ThemeMode): void {
-    if (mode === currentMode) {
-        return;
-    }
-    currentMode = mode;
-
-    if (mode === "automatic") {
-        startFollowingPreferredScheme();
-    } else {
-        stopFollowingPreferredScheme();
-        applyResolvedTheme(mode);
-    }
-}
-
-/**
- * Applies the current `prefers-color-scheme` and installs a single live
- * `change` listener for it (idempotent — a second automatic entry re-applies
- * but does not stack listeners).
- */
-function startFollowingPreferredScheme(): void {
-    const query = window.matchMedia("(prefers-color-scheme: dark)");
-    applyResolvedTheme(query.matches ? "dark" : "light");
-
-    if (mediaListener) {
-        return;
-    }
-    mediaQuery = query;
-    mediaListener = (event: MediaQueryListEvent) => {
-        if (currentMode === "automatic") {
-            applyResolvedTheme(event.matches ? "dark" : "light");
-        }
-    };
-    mediaQuery.addEventListener("change", mediaListener);
-}
-
-function stopFollowingPreferredScheme(): void {
-    if (mediaQuery && mediaListener) {
-        mediaQuery.removeEventListener("change", mediaListener);
-    }
-    mediaQuery = undefined;
-    mediaListener = undefined;
 }

--- a/packages/bpmn-modeler/vite.themes.config.mts
+++ b/packages/bpmn-modeler/vite.themes.config.mts
@@ -1,14 +1,25 @@
 import { defineConfig } from "vite";
 import { resolve } from "node:path";
 
-// The two theme stylesheets ship as standalone CSS entries a consumer links
-// (or that the modeler's "automatic" theme swaps via `#theme-link`). CSS cannot
-// be a Vite lib entry, so this is a separate CSS-only rollup. The output names
-// are a de-facto contract: `libs/modeler-types/theme.ts` swaps `lightTheme.css`
-// ↔ `darkTheme.css` by regex, so keep them exact.
+import stripThemeScope from "./scripts/postcss-strip-theme-scope.mjs";
+
+// The two legacy theme stylesheets ship as standalone CSS entries a consumer
+// links via `#theme-link` (the permanent compatibility fallback for the
+// authoritative `data-bpmn-theme` attribute mechanism). The dark source is
+// authored scoped under `[data-bpmn-theme="dark"]`; `stripThemeScope` removes
+// that scope here so the split `darkTheme.css` stays un-scoped as before (the
+// light input has no attribute, so the plugin is a no-op on it). CSS cannot be a
+// Vite lib entry, so this is a separate CSS-only rollup. The output names are a
+// de-facto contract — `#theme-link` swaps `lightTheme.css` ↔ `darkTheme.css` by
+// name — so keep them exact.
 export default defineConfig({
     root: __dirname,
     cacheDir: "../../node_modules/.vite/bpmn-modeler-themes",
+    css: {
+        postcss: {
+            plugins: [stripThemeScope()],
+        },
+    },
     build: {
         target: "es2021",
         outDir: "dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4158,6 +4158,8 @@ __metadata:
     lodash: "npm:4.18.1"
     minisearch: "npm:7.2.0"
     npm-run-all: "npm:4.1.5"
+    postcss: "npm:8.5.12"
+    postcss-selector-parser: "npm:7.1.1"
     preact: "npm:10.29.3"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.3"
@@ -19094,7 +19096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-selector-parser@npm:^7.0.0":
+"postcss-selector-parser@npm:7.1.1, postcss-selector-parser@npm:^7.0.0":
   version: 7.1.1
   resolution: "postcss-selector-parser@npm:7.1.1"
   dependencies:
@@ -19111,6 +19113,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:8.5.12, postcss@npm:^8.5.10":
+  version: 8.5.12
+  resolution: "postcss@npm:8.5.12"
+  dependencies:
+    nanoid: "npm:^3.3.11"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/5baebaf574c567bc1b3d61197f38af4ce5920b8f611c887fb6bc3dcc14af00253c169dbf19897bc889cce0b0d9818ab5eb4ea0caedf02b0bab10da8a43ce8c12
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.4.33, postcss@npm:^8.4.43":
   version: 8.5.10
   resolution: "postcss@npm:8.5.10"
@@ -19119,17 +19132,6 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/c592dffa0c4873b401f01955b265538d9942f425040df5e2b8f0ad34c83773a792ea0fa5859ccc99cfb5b955b4ebff118ab7056315388dc83b107b0fa8313576
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.10":
-  version: 8.5.12
-  resolution: "postcss@npm:8.5.12"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5baebaf574c567bc1b3d61197f38af4ce5920b8f611c887fb6bc3dcc14af00253c169dbf19897bc889cce0b0d9818ab5eb4ea0caedf02b0bab10da8a43ce8c12
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4158,7 +4158,7 @@ __metadata:
     lodash: "npm:4.18.1"
     minisearch: "npm:7.2.0"
     npm-run-all: "npm:4.1.5"
-    postcss: "npm:8.5.12"
+    postcss: "npm:8.5.26"
     postcss-selector-parser: "npm:7.1.1"
     preact: "npm:10.29.3"
     tslib: "npm:2.8.1"
@@ -17696,15 +17696,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.17":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
@@ -19113,29 +19104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.5.12, postcss@npm:^8.5.10":
-  version: 8.5.12
-  resolution: "postcss@npm:8.5.12"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5baebaf574c567bc1b3d61197f38af4ce5920b8f611c887fb6bc3dcc14af00253c169dbf19897bc889cce0b0d9818ab5eb4ea0caedf02b0bab10da8a43ce8c12
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.33, postcss@npm:^8.4.43":
-  version: 8.5.10
-  resolution: "postcss@npm:8.5.10"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/c592dffa0c4873b401f01955b265538d9942f425040df5e2b8f0ad34c83773a792ea0fa5859ccc99cfb5b955b4ebff118ab7056315388dc83b107b0fa8313576
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.26":
+"postcss@npm:8.5.26, postcss@npm:^8.4.33, postcss@npm:^8.4.43, postcss@npm:^8.5.10, postcss@npm:^8.5.26, postcss@npm:^8.5.8":
   version: 8.5.26
   resolution: "postcss@npm:8.5.26"
   dependencies:
@@ -19143,17 +19112,6 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/2bdafc00d96bd57b6649a52e458864a4bf58ee56cfdbe4aea1472b5cccc127e6c1ad653bd0bec50d211e650eb0b9270c80e1e72aff2e2fa40d9e7363234d6e43
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.8":
-  version: 8.5.8
-  resolution: "postcss@npm:8.5.8"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/dd918f7127ee7c60a0295bae2e72b3787892296e1d1c3c564d7a2a00c68d8df83cadc3178491259daa19ccc54804fb71ed8c937c6787e08d8bd4bedf8d17044c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issue

Closes #1406

## Description

Replaces the global `#theme-link` href swap with a per-instance `ThemeController` that toggles `data-bpmn-theme` on the modeler's container and properties-panel parent, with the dark rules authored scoped under that attribute and driven by CSS custom properties (folded into `styles.css`). The legacy `lightTheme.css`/`darkTheme.css` outputs are now generated from the same scoped source by a small postcss strip plugin, and the `#theme-link` swap remains as a permanent silent fallback. All in-repo BPMN shells (bpmn-webview, VS Code `WebviewHtml.ts`, IntelliJ `WebviewServer.kt`, demo pages) migrate to the attribute mechanism via a new `hostTheme.ts` adapter, while DMN keeps its `#theme-link` path untouched. `createModeler` now engages the documented `"automatic"` default when `theme` is omitted, and `dual.html` gains per-pane theme toggles as the per-instance regression check. See ADR 0012 for the decision record.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
