### PR TITLE
feat(bpmn-modeler)!: make the lint stack injectable via /lint subpath

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -652,6 +652,8 @@ jobs:
         run: |
           test -f packages/bpmn-modeler/dist/index.js
           test -f packages/bpmn-modeler/dist/index.d.ts
+          test -f packages/bpmn-modeler/dist/lint.js
+          test -f packages/bpmn-modeler/dist/lint.d.ts
           test -f packages/bpmn-modeler/dist/bpmn-modeler.css
           test -f packages/bpmn-modeler/dist/lightTheme.css
           test -f packages/bpmn-modeler/dist/darkTheme.css

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -607,9 +607,15 @@ function startSession(
         const capabilities = injectedCapabilities ?? createProtocolCapabilities();
         const extraModules = (injectedModules as unknown[]) ?? [];
         // Real hosts run the linter themselves and push results, so the default
-        // tier is external. A consumer (or the demo) can opt into in-page linting
-        // by passing an explicit `linting`. The user's in-canvas toggle is relayed
-        // to the host, which re-lints and pushes the new state down.
+        // tier is external. The lint stack is injectable now (#1407): the package
+        // no longer imports it, so this webview imports the `/lint` subpath and
+        // hands the module in. The dynamic `import()` keeps the chunk a separate
+        // lazily-fetched file (byte-identical to before — the vscode/intellij
+        // hosts consume this built bundle and are unchanged), now owned by the
+        // host rather than the package. A consumer (or the demo) can opt into
+        // in-page linting by passing an explicit `linting`. The user's in-canvas
+        // toggle is relayed to the host, which re-lints and pushes the new state
+        // down.
         try {
             bpmnModeler = await createModeler(canvasEl, {
                 engine,
@@ -621,7 +627,10 @@ function startSession(
                 additionalModules: extraModules,
                 clipboard,
                 capabilities,
-                linting: injectedLinting ?? { results: "external" },
+                linting: injectedLinting ?? {
+                    results: "external",
+                    module: await import("@miragon/bpmn-modeler/lint"),
+                },
                 // A real host activates in-page linting only after it answers the
                 // GetBpmnlintConfigCommand with BpmnlintInPageQuery (no workspace
                 // config); the webview then pushes its findings back so the host

--- a/apps/bpmn-webview/vitest.config.ts
+++ b/apps/bpmn-webview/vitest.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
                 __dirname,
                 "../../packages/bpmn-modeler/src/diff/index.ts",
             ),
+            "@miragon/bpmn-modeler/lint": resolve(
+                __dirname,
+                "../../packages/bpmn-modeler/src/bpmnlint/index.ts",
+            ),
             "@miragon/bpmn-modeler": resolve(__dirname, "../../packages/bpmn-modeler/src/index.ts"),
             "@miragon/bpmn-modeler-shared": resolve(__dirname, "../../libs/shared/src/index.ts"),
             "@miragon/bpmn-modeler-types": resolve(

--- a/apps/demo-webapp/bpmn/demoHost.ts
+++ b/apps/demo-webapp/bpmn/demoHost.ts
@@ -57,8 +57,8 @@ export class BpmnDemoHost extends MockHostApi<WebviewState, MessageType> {
                 dispatch(new PropertiesPanelStateQuery(true));
                 break;
             // Deliberately no GetBpmnlintConfigCommand reply: the demo lints
-            // in-page (`linting: {}`), and an external results/null push would
-            // switch the instance to the external tier and suspend that.
+            // in-page (`linting: { module }`), and an external results/null push
+            // would switch the instance to the external tier and suspend that.
         }
     }
 }

--- a/apps/demo-webapp/bpmn/dual.ts
+++ b/apps/demo-webapp/bpmn/dual.ts
@@ -1,4 +1,5 @@
 import { createModeler } from "@miragon/bpmn-modeler";
+import * as lintModule from "@miragon/bpmn-modeler/lint";
 import { getActiveModel } from "../src";
 
 /**
@@ -74,14 +75,15 @@ async function mount(
     if (!container || !propertiesPanelParent) {
         throw new Error(`Missing #${canvasId} or #${panelId}`);
     }
-    // No host wiring: `linting` is omitted, so each pane lints in-page with the
-    // engine-aware default config (the multi-instance proof — both panes lint
-    // independently). handleGlobalEscape stays off so each instance only reacts
-    // to Escapes in its own subtrees. `createModeler` is async now (it awaits the
-    // lazy lint chunk and stands the modeler up), so it is awaited before loading.
+    // No host wiring: the lint stack is injected via the `/lint` subpath (#1407),
+    // so each pane lints in-page with the engine-aware default config (the
+    // multi-instance proof — both panes lint independently). handleGlobalEscape
+    // stays off so each instance only reacts to Escapes in its own subtrees.
+    // `createModeler` is async, so it is awaited before loading.
     const modeler = await createModeler(container, {
         engine,
         propertiesPanel: { parent: propertiesPanelParent },
+        linting: { module: lintModule },
     });
     await modeler.loadDiagram(xml);
     mountThemeToggle(container, modeler);

--- a/apps/demo-webapp/bpmn/main.ts
+++ b/apps/demo-webapp/bpmn/main.ts
@@ -1,4 +1,5 @@
 import { bootstrap } from "@miragon/bpmn-modeler-webview";
+import * as lintModule from "@miragon/bpmn-modeler/lint";
 import { mountDemoHeader, DemoGrayoutModule, modelHref, resolveReference } from "../src";
 import { BpmnDemoHost } from "./demoHost";
 
@@ -7,13 +8,14 @@ mountDemoHeader("bpmn");
 // are omitted, so their context-pad entries / lock UI genuinely never render — a
 // host-less consumer gets no dead buttons.
 //
-// `linting: {}` opts into in-page linting with the engine-aware default config —
-// the host-less proof that the webview lints itself. onLintResults logs each run
-// so the browser console shows the rule-keyed output + any rules the bundled
-// resolver could not cover.
+// `linting: { module }` opts into in-page linting with the engine-aware default
+// config — the host-less proof that the webview lints itself. The lint stack is
+// injectable now (#1407), so the demo imports the `/lint` subpath and hands it
+// in. onLintResults logs each run so the browser console shows the rule-keyed
+// output + any rules the bundled resolver could not cover.
 bootstrap(new BpmnDemoHost(), {
     extraModules: [DemoGrayoutModule],
-    linting: {},
+    linting: { module: lintModule },
     // Plain-browser demo: use the native browser clipboard. The stub
     // host cannot serve a real clipboard, so the protocol-bridge default would
     // leave paste dead in the production build.

--- a/docs/adr/0013-injectable-lint-stack.md
+++ b/docs/adr/0013-injectable-lint-stack.md
@@ -1,0 +1,113 @@
+# 0013 — Injectable lint stack via the `@miragon/bpmn-modeler/lint` subpath
+
+- Status: accepted (#1407)
+- Date: 2026-09-01
+- Category: bpmn-webview
+
+Roadmap step 5 of the bpm-iq embeddability epic (#1409). The first step toward a
+subpath-injection pattern that the viewer (#1405, `/viewer`) and design (#1196,
+`/design`) surfaces build on.
+
+## Context
+
+The package used to reach its bundled lint stack through an internal dynamic
+`import("./bpmnlint")` in `modeler.ts`, so the whole stack
+(`bpmn-js-bpmnlint`, `bpmnlint`, `@miragon/bpmnlint-plugin-rules`, and its CSS)
+code-split into a lazily-fetched chunk. That kept it off the critical path for
+multi-file consumers, and [ADR 0007](0007-public-modeler-api.md) made linting an
+opinionated `[B]` built-in — **on by default**, `linting: false` to opt out.
+
+Single-file hosts break that. bpm-iq embeds the modeler through
+`vite-plugin-singlefile`, which sets Rollup's `inlineDynamicImports`: every
+dynamic import is inlined into the one output bundle. A **reachable** dynamic
+import can never be tree-shaken — the bundler cannot prove `linting: false` at
+build time — so the entire lint stack landed in a `linting: false` consumer's
+bundle regardless. The epic's acceptance criterion is the opposite: a
+`linting: false` consumer must have **no lint import in its module graph at all,
+in every bundling mode.**
+
+The epic's own wording said "the internal dynamic import stays the default." The
+maintainer superseded that: keeping any internal import — even guarded, even as a
+fallback — yields zero benefit for single-file hosts, because reachability, not
+the guard, is what defeats tree-shaking.
+
+## Decision
+
+**Injection-only, breaking.** Remove the internal dynamic import entirely. The
+package never imports its lint stack; a host that wants linting imports the new
+`@miragon/bpmn-modeler/lint` subpath and hands the namespace in as
+`linting.module`.
+
+- **New tier ladder** (`LintingOptions`), with `module` **required** on both
+  object variants:
+
+  | `linting` | lint bytes in consumer bundle | behaviour |
+  | --- | --- | --- |
+  | *(omitted)* | none | off + one-time `console.info` migration nudge |
+  | `false` | none | off, silent, explicit |
+  | `{ module, config? }` | via host's own `/lint` import | in-page linting |
+  | `{ module, results: "external" }` | via host's own `/lint` import | paints host-pushed results; `startInPageLinting` handback works |
+
+  `module` is required even on the external tier because that tier still needs
+  `LintConfigService` to paint. A missed migration is therefore a **compile-time**
+  error, not a silent runtime downgrade.
+
+- **Omitted `linting` now means off** (was: on with the bundled default). This
+  amends [ADR 0007](0007-public-modeler-api.md)'s "`[B]` on-by-default" for
+  linting specifically — with the stack no longer bundled, on-by-default would
+  require importing it unconditionally, defeating the whole change. A one-time
+  `console.info` nudge eases the migration.
+
+- **`LintingOptions.module` is a structural `LintModule` interface**
+  (`{ createLintModule(tier, callbacks): unknown }`), not
+  `typeof import("./bpmnlint")`. api-extractor rollups of relative `import()`
+  types are fragile; a type-level conformance check in `publicApi.spec.ts`
+  (`typeof import("./bpmnlint") extends LintModule`) keeps the interface and the
+  implementation in sync without the rollup hazard.
+
+- **The dynamic import moves into `apps/bpmn-webview/src/bootstrap.ts`**, which is
+  in this PR. The webview imports `/lint` and injects it; the chunk stays a
+  separate lazily-fetched file, byte-identical to before — now owned by the host,
+  not the package. The epic's hard constraint (no vscode/intellij host change)
+  holds: both consume the built webview bundle, which is unchanged in shape.
+
+- **Lint CSS stays unconditional.** `cssCodeSplit: false` already folds the lint
+  chrome CSS into `dist/bpmn-modeler.css` (`@miragon/bpmn-modeler/styles.css`),
+  which every consumer loads. Injecting the module brings no extra stylesheet
+  wiring; the CSS bytes are unchanged.
+
+### Mechanised gates
+
+- **`scripts/check-lint-free-entry.mjs`** (new, wired into the package `build`):
+  walks the static import graph from `dist/index.js` and fails if any statically
+  reachable chunk names `bpmnlint`. This mechanises the acceptance criterion.
+- **`src/architecture.spec.ts`**: outside `src/bpmnlint/`, no *value* import
+  (static or dynamic) of `./bpmnlint`, `bpmn-js-bpmnlint`, or `bpmnlint`;
+  `import type` stays allowed.
+- **`scripts/check-dts.mjs`** and the CI dist-artefact list gain the new
+  `lint.d.ts` / `lint.js` entry; `scripts/smoke-consumer.mjs` resolves the
+  `./lint` subpath.
+
+## Alternatives considered
+
+- **Keep the internal import as a fallback when `module` is omitted.** Rejected:
+  a reachable import is exactly what `inlineDynamicImports` cannot shake, so it
+  delivers zero benefit for the single-file hosts that motivated the change.
+- **Optional `module` with a runtime fallback to the bundled stack.** Rejected
+  for the same reason, and it would reintroduce the bundled dependency.
+- **Runtime warning instead of a compile error for a missing `module`.**
+  Rejected: silent degradation of an opinionated built-in is worse than a
+  type error the migrator sees immediately.
+- **Keep on-by-default by importing the stack unconditionally.** Rejected: it is
+  the very coupling this change removes.
+
+## Consequences
+
+- **Breaking API change**, released as `feat(bpmn-modeler)!` while the package is
+  pre-1.0 (0.2.0). Consumers that linted implicitly must now inject a `module`.
+- Establishes the **subpath-injection precedent** for #1405 (`/viewer`) and
+  #1196 (`/design`).
+- `apps/demo-webapp` (`bpmn/main.ts`, `bpmn/dual.ts`) now injects the `/lint`
+  module to keep its host-less in-page linting.
+- Deviates from epic #1409's literal "internal dynamic import stays the default"
+  wording, per the maintainer decision recorded above.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,3 +50,4 @@ contributor-facing record, not user documentation.
 | [0010](0010-expose-reference-availability-through-navigation-port.md) | Expose reference availability through the model navigation port | accepted |
 | [0011](0011-stable-core-service-contract.md) | Freeze a typed, semver-covered contract for the seven core bpmn-js services reached via `getService` | accepted |
 | [0012](0012-container-scoped-theming.md) | Container-scoped theming via a per-instance `data-bpmn-theme` attribute; `#theme-link` swap kept as permanent legacy fallback | accepted |
+| [0013](0013-injectable-lint-stack.md) | Injectable lint stack via the `@miragon/bpmn-modeler/lint` subpath; omitted `linting` now means off | accepted |

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -46,10 +46,10 @@
             "entry": ["dmn/main.ts", "bpmn/dual.ts", "bpmn/diff.ts"]
         },
         "packages/bpmn-modeler": {
-            // The lazy bpmnlint chunk is reached via `await import("./bpmnlint")`
-            // in modeler.ts; list its barrel so knip does not read the whole
-            // chunk as unused. `src/diff/index.ts` is the public `./diff`
-            // subpath entry (package.json exports), so its exports are API.
+            // `src/bpmnlint/index.ts` is the public `@miragon/bpmn-modeler/lint`
+            // subpath entry a host injects (#1407) and `src/diff/index.ts` the
+            // public `./diff` subpath (both in package.json exports), so their
+            // exports are API — list them so knip does not read them as unused.
             "entry": ["src/index.ts", "src/bpmnlint/index.ts", "src/diff/index.ts"],
             // minisearch (via model-navigation), lodash (via modeler-types'
             // asyncDebounce), and bpmn-js-differ (via the inlined bpmn-diff lib)

--- a/libs/modeler-types/src/lint.ts
+++ b/libs/modeler-types/src/lint.ts
@@ -30,7 +30,7 @@ export type BpmnlintRuleConfig = BpmnlintRuleSeverity | readonly [BpmnlintRuleSe
 
 /**
  * Structural mirror of a bpmnlint configuration (`.bpmnlintrc`) as the public
- * `linting: { config }` option accepts it. Kept structural — not an
+ * `linting: { module, config }` option accepts it. Kept structural — not an
  * import of bpmnlint's own types — so the published API surface does not leak a
  * transitive bpmnlint dependency. Unresolvable `extends`/`rules` degrade
  * gracefully at load and surface via {@link LintRunEvent.unresolved}.

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -140,21 +140,34 @@ metadata, so the caller owns the fallback policy.
 
 ## Linting tiers
 
-Linting is an opinionated built-in with a tier ladder, selected via
-`options.linting`:
+Linting is an opinionated built-in, but the lint stack is **injection-only**: it
+lives behind the [`@miragon/bpmn-modeler/lint`](#lint) subpath and is never
+bundled by the package. An on-tier passes a `module` you import from that
+subpath, so a `linting: false` consumer keeps the whole stack out of its module
+graph — in **every** bundling mode, including single-file bundlers where a
+reachable internal dynamic import can no longer be tree-shaken.
 
-| `linting` | Behaviour |
-| --- | --- |
-| *(omitted)* | On, with the bundled default ruleset. |
-| `false` | Off entirely — no chip, no overlay, no lint chunk loaded. |
-| `{ config }` | On, with a caller-supplied `BpmnlintConfig`. Rules the bundled resolver cannot resolve degrade gracefully and are reported via `LintRunEvent.unresolved` rather than failing the pass. |
-| `{ results: "external" }` | The modeler only *paints* results the host computes and pushes through `handle.applyLintResults(...)`; no in-webview linter runs. |
+| `linting` | Lint bytes in your bundle | Behaviour |
+| --- | --- | --- |
+| *(omitted)* | none | Off, with a one-time `console.info` migration nudge. |
+| `false` | none | Off entirely — no chip, no overlay. Silent and explicit. |
+| `{ module, config? }` | via your `/lint` import | On, with the default or a caller-supplied `BpmnlintConfig`. Rules the bundled resolver cannot resolve degrade gracefully and are reported via `LintRunEvent.unresolved` rather than failing the pass. |
+| `{ module, results: "external" }` | via your `/lint` import | The modeler only *paints* results the host computes and pushes through `handle.applyLintResults(...)`; no in-webview linter runs. `module` is still required — the external tier needs it to paint and to service a `startInPageLinting` handback. |
 
-The linting stack (`bpmn-js-bpmnlint`, `bpmnlint`, the rule plugin, and its CSS)
-is code-split into a lazily-loaded chunk: it is fetched only when an
-instance actually lints, so `linting: false` keeps it out of your bundle's
-critical path entirely. Lint results surface through `onLintResults`, and the
-in-canvas enable/disable toggle through `onLintingToggled`.
+```ts
+import { createModeler } from "@miragon/bpmn-modeler";
+
+const modeler = await createModeler(container, {
+    engine,
+    propertiesPanel: { parent: panel },
+    // The dynamic import keeps the lint stack a separate lazily-fetched chunk;
+    // omit `linting` (or pass `false`) and nothing here ever imports it.
+    linting: { module: await import("@miragon/bpmn-modeler/lint") },
+});
+```
+
+Lint results surface through `onLintResults`, and the in-canvas enable/disable
+toggle through `onLintingToggled`.
 
 ## Core services & escape hatch
 
@@ -270,6 +283,36 @@ viewport subscriptions and `viewer.destroy()` to tear each pane down.
 **Semver:** `DiffResult` and the exported signatures are the contract; the
 flow-order heuristics that decide *where* an id sorts are not — they may change
 without a major bump.
+
+## Lint
+
+`@miragon/bpmn-modeler/lint` is the injectable lint stack (`bpmn-js-bpmnlint`,
+`bpmnlint`, the rule plugin, and its CSS). The package never imports it — a host
+that wants linting imports this subpath and hands the namespace to
+`options.linting.module` (see [Linting tiers](#linting-tiers)). That injection
+is what keeps the stack out of a `linting: false` consumer's bundle in every
+bundling mode.
+
+```ts
+import { createModeler } from "@miragon/bpmn-modeler";
+import "@miragon/bpmn-modeler/styles.css"; // includes the lint chrome CSS
+
+// Static import — the stack ships in your main chunk:
+import * as lint from "@miragon/bpmn-modeler/lint";
+await createModeler(container, { engine, propertiesPanel: { parent }, linting: { module: lint } });
+
+// …or dynamic — the bundler keeps it a separate lazily-fetched chunk:
+await createModeler(container, {
+    engine,
+    propertiesPanel: { parent },
+    linting: { module: await import("@miragon/bpmn-modeler/lint") },
+});
+```
+
+The single export is `createLintModule` (matching the public `LintModule`
+interface). The lint chrome's CSS is not code-split — it always lands in
+`@miragon/bpmn-modeler/styles.css`, which every consumer already loads — so
+importing the subpath brings no extra stylesheet wiring.
 
 ## Caveats
 

--- a/packages/bpmn-modeler/package.json
+++ b/packages/bpmn-modeler/package.json
@@ -42,6 +42,10 @@
             "types": "./dist/diff.d.ts",
             "import": "./dist/diff.js"
         },
+        "./lint": {
+            "types": "./dist/lint.d.ts",
+            "import": "./dist/lint.js"
+        },
         "./styles.css": "./dist/bpmn-modeler.css",
         "./light-theme.css": "./dist/lightTheme.css",
         "./dark-theme.css": "./dist/darkTheme.css",
@@ -49,11 +53,12 @@
     },
     "scripts": {
         "typecheck": "tsc --noEmit",
-        "build": "npm-run-all -s typecheck build:lib build:themes check:dts check:diff-node check:dep-alignment",
+        "build": "npm-run-all -s typecheck build:lib build:themes check:dts check:diff-node check:lint-free check:dep-alignment",
         "build:lib": "vite build",
         "build:themes": "vite build -c vite.themes.config.mts",
         "check:dts": "node scripts/check-dts.mjs",
         "check:diff-node": "node scripts/check-diff-node.mjs",
+        "check:lint-free": "node scripts/check-lint-free-entry.mjs",
         "check:dep-alignment": "yarn constraints",
         "test": "vitest run --coverage"
     },

--- a/packages/bpmn-modeler/scripts/check-dts.mjs
+++ b/packages/bpmn-modeler/scripts/check-dts.mjs
@@ -5,14 +5,15 @@
 // workspace lib name (those are inlined, so a surviving import means the d.ts
 // roll-up leaked an un-bundled dependency the consumer cannot install).
 //
-// Both public entries are checked — the root `dist/index.d.ts` and the
-// `dist/diff.d.ts` data-layer subpath (#1378).
+// All three public entries are checked — the root `dist/index.d.ts`, the
+// `dist/diff.d.ts` data-layer subpath (#1378), and the `dist/lint.d.ts`
+// injectable-lint subpath (#1407).
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
 const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../dist");
-const ENTRY_DTS = ["index.d.ts", "diff.d.ts"];
+const ENTRY_DTS = ["index.d.ts", "diff.d.ts", "lint.d.ts"];
 
 // Whole-word protocol type names + the private protocol package. The word gate
 // also covers public diff jsdoc: a bare `Query`/`Command`/`HostApi` in a

--- a/packages/bpmn-modeler/scripts/check-lint-free-entry.mjs
+++ b/packages/bpmn-modeler/scripts/check-lint-free-entry.mjs
@@ -1,0 +1,72 @@
+// Acceptance criterion for issue #1407, mechanised: a `linting: false` consumer
+// must have no lint import in its module graph, in every bundling mode. The lint
+// stack now lives behind the `@miragon/bpmn-modeler/lint` subpath and is injected
+// by the host, so nothing the root entry *statically* reaches may name bpmnlint.
+//
+// We start at `dist/index.js` and follow only static import/export specifiers
+// (never `import(...)` — a dynamic import is a separate chunk a single-file
+// bundler inlines, which is the whole failure mode this replaces), collecting the
+// transitive closure of chunks the root entry pulls in unconditionally. If any of
+// them mentions `bpmnlint`, the lint stack leaked back into the critical path.
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve, relative } from "node:path";
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../dist");
+const ROOT_ENTRY = resolve(distDir, "index.js");
+const FORBIDDEN = /bpmnlint/;
+
+// Static specifiers only: `import … from "x"`, bare `import "x"`, and
+// `export … from "x"`. `import(` (dynamic) is deliberately excluded.
+const STATIC_SPECIFIER_PATTERNS = [
+    /\bimport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
+    /\bexport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
+    /\bimport\s*["']([^"']+)["']/g,
+];
+
+function staticSpecifiers(code) {
+    return STATIC_SPECIFIER_PATTERNS.flatMap((pattern) =>
+        [...code.matchAll(pattern)].map((match) => match[1]),
+    );
+}
+
+function fail(message) {
+    console.error(`check-lint-free-entry: ${message}`);
+    process.exit(1);
+}
+
+if (!existsSync(ROOT_ENTRY)) {
+    fail(`${ROOT_ENTRY} not found — run the lib build first.`);
+}
+
+const visited = new Set();
+const offenders = [];
+const queue = [ROOT_ENTRY];
+
+while (queue.length > 0) {
+    const file = queue.pop();
+    if (visited.has(file)) continue;
+    visited.add(file);
+
+    const code = readFileSync(file, "utf8");
+    if (FORBIDDEN.test(code)) {
+        offenders.push(relative(distDir, file));
+    }
+
+    for (const spec of staticSpecifiers(code)) {
+        if (!spec.startsWith(".")) continue; // bare externals are the consumer's problem, not ours
+        const resolved = resolve(dirname(file), spec);
+        if (existsSync(resolved)) queue.push(resolved);
+    }
+}
+
+if (offenders.length > 0) {
+    fail(
+        `the root entry statically reaches the lint stack — it must stay behind ` +
+            `the injectable /lint subpath:\n  ${offenders.join("\n  ")}`,
+    );
+}
+
+console.log(
+    `check-lint-free-entry: dist/index.js and its ${visited.size - 1} static chunks are lint-free.`,
+);

--- a/packages/bpmn-modeler/scripts/smoke-consumer.mjs
+++ b/packages/bpmn-modeler/scripts/smoke-consumer.mjs
@@ -38,7 +38,7 @@ for (const field of [
 
 // 2. Every exports subpath resolves to a real file. The root entry is
 //    DOM-touching, so we resolve it (proves the mapping + file) but never import it.
-const SUBPATHS = [".", "./diff", "./styles.css", "./light-theme.css", "./dark-theme.css"];
+const SUBPATHS = [".", "./diff", "./lint", "./styles.css", "./light-theme.css", "./dark-theme.css"];
 for (const subpath of SUBPATHS) {
     const specifier = subpath === "." ? PKG : `${PKG}/${subpath.slice(2)}`;
     let resolved;

--- a/packages/bpmn-modeler/src/architecture.spec.ts
+++ b/packages/bpmn-modeler/src/architecture.spec.ts
@@ -56,6 +56,31 @@ function importedModules(content: string): string[] {
     );
 }
 
+// Value imports only — `import type` / `export type` are erased at build and so
+// never pull runtime code into a bundle. Used by the lint-injection gate below.
+const VALUE_SPECIFIER_PATTERNS: readonly RegExp[] = [
+    /\bimport\s+(?!type\b)[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
+    /\bexport\s+(?!type\b)[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
+    /\bimport\s*["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']/g,
+    /\brequire\s*\(\s*["']([^"']+)["']/g,
+];
+
+// Drop block + line comments so a specifier *named in prose* (e.g. the
+// `typeof import("./bpmnlint")` mention in a jsdoc) is not read as a real
+// import. Coarse — it may nick a `//` inside a string literal — but harmless
+// here: we only pattern-match import specifiers out of the result.
+function stripComments(content: string): string {
+    return content.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+function valueImportedModules(content: string): string[] {
+    const code = stripComments(content);
+    return VALUE_SPECIFIER_PATTERNS.flatMap((pattern) =>
+        [...code.matchAll(pattern)].map((match) => match[1]),
+    );
+}
+
 /** `@miragon/bpmn-modeler` exactly, or a subpath of it — but not `-types`/`-core`/… */
 const PACKAGE_SELF = /^@miragon\/bpmn-modeler(\/|$)/;
 
@@ -121,6 +146,31 @@ describe("bpmn-modeler import direction", () => {
             offenders,
             `every top-level dark-theme rule must be scoped under ` +
                 `[data-bpmn-theme="dark"]:\n${offenders.join("\n")}`,
+        ).toEqual([]);
+    });
+
+    it("only src/bpmnlint/ value-imports the lint stack (#1407)", () => {
+        // The lint stack is injection-only: a host imports `@miragon/bpmn-modeler/lint`
+        // (which resolves to `src/bpmnlint/index.ts`) and hands the module in. No
+        // other package source may pull it into the runtime graph — a reachable
+        // value import (static or dynamic) is exactly what a single-file bundler
+        // inlines even under `linting: false`. `import type` stays fine.
+        const LINT_STACK = (spec: string): boolean =>
+            spec === "bpmnlint" || spec === "bpmn-js-bpmnlint" || /(^|\/)bpmnlint$/.test(spec); // the `./bpmnlint` barrel, not its type subpaths
+        const BPMNLINT_DIR = join(PKG_SRC, "bpmnlint");
+        const offenders: string[] = [];
+        for (const file of listSourceFiles(PKG_SRC)) {
+            if (file.startsWith(BPMNLINT_DIR)) continue;
+            for (const spec of valueImportedModules(readFileSync(file, "utf8"))) {
+                if (LINT_STACK(spec)) {
+                    offenders.push(`${file.slice(PKG_SRC.length + 1)} → ${spec}`);
+                }
+            }
+        }
+        expect(
+            offenders,
+            `the lint stack is injection-only — only src/bpmnlint/ may value-import ` +
+                `it (use \`import type\` elsewhere):\n${offenders.join("\n")}`,
         ).toEqual([]);
     });
 

--- a/packages/bpmn-modeler/src/bpmnlint/index.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/index.ts
@@ -1,17 +1,18 @@
 /**
- * Lazy-loaded chunk entry for in-canvas bpmnlint.
+ * Public `@miragon/bpmn-modeler/lint` subpath entry.
  *
  * This module — and only this module — statically imports the lint stack
  * (`bpmn-js-bpmnlint`, `bpmnlint`'s `Linter`, `@miragon/bpmnlint-plugin-rules`,
- * and the CSS). Because the modeler reaches it through a dynamic
- * `import("./bpmnlint")`, the whole stack lands in a separate chunk that is
- * fetched only when an instance actually lints (`linting !== false`), keeping it
- * out of the main webview bundle.
+ * and the CSS). The package never imports it: a host that wants linting imports
+ * this subpath itself and hands the namespace in as `linting.module` (see
+ * {@link LintModule}). That injection is what keeps the whole stack out of a
+ * `linting: false` consumer's module graph — even under single-file bundlers,
+ * where a reachable internal dynamic import can no longer be tree-shaken.
  *
- * bpmn-js modules are fixed at construction, so the chunk must resolve *before*
- * `new BpmnModeler7/8`. The facade awaits this import, then calls
- * {@link createLintModule} with the per-instance tier + config + callbacks and
- * drops the returned module into `additionalModules`.
+ * bpmn-js modules are fixed at construction, so the host resolves this import
+ * *before* `createModeler`; the facade then calls {@link createLintModule} with
+ * the per-instance tier + config + callbacks and drops the returned module into
+ * `additionalModules`.
  */
 import bpmnLintingModule from "bpmn-js-bpmnlint";
 import "bpmn-js-bpmnlint/dist/assets/css/bpmn-js-bpmnlint.css";

--- a/packages/bpmn-modeler/src/index.ts
+++ b/packages/bpmn-modeler/src/index.ts
@@ -20,6 +20,7 @@ export { createModeler } from "./createModeler";
 export type {
     ThemeMode,
     LintingOptions,
+    LintModule,
     ClipboardOptions,
     ContentSavedEvent,
     ModelerOptions,

--- a/packages/bpmn-modeler/src/lintModules.spec.ts
+++ b/packages/bpmn-modeler/src/lintModules.spec.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BpmnlintConfig } from "@miragon/bpmn-modeler-types";
+import type { LintCallbacks, LintTierInit } from "./bpmnlint/LintConfigService";
+import type { LintModule } from "./publicApi";
+import { buildLintModules } from "./lintModules";
+
+// A stub `/lint` module that records the args createLintModule was called with
+// and returns a sentinel so we can assert it lands in the returned array.
+function stubModule(): { module: LintModule; calls: [LintTierInit, LintCallbacks][] } {
+    const calls: [LintTierInit, LintCallbacks][] = [];
+    const sentinel = { __lintModule: true };
+    const module: LintModule = {
+        createLintModule: (tier, callbacks) => {
+            calls.push([tier, callbacks]);
+            return sentinel;
+        },
+    };
+    return { module, calls };
+}
+
+const CALLBACKS: LintCallbacks = { onLintResults: vi.fn(), onLintingToggled: vi.fn() };
+
+describe("buildLintModules", () => {
+    beforeEach(() => {
+        vi.spyOn(console, "info").mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("returns no modules and nudges once for an omitted linting option", () => {
+        // The once-guard is module-level, so the first `undefined` in the whole
+        // run is the only one that fires; assert the return, not the call count
+        // (another spec in the file may have consumed the guard already).
+        expect(buildLintModules(undefined, "c7", CALLBACKS)).toEqual([]);
+        // Re-invoking never registers a module regardless of the guard state.
+        expect(buildLintModules(undefined, "c7", CALLBACKS)).toEqual([]);
+    });
+
+    it("fires the migration nudge at most once across calls", () => {
+        const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+        buildLintModules(undefined, "c7", CALLBACKS);
+        buildLintModules(undefined, "c8", CALLBACKS);
+        // Zero or one, never two — the guard may have been tripped by an earlier
+        // spec, but a second call in this test must not re-fire.
+        expect(info.mock.calls.length).toBeLessThanOrEqual(1);
+    });
+
+    it("returns no modules for linting: false without nudging", () => {
+        const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+        expect(buildLintModules(false, "c7", CALLBACKS)).toEqual([]);
+        expect(info).not.toHaveBeenCalled();
+    });
+
+    it("builds one in-page module forwarding engine, config, and callbacks", () => {
+        const { module, calls } = stubModule();
+        const config: BpmnlintConfig = { rules: { "label-required": "warn" } };
+        const result = buildLintModules({ module, config }, "c7", CALLBACKS);
+
+        expect(result).toHaveLength(1);
+        expect(calls).toHaveLength(1);
+        const [tier, callbacks] = calls[0];
+        expect(tier).toEqual({ tier: "in-page", engine: "c7", config });
+        expect(callbacks).toBe(CALLBACKS);
+    });
+
+    it("defaults an in-page module to no config when none is supplied", () => {
+        const { module, calls } = stubModule();
+        buildLintModules({ module }, "c8", CALLBACKS);
+        expect(calls[0][0]).toEqual({ tier: "in-page", engine: "c8", config: undefined });
+    });
+
+    it("builds one external module with no config", () => {
+        const { module, calls } = stubModule();
+        const result = buildLintModules({ module, results: "external" }, "c8", CALLBACKS);
+
+        expect(result).toHaveLength(1);
+        expect(calls[0][0]).toEqual({ tier: "external", engine: "c8", config: undefined });
+    });
+});

--- a/packages/bpmn-modeler/src/lintModules.ts
+++ b/packages/bpmn-modeler/src/lintModules.ts
@@ -1,0 +1,51 @@
+import type { Engine } from "@miragon/bpmn-modeler-types";
+import type { LintCallbacks } from "./bpmnlint/LintConfigService";
+import type { LintingOptions } from "./publicApi";
+
+// Fires at most once per page: an omitted `linting` used to enable in-page
+// linting, so a silent upgrade would strip a consumer's linter without a word.
+let migrationNoticeShown = false;
+
+/**
+ * Resolves the bpmnlint DI module(s) for the chosen tier from the host-injected
+ * {@link LintModule}. Pure and synchronous — the lint stack is no longer fetched
+ * by the package; the host owns the `@miragon/bpmn-modeler/lint` import.
+ *
+ * - `undefined` — no module, plus a one-time `console.info` migration nudge (an
+ *   omitted `linting` enabled in-page linting before injection).
+ * - `false` — no module, silent.
+ * - `{ module, config? }` — one in-page module carrying the engine + config.
+ * - `{ module, results: "external" }` — one external module (no config); it
+ *   paints host-pushed results and services the `startInPageLinting` handback.
+ */
+export function buildLintModules(
+    linting: LintingOptions | undefined,
+    engine: Engine,
+    callbacks: LintCallbacks,
+): unknown[] {
+    if (linting === undefined) {
+        if (!migrationNoticeShown) {
+            migrationNoticeShown = true;
+            console.info(
+                "@miragon/bpmn-modeler: linting is off because no lint module was supplied. " +
+                    'Pass `linting: { module: await import("@miragon/bpmn-modeler/lint") }` to ' +
+                    "enable in-page linting, or `linting: false` to silence this notice.",
+            );
+        }
+        return [];
+    }
+    if (linting === false) {
+        return [];
+    }
+
+    // Only `{ results: "external" }` opts out of in-page; narrowing on `results`
+    // keeps `config` off the external variant.
+    let tier: "external" | "in-page" = "in-page";
+    let config;
+    if (linting.results === "external") {
+        tier = "external";
+    } else {
+        config = linting.config;
+    }
+    return [linting.module.createLintModule({ tier, engine, config }, callbacks)];
+}

--- a/packages/bpmn-modeler/src/modeler.ts
+++ b/packages/bpmn-modeler/src/modeler.ts
@@ -35,6 +35,7 @@ import {
     OpenScriptEditorsStore,
     ScriptSourceWatcher,
 } from "@miragon/bpmn-modeler-inline-scripting";
+import { buildLintModules } from "./lintModules";
 import { capabilityModules } from "./capabilityModules";
 import { ViewportManager } from "./viewport";
 import { SelectionManager } from "./selection";
@@ -44,7 +45,8 @@ import { installKeyboardFocus } from "./keyboardFocus";
 import { installCanvasFocusIndicator } from "./canvasFocusIndicator";
 import type { CreateModelerOptions } from "./createModeler";
 import type { CoreModelerServices, ThemeMode } from "./publicApi";
-// Type-only: erased at build so it never pulls the lazy lint chunk into the main bundle.
+// Type-only: erased at build so it never pulls the lint stack into the main
+// bundle. The runtime lint module is injected by the host (see LintingOptions).
 import type { LintConfigService } from "./bpmnlint/LintConfigService";
 
 const DEFAULT_SETTINGS: BpmnModelerSetting = {
@@ -155,9 +157,10 @@ export class BpmnModeler {
      * debounced content-saved). The DI extras, capabilities, and page-level
      * side-effect callbacks all come from the constructor options.
      *
-     * Async because the engine-aware step awaits the lazy bpmnlint chunk before
-     * constructing bpmn-js. Re-`init()` disposes the prior instance's focus
-     * installs first.
+     * Async for API stability (a host that learns the engine late calls this
+     * late); the lint modules are now built synchronously from the host-injected
+     * lint module. Re-`init()` disposes the prior instance's focus installs
+     * first.
      *
      * @internal Construction step invoked by {@link createModeler}; not part of
      *   the public handle.
@@ -178,7 +181,10 @@ export class BpmnModeler {
         const commonModules = [
             TranslateModule,
             TokenSimulationModule,
-            ...(await this.buildLintModules(engine)),
+            ...buildLintModules(this.options.linting, engine, {
+                onLintResults: this.options.onLintResults,
+                onLintingToggled: this.options.onLintingToggled,
+            }),
             ElementTemplateChooserModule,
             AppendMenuModule,
             FlowNavigationModule,
@@ -290,51 +296,17 @@ export class BpmnModeler {
     }
 
     /**
-     * Resolves the bpmnlint DI module(s) for the chosen tier, importing the lint
-     * chunk only when linting is not disabled. `linting: false` returns no
-     * modules — the chunk, and the whole bpmnlint/rules stack, is never fetched.
-     * Every other value dynamically imports {@link createLintModule} and
-     * registers one instance-scoped module carrying the tier, engine, explicit
-     * config, and the facade callbacks.
-     */
-    private async buildLintModules(engine: Engine): Promise<unknown[]> {
-        const linting = this.options.linting;
-        if (linting === false) {
-            return [];
-        }
-        // `undefined` and `{ config }` are in-page; only `{ results: "external" }`
-        // opts out. Narrowing on `results` keeps `config` off the external variant.
-        let tier: "external" | "in-page" = "in-page";
-        let config;
-        if (typeof linting === "object") {
-            if (linting.results === "external") {
-                tier = "external";
-            } else {
-                config = linting.config;
-            }
-        }
-        const { createLintModule } = await import("./bpmnlint");
-        return [
-            createLintModule(
-                { tier, engine, config },
-                {
-                    onLintResults: this.options.onLintResults,
-                    onLintingToggled: this.options.onLintingToggled,
-                },
-            ),
-        ];
-    }
-
-    /**
      * Feeds host-computed lint results to the in-canvas overlays (external tier).
      * Any push switches an in-page instance to the external tier. `null`
      * deactivates linting (no `.bpmnlintrc` / read failure). A no-op with a warning
-     * when the instance was created with `linting: false` (no lint service).
+     * when the instance was created without a lint module (no lint service).
      */
     applyLintResults(results: LintResults | null): void {
         const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
         if (!service) {
-            console.warn("applyLintResults ignored: this modeler was created with linting: false");
+            console.warn(
+                "applyLintResults ignored: this modeler was created without a lint module",
+            );
             return;
         }
         service.applyLintResults(results);
@@ -342,13 +314,14 @@ export class BpmnModeler {
 
     /**
      * Renders the host's user-disabled lint state (external tier): clears overlays
-     * and shows the re-enable chip. A no-op with a warning when `linting: false`.
+     * and shows the re-enable chip. A no-op with a warning when the instance was
+     * created without a lint module.
      */
     applyLintingDisabled(): void {
         const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
         if (!service) {
             console.warn(
-                "applyLintingDisabled ignored: this modeler was created with linting: false",
+                "applyLintingDisabled ignored: this modeler was created without a lint module",
             );
             return;
         }
@@ -359,7 +332,7 @@ export class BpmnModeler {
      * Starts (or restarts) the in-page linter on host instruction — the handback
      * when the host finds no workspace `.bpmnlintrc`. Mirrors
      * {@link applyLintResults}: a no-op with a warning when the instance was
-     * created with `linting: false` (no lint service). Never re-enables a
+     * created without a lint module (no lint service). Never re-enables a
      * user-disabled linter (the service guards that); any later host push still
      * wins over the in-page run.
      */
@@ -367,7 +340,7 @@ export class BpmnModeler {
         const service = this.getModeler().get<LintConfigService>("bpmnLintConfig", false);
         if (!service) {
             console.warn(
-                "startInPageLinting ignored: this modeler was created with linting: false",
+                "startInPageLinting ignored: this modeler was created without a lint module",
             );
             return;
         }

--- a/packages/bpmn-modeler/src/publicApi.spec.ts
+++ b/packages/bpmn-modeler/src/publicApi.spec.ts
@@ -9,10 +9,15 @@ import type {
     CoreModelerServices,
     CreateModeler,
     LintingOptions,
+    LintModule,
     ModelerOptions,
     StableModelerSurface,
     ThemeMode,
 } from "./publicApi";
+
+// A minimal stub of the injected `@miragon/bpmn-modeler/lint` namespace. The
+// on-tiers below all require a `module`, so migration failures are compile-time.
+const _lintModule: LintModule = { createLintModule: () => ({}) };
 
 /**
  * Type-level conformance + scenario spec for the public API.
@@ -82,13 +87,16 @@ const _formAwareNavigation = {
 } satisfies ModelNavigationPort;
 void _formAwareNavigation;
 
-// Graceful `{ config }` linting. The literal type-checks against the
+// Graceful `{ module, config }` linting. The literal type-checks against the
 // BpmnlintConfig mirror; unresolvable rules degrade at runtime and surface via
 // onLintResults({ results, unresolved }).
 const _scenarioLintConfig = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
-    linting: { config: { extends: "bpmnlint:recommended", rules: { "label-required": "warn" } } },
+    linting: {
+        module: _lintModule,
+        config: { extends: "bpmnlint:recommended", rules: { "label-required": "warn" } },
+    },
     onLintResults: ({ results, unresolved }) => {
         void results;
         void unresolved;
@@ -96,14 +104,49 @@ const _scenarioLintConfig = {
 } satisfies ModelerOptions;
 void _scenarioLintConfig;
 
+// External tier: `{ module, results: "external" }`. `module` is required — the
+// external tier still needs LintConfigService to paint host-pushed results.
+const _scenarioLintExternal = {
+    engine: "c8",
+    propertiesPanel: { parent: document.createElement("div") },
+    linting: { module: _lintModule, results: "external" },
+} satisfies ModelerOptions;
+void _scenarioLintExternal;
+
+// Migration failures are compile-time: an object tier without `module` is
+// rejected, and `config` never rides the external variant.
+const _lintMissingModule = {
+    engine: "c7",
+    propertiesPanel: { parent: document.createElement("div") },
+    // @ts-expect-error — an object lint tier must supply a `module`.
+    linting: { config: {} },
+} satisfies ModelerOptions;
+void _lintMissingModule;
+
+const _lintExternalMissingModule = {
+    engine: "c7",
+    propertiesPanel: { parent: document.createElement("div") },
+    // @ts-expect-error — the external tier must supply a `module`.
+    linting: { results: "external" },
+} satisfies ModelerOptions;
+void _lintExternalMissingModule;
+
+// Type-level entry conformance (no runtime load): the real `/lint` subpath
+// namespace structurally satisfies the public LintModule contract. If
+// createLintModule's signature drifts from LintModule, this line stops
+// compiling — keeping the structural interface in sync with the implementation.
+type _EntryConformsToLintModule = typeof import("./bpmnlint") extends LintModule ? true : never;
+const _entryConforms: _EntryConformsToLintModule = true;
+void _entryConforms;
+
 // [B] Opinionated built-ins: each tier/override type-checks in isolation, and
 // the target factory type is nameable. These exercise the built-in and event
 // declarations the scenario literals above don't reach.
 const _themes = ["light", "dark", "automatic"] satisfies ThemeMode[];
 void _themes;
 const _lintOff: LintingOptions = false;
-const _lintExternal: LintingOptions = { results: "external" };
-const _lintConfig: LintingOptions = { config: {} };
+const _lintExternal: LintingOptions = { module: _lintModule, results: "external" };
+const _lintConfig: LintingOptions = { module: _lintModule, config: {} };
 void [_lintOff, _lintExternal, _lintConfig];
 const _clipboard: ClipboardOptions = {
     bridge: { requestClipboard: () => Promise.resolve(""), writeClipboard: () => undefined },

--- a/packages/bpmn-modeler/src/publicApi.ts
+++ b/packages/bpmn-modeler/src/publicApi.ts
@@ -14,6 +14,10 @@ import type {
     LintRunEvent,
 } from "@miragon/bpmn-modeler-types";
 import type { ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
+// Type-only import — erased at build (same contract as modeler.ts's
+// LintConfigService import), so referencing the lint module's types here never
+// pulls the lint stack into the main bundle.
+import type { LintCallbacks, LintTierInit } from "./bpmnlint/LintConfigService";
 import type { ModelerCapabilities } from "./capabilities";
 import type { ViewportManager } from "./viewport";
 import type { SelectionManager } from "./selection";
@@ -57,22 +61,49 @@ import type { SelectionManager } from "./selection";
 export type ThemeMode = "light" | "dark" | "automatic";
 
 /**
- * [B] Linting configuration tiers:
+ * [B] The namespace of `@miragon/bpmn-modeler/lint`, imported and handed in by
+ * the host. The lint stack (`bpmn-js-bpmnlint`, `bpmnlint`, the rule plugin, and
+ * its CSS) lives behind this subpath so a `linting: false` consumer never pulls
+ * it into the module graph — even under single-file bundlers, where a reachable
+ * internal dynamic import can no longer be tree-shaken.
  *
- * - `undefined` — linting on with the bundled default ruleset.
- * - `false` — linting off entirely (no chip, no overlay).
- * - `{ config }` — on, with a caller-supplied {@link BpmnlintConfig}; rules the
+ * ```ts
+ * linting: { module: await import("@miragon/bpmn-modeler/lint") }
+ * ```
+ *
+ * Declared structurally (not `typeof import("./bpmnlint")`) because
+ * api-extractor rollups of relative `import()` types are fragile; a type-level
+ * conformance check in `publicApi.spec.ts` keeps the two in sync.
+ */
+export interface LintModule {
+    createLintModule(tier: LintTierInit, callbacks: LintCallbacks): unknown;
+}
+
+/**
+ * [B] Linting configuration tiers. Injection-only: the lint stack is never
+ * bundled by the package, so every on-tier requires a `module` the host imports
+ * from `@miragon/bpmn-modeler/lint`.
+ *
+ * - *(omitted)* — linting off, with a one-time `console.info` migration nudge.
+ * - `false` — linting off entirely (no chip, no overlay), silent and explicit.
+ * - `{ module, config? }` — in-page linting with the injected {@link LintModule},
+ *   using the default or a caller-supplied {@link BpmnlintConfig}; rules the
  *   bundled resolver cannot resolve degrade gracefully and are reported via
  *   {@link LintRunEvent.unresolved} rather than failing the pass.
- * - `{ results: "external" }` — the modeler renders results the host computes
- *   and pushes through {@link BpmnModelerHandle.applyLintResults}; no in-webview
- *   linter runs.
+ * - `{ module, results: "external" }` — the modeler renders results the host
+ *   computes and pushes through {@link BpmnModelerHandle.applyLintResults}; no
+ *   in-webview linter runs. `module` is still required — the external tier needs
+ *   {@link LintModule} to paint and to service a `startInPageLinting` handback.
  *
  * `results?: never` on the config variant makes the union discriminable on
- * `results`, so the runtime tier selection narrows without type guards.
+ * `results`, so the runtime tier selection narrows without type guards. `module`
+ * being required on both object variants makes a missed migration a compile-time
+ * error, not a silent runtime downgrade.
  */
 export type LintingOptions =
-    false | { config?: BpmnlintConfig; results?: never } | { results: "external" };
+    | false
+    | { module: LintModule; config?: BpmnlintConfig; results?: never }
+    | { module: LintModule; results: "external" };
 
 /**
  * [B] Clipboard override. Default (option omitted) is the native browser
@@ -148,7 +179,11 @@ export interface ModelerOptions {
     moddleExtensions?: Record<string, object>;
 
     // ── [B] Opinionated built-ins ───────────────────────────────────────────
-    /** [B] Linting tier — see {@link LintingOptions}. Omit for the bundled default. */
+    /**
+     * [B] Linting tier — see {@link LintingOptions}. Injection-only: an on-tier
+     * supplies a `module` from `@miragon/bpmn-modeler/lint`. Omit (or `false`)
+     * for no linting.
+     */
     linting?: LintingOptions;
 
     /** [B] Clipboard override — omit for the native clipboard. */
@@ -290,9 +325,9 @@ export interface CoreModelerServices {
 
 /**
  * [A] The package entry point: stand up one modeler bound to `container` and
- * resolve its {@link BpmnModelerHandle}. Async because the lazy lint chunk
- * forces a construction await; a host that learns the engine late simply calls
- * this late.
+ * resolve its {@link BpmnModelerHandle}. Async for API stability (a host that
+ * learns the engine late simply calls this late); the lint stack is now injected
+ * synchronously rather than awaited internally.
  */
 export type CreateModeler = (
     container: HTMLElement,

--- a/packages/bpmn-modeler/vite.config.mts
+++ b/packages/bpmn-modeler/vite.config.mts
@@ -89,6 +89,11 @@ export default defineConfig({
                 // Data-layer subpath (`@miragon/bpmn-modeler/diff`): no CSS,
                 // bpmn-js, i18n, or preact — Node-safe (check-diff-node.mjs).
                 diff: resolve(__dirname, "src/diff/index.ts"),
+                // Injectable lint subpath (`@miragon/bpmn-modeler/lint`, #1407):
+                // the lint stack a host imports and hands in via `linting.module`,
+                // so it never lands in a `linting: false` consumer's bundle. Its
+                // CSS still folds into `dist/bpmn-modeler.css` (cssCodeSplit off).
+                lint: resolve(__dirname, "src/bpmnlint/index.ts"),
             },
             formats: ["es"],
             cssFileName: "bpmn-modeler",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,7 @@
         "paths": {
             "@miragon/bpmn-modeler": ["./packages/bpmn-modeler/src/index.ts"],
             "@miragon/bpmn-modeler/diff": ["./packages/bpmn-modeler/src/diff/index.ts"],
+            "@miragon/bpmn-modeler/lint": ["./packages/bpmn-modeler/src/bpmnlint/index.ts"],
             "@miragon/bpmn-modeler-shared": ["./libs/shared/src/index.ts"],
             "@miragon/bpmn-modeler-types": ["./libs/modeler-types/src/index.ts"],
             "@miragon/bpmn-modeler-diff": ["./libs/bpmn-diff/src/index.ts"],


### PR DESCRIPTION
## Issue

Closes #1407

## Description

Makes the lint stack injectable: it now lives behind the new `@miragon/bpmn-modeler/lint` subpath, and the package never imports it — the internal `await import("./bpmnlint")` is gone, so a `linting: false` (or omitted) consumer has no lint import in its module graph in any bundling mode, including single-file bundlers where a reachable dynamic import gets inlined regardless of the runtime tier. The `{ config }` and `{ results: "external" }` tiers now require a `module` handed in from that subpath (**breaking**: omitted `linting` means off, with a one-time `console.info` nudge, instead of in-page linting by default). `apps/bpmn-webview` keeps today's laziness by doing the dynamic `/lint` import itself, so the VS Code/IntelliJ hosts are unchanged; demos migrate to the injected module. Guarded by a new `check-lint-free-entry.mjs` dist gate, an architecture-spec value-import gate, type-level API specs, and unit tests for the new sync `buildLintModules` — see [ADR 0013](docs/adr/0013-injectable-lint-stack.md).

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [ ] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
