### PR TITLE
feat(bpmn-modeler): add readonly createViewer() on /viewer subpath

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -654,6 +654,9 @@ jobs:
           test -f packages/bpmn-modeler/dist/index.d.ts
           test -f packages/bpmn-modeler/dist/lint.js
           test -f packages/bpmn-modeler/dist/lint.d.ts
+          test -f packages/bpmn-modeler/dist/viewer.js
+          test -f packages/bpmn-modeler/dist/viewer.d.ts
+          test -f packages/bpmn-modeler/dist/viewer.css
           test -f packages/bpmn-modeler/dist/bpmn-modeler.css
           test -f packages/bpmn-modeler/dist/lightTheme.css
           test -f packages/bpmn-modeler/dist/darkTheme.css

--- a/apps/demo-webapp/bpmn/demoHost.ts
+++ b/apps/demo-webapp/bpmn/demoHost.ts
@@ -49,7 +49,10 @@ export class BpmnDemoHost extends MockHostApi<WebviewState, MessageType> {
                     new BpmnModelerSettingQuery({
                         alignToOrigin: false,
                         showTransactionBoundaries: true,
-                        colorTheme: "light",
+                        // "automatic" keeps the host theme adapter's body-class
+                        // MutationObserver alive so the shared demo header's theme
+                        // switch reaches the modeler instance.
+                        colorTheme: "automatic",
                     }),
                 );
                 break;

--- a/apps/demo-webapp/bpmn/diff.html
+++ b/apps/demo-webapp/bpmn/diff.html
@@ -3,9 +3,10 @@
     <head>
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <!-- The engine + theme CSS is imported from diff.ts so Vite serves it in
-             dev (a raw <link> to the package source escapes the dev-server root
-             and 404s). The diff view is light-only and never swaps themes. -->
+        <!-- The engine + theme CSS ships via the `@miragon/bpmn-modeler` side
+             effects imported from diff.ts (Vite serves it in dev; a raw <link>
+             to the package source would escape the dev-server root and 404).
+             Both panes theme off the shared demo header's `data-bpmn-theme`. -->
         <meta content="width=device-width, initial-scale=1.0" name="viewport" />
         <title>Miragon Modeler — Two-Pane Diff Demo</title>
         <style>
@@ -27,6 +28,9 @@
             }
             .pane:last-child {
                 border-right: none;
+            }
+            :root[data-bpmn-theme="dark"] .pane {
+                border-right-color: #3a3a3a;
             }
             .pane .canvas {
                 position: absolute;

--- a/apps/demo-webapp/bpmn/diff.ts
+++ b/apps/demo-webapp/bpmn/diff.ts
@@ -2,12 +2,10 @@ import { computeDiff } from "@miragon/bpmn-modeler/diff";
 import { DiffLegend, DiffPaneCoordinator, DiffViewer } from "@miragon/bpmn-modeler";
 import { mountDemoHeader } from "../src";
 
-// The diff page uses bare DiffViewers, which never swap `#theme-link`, so the
-// engine (Camunda C7/C8) + token-sim stylesheets must be imported here. A JS
-// import lets Vite process it (and its node_modules `@import`s) in both dev and
-// build — a raw `<link>` to this source path escapes the dev-server root and
-// 404s. The base modeler CSS ships via the `@miragon/bpmn-modeler` side effects.
-import "../../../packages/bpmn-modeler/src/styles/light-theme/index.css";
+// The engine (Camunda C7/C8) + token-sim stylesheets and the light/dark theme
+// rules all ship via the `@miragon/bpmn-modeler` side effects imported above
+// (its `themes.css` @imports `light-theme/index.css`), so both panes theme off
+// the shared demo header's ambient `data-bpmn-theme` with no extra `<link>`.
 
 import { DIFF_AFTER_XML, DIFF_BEFORE_XML } from "./diffFixtures";
 

--- a/apps/demo-webapp/bpmn/viewer.html
+++ b/apps/demo-webapp/bpmn/viewer.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Miragon Modeler — Readonly Viewer Demo</title>
+        <style>
+            body {
+                margin: 0;
+            }
+            /* A single readonly canvas — no palette, no properties panel. #app is
+               sized by the shared demo header (viewport minus header + footer). */
+            .viewer {
+                position: relative;
+                height: 100%;
+            }
+            .viewer .canvas {
+                position: absolute;
+                inset: 0;
+            }
+            .viewer .toolbar {
+                position: absolute;
+                top: 12px;
+                right: 12px;
+                z-index: 10;
+                display: flex;
+                gap: 10px;
+                align-items: center;
+                padding: 8px 12px;
+                background: rgba(255, 255, 255, 0.9);
+                border: 1px solid #d7d9de;
+                border-radius: 6px;
+                font: 500 12px/1.4 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+            }
+            .viewer .toolbar select {
+                font: inherit;
+            }
+            .viewer .selection {
+                min-width: 120px;
+                color: #6b7280;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="app" style="height: 100vh">
+            <div class="viewer">
+                <div class="canvas" id="canvas"></div>
+                <div class="toolbar">
+                    <label for="theme">Theme:</label>
+                    <select id="theme">
+                        <option value="automatic">Automatic</option>
+                        <option value="light">Light</option>
+                        <option value="dark">Dark</option>
+                    </select>
+                    <span class="selection" id="selection">Nothing selected</span>
+                </div>
+            </div>
+        </div>
+        <script src="/viewer.ts" type="module"></script>
+    </body>
+</html>

--- a/apps/demo-webapp/bpmn/viewer.html
+++ b/apps/demo-webapp/bpmn/viewer.html
@@ -33,12 +33,18 @@
                 border-radius: 6px;
                 font: 500 12px/1.4 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
             }
-            .viewer .toolbar select {
-                font: inherit;
-            }
             .viewer .selection {
                 min-width: 120px;
                 color: #6b7280;
+            }
+            /* Theme is driven by the shared demo header now; the toolbar carries
+               only the selection readout, so dark mode just needs a legible chrome. */
+            :root[data-bpmn-theme="dark"] .viewer .toolbar {
+                background: rgba(29, 29, 29, 0.9);
+                border-color: #3a3a3a;
+            }
+            :root[data-bpmn-theme="dark"] .viewer .selection {
+                color: #9aa0aa;
             }
         </style>
     </head>
@@ -47,12 +53,6 @@
             <div class="viewer">
                 <div class="canvas" id="canvas"></div>
                 <div class="toolbar">
-                    <label for="theme">Theme:</label>
-                    <select id="theme">
-                        <option value="automatic">Automatic</option>
-                        <option value="light">Light</option>
-                        <option value="dark">Dark</option>
-                    </select>
                     <span class="selection" id="selection">Nothing selected</span>
                 </div>
             </div>

--- a/apps/demo-webapp/bpmn/viewer.ts
+++ b/apps/demo-webapp/bpmn/viewer.ts
@@ -1,0 +1,43 @@
+import { createViewer } from "@miragon/bpmn-modeler/viewer";
+import type { ThemeMode } from "@miragon/bpmn-modeler/viewer";
+import { mountDemoHeader } from "../src";
+import { MODELS } from "../src/registry";
+
+// The viewer ships its own lean stylesheet (`@miragon/bpmn-modeler/viewer.css`),
+// separate from the modeler's `styles.css`. A JS import lets Vite process it (and
+// its node_modules `@import`s) in dev and build — a raw `<link>` to the package
+// source escapes the dev-server root and 404s. This is the epic's regression
+// check: the viewer page must render, select, hover, zoom/pan, and switch themes
+// with no editing affordance (no palette, context pad, or keyboard delete).
+import "../../../packages/bpmn-modeler/src/styles/viewer.css";
+
+/**
+ * In-page readonly viewer demo — the in-repo consumer of the `/viewer` subpath.
+ * No host, no bootstrap: one `createViewer` handle over a registry model, a theme
+ * `<select>` wired to `setTheme`, and a live selection readout.
+ */
+async function main(): Promise<void> {
+    mountDemoHeader("viewer");
+
+    const canvas = document.getElementById("canvas");
+    const themeSelect = document.getElementById("theme") as HTMLSelectElement | null;
+    const selectionOut = document.getElementById("selection");
+    if (!canvas || !themeSelect || !selectionOut) {
+        throw new Error("viewer demo: missing host elements");
+    }
+
+    const model = MODELS.find((m) => m.type === "bpmn") ?? MODELS[0];
+
+    const viewer = await createViewer(canvas, { theme: themeSelect.value as ThemeMode });
+    await viewer.loadDiagram(model.xml);
+
+    themeSelect.addEventListener("change", () => {
+        viewer.setTheme(themeSelect.value as ThemeMode);
+    });
+
+    viewer.selection.onSelectionChanged((ids) => {
+        selectionOut.textContent = ids.length > 0 ? ids.join(", ") : "Nothing selected";
+    });
+}
+
+void main();

--- a/apps/demo-webapp/bpmn/viewer.ts
+++ b/apps/demo-webapp/bpmn/viewer.ts
@@ -13,27 +13,32 @@ import "../../../packages/bpmn-modeler/src/styles/viewer.css";
 
 /**
  * In-page readonly viewer demo — the in-repo consumer of the `/viewer` subpath.
- * No host, no bootstrap: one `createViewer` handle over a registry model, a theme
- * `<select>` wired to `setTheme`, and a live selection readout.
+ * No host, no bootstrap: one `createViewer` handle over a registry model and a
+ * live selection readout. Theme comes from the shared demo header, which seeds
+ * the initial `createViewer` mode and routes later changes to the public
+ * `viewer.setTheme` API (the epic's regression check).
  */
 async function main(): Promise<void> {
-    mountDemoHeader("viewer");
+    // The header seeds the initial theme (below) and routes later changes to
+    // this handle, which only exists after createViewer resolves — hence the ref.
+    const viewerRef: { current?: Awaited<ReturnType<typeof createViewer>> } = {};
+    const { themeMode } = mountDemoHeader(
+        "viewer",
+        {},
+        { onThemeChange: (mode) => viewerRef.current?.setTheme(mode as ThemeMode) },
+    );
 
     const canvas = document.getElementById("canvas");
-    const themeSelect = document.getElementById("theme") as HTMLSelectElement | null;
     const selectionOut = document.getElementById("selection");
-    if (!canvas || !themeSelect || !selectionOut) {
+    if (!canvas || !selectionOut) {
         throw new Error("viewer demo: missing host elements");
     }
 
     const model = MODELS.find((m) => m.type === "bpmn") ?? MODELS[0];
 
-    const viewer = await createViewer(canvas, { theme: themeSelect.value as ThemeMode });
+    const viewer = await createViewer(canvas, { theme: themeMode as ThemeMode });
+    viewerRef.current = viewer;
     await viewer.loadDiagram(model.xml);
-
-    themeSelect.addEventListener("change", () => {
-        viewer.setTheme(themeSelect.value as ThemeMode);
-    });
 
     viewer.selection.onSelectionChanged((ids) => {
         selectionOut.textContent = ids.length > 0 ? ids.join(", ") : "Nothing selected";

--- a/apps/demo-webapp/dmn/demoHost.ts
+++ b/apps/demo-webapp/dmn/demoHost.ts
@@ -38,7 +38,9 @@ export class DmnDemoHost extends MockHostApi<WebviewState, MessageType> {
                 dispatch(new PropertiesPanelStateQuery(true));
                 break;
             case "GetDmnModelerSettingCommand":
-                dispatch(new DmnModelerSettingQuery({ colorTheme: "light" }));
+                // "automatic" keeps the `#theme-link` MutationObserver alive so
+                // the shared demo header's theme switch reaches the decision table.
+                dispatch(new DmnModelerSettingQuery({ colorTheme: "automatic" }));
                 break;
         }
     }

--- a/apps/demo-webapp/serve-demo.mjs
+++ b/apps/demo-webapp/serve-demo.mjs
@@ -95,5 +95,6 @@ server.listen(port, host, () => {
     console.log(`\n  Miragon Modeler demo → ${base}/`);
     console.log(`  BPMN: ${base}/bpmn/?model=newsletter`);
     console.log(`  DMN:  ${base}/dmn/?model=categorize-applicant`);
-    console.log(`  Diff: ${base}/bpmn/diff.html\n`);
+    console.log(`  Diff: ${base}/bpmn/diff.html`);
+    console.log(`  Viewer: ${base}/bpmn/viewer.html\n`);
 });

--- a/apps/demo-webapp/src/demoHeader.ts
+++ b/apps/demo-webapp/src/demoHeader.ts
@@ -6,12 +6,14 @@ export interface DemoHeaderLinks {
     docs: string;
 }
 
-// The demo has two views: the single-model modeler (bpmn/dmn) and the two-pane
-// diff. `"diff"` is not a `ModelType` — it has no active model — so the model
-// dropdown is hidden there; the view switcher is how users cross between them.
-export type DemoPage = ModelType | "diff";
+// The demo has three views: the single-model modeler (bpmn/dmn), the two-pane
+// diff, and the readonly viewer. `"diff"` and `"viewer"` are not `ModelType`s —
+// they have no active model — so the model dropdown is hidden there; the view
+// switcher is how users cross between them.
+export type DemoPage = ModelType | "diff" | "viewer";
 
 const DIFF_HREF = "/bpmn/diff.html";
+const VIEWER_HREF = "/bpmn/viewer.html";
 
 // Where the "Modeler" view link points from the diff page — the first bpmn model.
 const DEFAULT_MODELER_HREF = modelHref(MODELS.find((m) => m.type === "bpmn") ?? MODELS[0]);
@@ -28,9 +30,11 @@ const KOMET_SVG = `<svg class="komet" viewBox="0 0 512 512" aria-hidden="true"><
 export function mountDemoHeader(page: DemoPage, links: Partial<DemoHeaderLinks> = {}): void {
     const l = { ...DEFAULT_LINKS, ...links };
     const isDiff = page === "diff";
-    // The diff view has no active model; its "Modeler" link falls back to the
-    // default bpmn model so users always land somewhere sensible.
-    const modelerHref = isDiff ? DEFAULT_MODELER_HREF : modelHref(getActiveModel(page));
+    const isViewer = page === "viewer";
+    // The diff/viewer views have no active model; their "Modeler" link falls
+    // back to the default bpmn model so users always land somewhere sensible.
+    const noModel = isDiff || isViewer;
+    const modelerHref = noModel ? DEFAULT_MODELER_HREF : modelHref(getActiveModel(page));
 
     const style = document.createElement("style");
     // Colour tokens mirror Miragon/corporate-identity (brand/tokens.json).
@@ -119,23 +123,26 @@ export function mountDemoHeader(page: DemoPage, links: Partial<DemoHeaderLinks> 
     `;
     document.head.appendChild(style);
 
-    const activeId = isDiff ? null : getActiveModel(page).id;
+    const activeId = noModel ? null : getActiveModel(page).id;
     const options = MODELS.map(
         (m) =>
             `<option value="${m.id}"${m.id === activeId ? " selected" : ""}>` +
             `${m.title} (${m.type.toUpperCase()})</option>`,
     ).join("");
 
-    // The diff view has no active model, so it omits the model dropdown; both
-    // views share the switcher. All hrefs here are internal string literals.
-    const modelPicker = isDiff
+    // The diff/viewer views have no active model, so they omit the model
+    // dropdown; all views share the switcher. All hrefs here are internal
+    // string literals.
+    const modelPicker = noModel
         ? ""
         : `<label for="miragon-demo-model">Modell:</label>
            <select id="miragon-demo-model" aria-label="Modell wählen">${options}</select>`;
+    const activeAttr = ' class="active" aria-current="page"';
     const views = `
         <nav class="views" aria-label="Ansicht wählen">
-            <a href="${modelerHref}"${isDiff ? "" : ' class="active" aria-current="page"'}>Modeler</a>
-            <a href="${DIFF_HREF}"${isDiff ? ' class="active" aria-current="page"' : ""}>Diff</a>
+            <a href="${modelerHref}"${noModel ? "" : activeAttr}>Modeler</a>
+            <a href="${DIFF_HREF}"${isDiff ? activeAttr : ""}>Diff</a>
+            <a href="${VIEWER_HREF}"${isViewer ? activeAttr : ""}>Viewer</a>
         </nav>`;
 
     const header = document.createElement("header");

--- a/apps/demo-webapp/src/demoHeader.ts
+++ b/apps/demo-webapp/src/demoHeader.ts
@@ -12,6 +12,74 @@ export interface DemoHeaderLinks {
 // switcher is how users cross between them.
 export type DemoPage = ModelType | "diff" | "viewer";
 
+// The header's single theme control. `"automatic"` follows the OS
+// `prefers-color-scheme`; `"light"`/`"dark"` force a fixed choice.
+export type DemoThemeMode = "automatic" | "light" | "dark";
+type DemoThemeKind = "light" | "dark";
+
+export interface MountDemoHeaderOptions {
+    // Fired with the raw mode on every user theme change. The viewer page uses
+    // it to drive the public `viewer.setTheme`; the modeler/diff pages theme
+    // ambiently via `data-bpmn-theme` + the `vscode-dark` body class and need no
+    // callback.
+    onThemeChange?: (mode: DemoThemeMode) => void;
+}
+
+const THEME_STORAGE_KEY = "miragon-demo-theme";
+
+function readThemeMode(): DemoThemeMode {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    return stored === "light" || stored === "dark" || stored === "automatic" ? stored : "automatic";
+}
+
+function prefersDark(): boolean {
+    return (
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+    );
+}
+
+function resolveThemeKind(mode: DemoThemeMode): DemoThemeKind {
+    if (mode === "automatic") {
+        return prefersDark() ? "dark" : "light";
+    }
+    return mode;
+}
+
+// Live OS-preference listener, active only while the mode is `"automatic"`.
+let mediaQuery: MediaQueryList | undefined;
+let mediaListener: ((event: MediaQueryListEvent) => void) | undefined;
+
+function applyThemeKind(kind: DemoThemeKind): void {
+    // `data-bpmn-theme` themes every canvas, panel, and the demo chrome via CSS;
+    // the `vscode-dark` body class drives the BPMN webview's HostThemeAdapter and
+    // the DMN webview's `#theme-link` swap (both left in `"automatic"` mode) plus
+    // the package's existing `body.vscode-dark .diff-legend*` rules.
+    document.documentElement.setAttribute("data-bpmn-theme", kind);
+    document.body.classList.toggle("vscode-dark", kind === "dark");
+}
+
+/**
+ * Resolves the mode to a concrete kind, applies it to `<html>`/`<body>`, and —
+ * while `"automatic"` — installs a live `prefers-color-scheme` listener (tearing
+ * down any prior one first) so the demo follows the OS in real time.
+ */
+function applyDemoTheme(mode: DemoThemeMode): void {
+    if (mediaQuery && mediaListener) {
+        mediaQuery.removeEventListener("change", mediaListener);
+        mediaQuery = undefined;
+        mediaListener = undefined;
+    }
+
+    applyThemeKind(resolveThemeKind(mode));
+
+    if (mode === "automatic" && typeof window.matchMedia === "function") {
+        mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+        mediaListener = (event) => applyThemeKind(event.matches ? "dark" : "light");
+        mediaQuery.addEventListener("change", mediaListener);
+    }
+}
+
 const DIFF_HREF = "/bpmn/diff.html";
 const VIEWER_HREF = "/bpmn/viewer.html";
 
@@ -27,7 +95,11 @@ const DEFAULT_LINKS: DemoHeaderLinks = {
 
 const KOMET_SVG = `<svg class="komet" viewBox="0 0 512 512" aria-hidden="true"><rect width="512" height="512" rx="112" fill="#335de5"/><g transform="translate(66 196.9) scale(1.31908)"><path fill="#00e676" d="M0,89.63l220.2-14.78c11.65-.78,23.38-2.66,33.31-5.14s22.92-8.94,29.16-19.41c3.65-6.12,5.09-13.73,5.38-18.91,.27-4.94-.99-10.2-2.54-13.33-2.76-5.55-6.11-8.42-8.55-10.26-2.45-1.84-7.55-5.77-18.08-7.35-10.53-1.58-29.62,1.2-44.31,5.84C199.87,10.92,0,89.63,0,89.63Z"/></g></svg>`;
 
-export function mountDemoHeader(page: DemoPage, links: Partial<DemoHeaderLinks> = {}): void {
+export function mountDemoHeader(
+    page: DemoPage,
+    links: Partial<DemoHeaderLinks> = {},
+    options: MountDemoHeaderOptions = {},
+): { themeMode: DemoThemeMode } {
     const l = { ...DEFAULT_LINKS, ...links };
     const isDiff = page === "diff";
     const isViewer = page === "viewer";
@@ -120,11 +192,50 @@ export function mountDemoHeader(page: DemoPage, links: Partial<DemoHeaderLinks> 
         .djs-context-pad .entry.entry-demo-disabled {
             opacity: .35; cursor: not-allowed; filter: grayscale(1);
         }
+
+        /* Dark chrome, scoped on the same attribute the canvases theme off.
+           The viewer page loads only viewer.css (no body-background rule), so
+           the body fallback below paints its surround — value from the
+           dark-theme --dt-surface-a0 family (#121212). */
+        :root[data-bpmn-theme="dark"] body { background: #121212; }
+        :root[data-bpmn-theme="dark"] .miragon-demo-header {
+            background: var(--cd-schwarz); color: #f2f2f2;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 1px 3px rgba(0, 0, 0, 0.5);
+        }
+        :root[data-bpmn-theme="dark"] .miragon-demo-header label { color: #9aa0aa; }
+        :root[data-bpmn-theme="dark"] .miragon-demo-header .views {
+            background: #2a2a2a; border-color: #3a3a3a;
+        }
+        :root[data-bpmn-theme="dark"] .miragon-demo-header .views a { color: #9aa0aa; }
+        :root[data-bpmn-theme="dark"] .miragon-demo-header .views a:hover {
+            background: rgba(51, 93, 229, 0.18);
+        }
+        :root[data-bpmn-theme="dark"] .miragon-demo-header .views a.active {
+            background: var(--cd-schwarz); color: #6f8cf0;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+        }
+        :root[data-bpmn-theme="dark"] .miragon-demo-header select {
+            background: #2a2a2a; color: #f2f2f2; border-color: #3a3a3a;
+        }
+        :root[data-bpmn-theme="dark"] .miragon-demo-header a {
+            color: #6f8cf0; border-color: #3a3a3a;
+        }
+        :root[data-bpmn-theme="dark"] .miragon-demo-header a:hover {
+            border-color: var(--cd-blau); background: rgba(51, 93, 229, 0.18);
+        }
+        :root[data-bpmn-theme="dark"] .miragon-demo-header a.primary {
+            color: var(--cd-weiss); background: var(--cd-blau); border-color: var(--cd-blau);
+        }
+        :root[data-bpmn-theme="dark"] .miragon-demo-footer {
+            background: #1a1a1a; color: #9aa0aa; border-top-color: #2a2a2a;
+        }
+        :root[data-bpmn-theme="dark"] .miragon-demo-footer a { color: #9aa0aa; }
+        :root[data-bpmn-theme="dark"] .miragon-demo-footer a:hover { color: #6f8cf0; }
     `;
     document.head.appendChild(style);
 
     const activeId = noModel ? null : getActiveModel(page).id;
-    const options = MODELS.map(
+    const modelOptions = MODELS.map(
         (m) =>
             `<option value="${m.id}"${m.id === activeId ? " selected" : ""}>` +
             `${m.title} (${m.type.toUpperCase()})</option>`,
@@ -136,7 +247,17 @@ export function mountDemoHeader(page: DemoPage, links: Partial<DemoHeaderLinks> 
     const modelPicker = noModel
         ? ""
         : `<label for="miragon-demo-model">Modell:</label>
-           <select id="miragon-demo-model" aria-label="Modell wählen">${options}</select>`;
+           <select id="miragon-demo-model" aria-label="Modell wählen">${modelOptions}</select>`;
+
+    const themeMode = readThemeMode();
+    const themeOption = (value: DemoThemeMode, label: string): string =>
+        `<option value="${value}"${value === themeMode ? " selected" : ""}>${label}</option>`;
+    const themePicker = `<label for="miragon-demo-theme">Theme:</label>
+        <select id="miragon-demo-theme" aria-label="Theme wählen">
+            ${themeOption("automatic", "Automatic")}
+            ${themeOption("light", "Light")}
+            ${themeOption("dark", "Dark")}
+        </select>`;
     const activeAttr = ' class="active" aria-current="page"';
     const views = `
         <nav class="views" aria-label="Ansicht wählen">
@@ -151,6 +272,7 @@ export function mountDemoHeader(page: DemoPage, links: Partial<DemoHeaderLinks> 
         <span class="brand">${KOMET_SVG}Miragon Modeler Demo</span>
         ${views}
         ${modelPicker}
+        ${themePicker}
         <span class="spacer"></span>
     `;
     // Build the action links via the DOM API instead of interpolating the
@@ -191,4 +313,19 @@ export function mountDemoHeader(page: DemoPage, links: Partial<DemoHeaderLinks> 
             window.location.href = modelHref(model);
         }
     });
+
+    // Apply the saved mode now — mountDemoHeader runs before each page's
+    // bootstrap()/createViewer(), so the body class is in place before the
+    // theme adapters initialise.
+    applyDemoTheme(themeMode);
+
+    const themeSelect = header.querySelector<HTMLSelectElement>("#miragon-demo-theme");
+    themeSelect?.addEventListener("change", () => {
+        const mode = themeSelect.value as DemoThemeMode;
+        localStorage.setItem(THEME_STORAGE_KEY, mode);
+        applyDemoTheme(mode);
+        options.onThemeChange?.(mode);
+    });
+
+    return { themeMode };
 }

--- a/apps/demo-webapp/vite.config.mts
+++ b/apps/demo-webapp/vite.config.mts
@@ -39,9 +39,9 @@ export default defineConfig(({ mode }) => {
             outDir: resolve(__dirname, `../../dist/demo/${target}`),
             emptyOutDir: true,
             // The bpmn page ships extra entries — the two-instance regression
-            // proof at /bpmn/dual.html and the two-pane diff demo at
-            // /bpmn/diff.html. The dev server serves them automatically; only the
-            // build needs the extra rollup inputs.
+            // proof at /bpmn/dual.html, the two-pane diff demo at /bpmn/diff.html,
+            // and the readonly viewer demo at /bpmn/viewer.html. The dev server
+            // serves them automatically; only the build needs the extra inputs.
             rollupOptions:
                 target === "bpmn"
                     ? {
@@ -49,6 +49,7 @@ export default defineConfig(({ mode }) => {
                               index: resolve(__dirname, "bpmn/index.html"),
                               dual: resolve(__dirname, "bpmn/dual.html"),
                               diff: resolve(__dirname, "bpmn/diff.html"),
+                              viewer: resolve(__dirname, "bpmn/viewer.html"),
                           },
                       }
                     : undefined,

--- a/docs/adr/0014-readonly-viewer-subpath.md
+++ b/docs/adr/0014-readonly-viewer-subpath.md
@@ -1,0 +1,110 @@
+# 0014 — Readonly viewer via the `@miragon/bpmn-modeler/viewer` subpath
+
+- Status: accepted (#1405)
+- Date: 2026-09-02
+- Category: bpmn-webview
+
+Roadmap step 6 of the bpm-iq embeddability epic (#1409), building directly on the
+subpath-injection precedent [ADR 0013](0013-injectable-lint-stack.md) set for
+`/lint`, the `Pick`-able core-service contract of
+[ADR 0011](0011-stable-core-service-contract.md), and the container-scoped
+theming of [ADR 0012](0012-container-scoped-theming.md).
+
+## Context
+
+The package exposed only `createModeler` — a full editor. Hosts that need a
+readonly surface (view-only permissions, embedded previews) had nothing: hiding
+the palette leaves editing live (keyboard, context pad), and the full modeler
+drags camunda-bpmn-js, preact/properties-panel, CodeMirror, token simulation,
+and lint into the graph regardless.
+
+The same forcing function as #1407 applies: single-file hosts embed the modeler
+through `vite-plugin-singlefile`, which inlines everything *reachable*. So a
+readonly surface cannot be a runtime flag on the editor — the editor stack would
+still be reachable and therefore inlined. Leanness has to hold at the
+**module-graph** level, which means a separate entry the bundler can keep apart.
+
+The prior ADRs had prepared exactly this: `CoreModelerServices` is deliberately
+`Pick`-able (0011), `ThemeController` is generic over plain scope roots (0012),
+and 0013 established the subpath + purity-gate pattern.
+
+**Verified premises** (they differ from the issue sketch):
+
+- bpmn-js 18's base `Viewer` already ships `SelectionModule` (with
+  `interaction-events` hover/click). The only piece missing for *visible*
+  selection/hover is `bpmn-js/lib/features/outline`, which is Modeler-only
+  upstream — so the viewer adds exactly that one module.
+- `ViewportManager` / `SelectionManager` are `ServiceAccessor`-based and reuse
+  as-is (`fitViewport`'s `.djs-palette` lookup degrades to the default inset).
+- The jsdom blocker recorded in 0011 (camunda-bpmn-js's minimap CJS interop) is
+  absent from the viewer graph, so a runtime spec is feasible.
+
+## Decision
+
+Ship a **new subpath `@miragon/bpmn-modeler/viewer`** exporting an async
+`createViewer(container, options?)` that resolves a `BpmnViewerHandle`.
+
+- **NavigatedViewer + outline only.** The viewer wraps
+  `bpmn-js/lib/NavigatedViewer` (mouse + keyboard pan/zoom, no editing) and adds
+  `bpmn-js/lib/features/outline` as its single default module. No camunda
+  moddle, properties panel, lint, clipboard, token simulation, or i18n.
+- **`Pick`'d services (0011).** `CoreViewerServices = Pick<CoreModelerServices,
+  "canvas" | "elementRegistry" | "eventBus" | "overlays" | "selection">` — the
+  readonly subset. `modeling` / `commandStack` are never registered, so
+  resolving one throws. The absence of an editing surface is expressed in the
+  type *and* provable at runtime.
+- **Subset-compatible handle.** Every `BpmnViewerHandle` member is
+  signature-identical to its `BpmnModelerHandle` counterpart (asserted in
+  `publicApi.spec.ts`: `(m: BpmnModelerHandle): BpmnViewerHandle => m`), so a
+  host can narrow a modeler handle to a viewer handle without adapters.
+- **Scope-preserving `viewer.css` via a third CSS build.** The viewer's
+  `index.ts` imports no CSS — `cssCodeSplit: false` on the lib build would
+  otherwise fold any reachable sheet into the shared `dist/bpmn-modeler.css`,
+  dragging the editor chrome's CSS back in. Its sheet ships separately as
+  `@miragon/bpmn-modeler/viewer.css`, built by a clone of
+  `vite.themes.config.mts` **without** `stripThemeScope` (the viewer sheet keeps
+  its `[data-bpmn-theme="dark"]` scoping so per-instance theming works).
+- **Theming always engages (0012).** `createViewer` calls `setTheme(theme ??
+  "automatic")`, constructing a `ThemeController` over the single container root.
+
+### `locale` omitted in v1
+
+The issue sketch included `locale` on `ViewerOptions`. It is **deliberately
+omitted**: the viewer has no translatable UI, and honoring `locale` would pull
+the i18n dictionaries (`@miragon/bpmn-modeler-i18n` + the extras overlay) into
+the lean graph, defeating the whole point. This is additive later — a future
+`locale` is a non-breaking option add — so nothing is foreclosed. (Maintainer
+decision, recorded here per the deviation from the issue text.)
+
+### Mechanised gates
+
+- **`scripts/check-viewer-pure-entry.mjs`** (new, wired into `build`): walks the
+  static import graph from `dist/viewer.js` and fails if any bare specifier names
+  the editor stack (camunda-bpmn-js, bpmn-js-properties-panel, preact,
+  codemirror, bpmnlint, token-simulation, create-append-anything,
+  transaction-boundaries, minisearch, `@miragon/bpmn-modeler-i18n`). The heavy
+  stacks are Vite `external`s, so they survive as bare imports the gate can see.
+- **`src/architecture.spec.ts`**: every value-import in `src/viewer/**` and the
+  reused helpers (`viewport.ts`, `selection.ts`, `theme.ts`,
+  `elementGeometry.ts`) must be relative, `bpmn-js/*`, `diagram-js/*`, or
+  `@miragon/bpmn-modeler-types`. `import type` stays fine.
+- **`scripts/check-dts.mjs`**, the CI dist-artefact list, and
+  `scripts/smoke-consumer.mjs` gain the `viewer.js` / `viewer.d.ts` /
+  `viewer.css` entries and the `./viewer` / `./viewer.css` subpaths.
+
+## Consequences
+
+- **Additive, non-breaking.** No host (vscode/intellij) change — #1405 is purely
+  additive per the epic's hard constraint.
+- **The `DiffViewer` refactor onto the viewer internals is an explicit
+  follow-up** (a separate issue): `DiffViewer` today wraps its own
+  `NavigatedViewer`, and the viewer now generalises that. This also discharges
+  0012's "until #1405 gives it an instance" note — the viewer *is* that instance.
+- **First runtime-testable factory.** `createViewer.spec.ts` stands up a real
+  bpmn-js viewer in jsdom for the readonly proof and lifecycle; the
+  render-dependent cases (`loadDiagram` and live-registry reads) stay `it.skip`
+  because jsdom lays nothing out and bpmn-js's viewbox transform dereferences an
+  SVG `transform.baseVal` jsdom does not implement — they are covered manually
+  via the demo page (`apps/demo-webapp/bpmn/viewer.html`).
+- Establishes that the subpath-injection pattern (0013) generalises beyond
+  injection to whole alternative surfaces; #1196 (`/design`) is next.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,3 +58,4 @@ contributor-facing record, not user documentation.
 | [0011](0011-stable-core-service-contract.md) | Freeze a typed, semver-covered contract for the seven core bpmn-js services reached via `getService` | accepted |
 | [0012](0012-container-scoped-theming.md) | Container-scoped theming via a per-instance `data-bpmn-theme` attribute; `#theme-link` swap kept as permanent legacy fallback | accepted |
 | [0013](0013-injectable-lint-stack.md) | Injectable lint stack via the `@miragon/bpmn-modeler/lint` subpath; omitted `linting` now means off | accepted |
+| [0014](0014-readonly-viewer-subpath.md) | Readonly `createViewer` via the `@miragon/bpmn-modeler/viewer` subpath: NavigatedViewer + outline, `Pick`'d services, scope-preserving `viewer.css`, `locale` omitted | accepted |

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -43,14 +43,19 @@
         "apps/demo-webapp": {
             // dual.ts / diff.ts are reached only via their .html files, which the
             // vite plugin does not walk (single-mode root), so list them.
-            "entry": ["dmn/main.ts", "bpmn/dual.ts", "bpmn/diff.ts"]
+            "entry": ["dmn/main.ts", "bpmn/dual.ts", "bpmn/diff.ts", "bpmn/viewer.ts"]
         },
         "packages/bpmn-modeler": {
             // `src/bpmnlint/index.ts` is the public `@miragon/bpmn-modeler/lint`
             // subpath entry a host injects (#1407) and `src/diff/index.ts` the
             // public `./diff` subpath (both in package.json exports), so their
             // exports are API — list them so knip does not read them as unused.
-            "entry": ["src/index.ts", "src/bpmnlint/index.ts", "src/diff/index.ts"],
+            "entry": [
+                "src/index.ts",
+                "src/bpmnlint/index.ts",
+                "src/diff/index.ts",
+                "src/viewer/index.ts"
+            ],
             // minisearch (via model-navigation), lodash (via modeler-types'
             // asyncDebounce), and bpmn-js-differ (via the inlined bpmn-diff lib)
             // are pulled in only through inlined workspace libs; the Vite lib

--- a/libs/modeler-types/src/theme.spec.ts
+++ b/libs/modeler-types/src/theme.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `applyTheme` is private and module state (`currentMode`) is a singleton, so we
+// exercise it through the public `setColorThemeMode` with a fresh module per
+// test — a fresh module starts in `"automatic"`, so the first forced switch
+// always engages instead of short-circuiting on the same-mode guard.
+async function loadTheme(): Promise<typeof import("./theme")> {
+    vi.resetModules();
+    return import("./theme");
+}
+
+function setThemeLink(href: string): HTMLLinkElement {
+    document.head.innerHTML = "";
+    const link = document.createElement("link");
+    link.id = "theme-link";
+    link.rel = "stylesheet";
+    link.href = href;
+    document.head.appendChild(link);
+    return link;
+}
+
+describe("applyTheme href swap", () => {
+    beforeEach(() => {
+        document.body.className = "";
+    });
+
+    it("swaps the built filename light → dark", async () => {
+        const link = setThemeLink("lightTheme.css");
+        const { setColorThemeMode } = await loadTheme();
+
+        setColorThemeMode("dark");
+
+        expect(link.href).toMatch(/darkTheme\.css$/);
+    });
+
+    it("swaps the built filename dark → light", async () => {
+        const link = setThemeLink("darkTheme.css");
+        const { setColorThemeMode } = await loadTheme();
+
+        setColorThemeMode("light");
+
+        expect(link.href).toMatch(/lightTheme\.css$/);
+    });
+
+    it("swaps the source-style href light → dark", async () => {
+        const link = setThemeLink("styles/light-theme/index.css");
+        const { setColorThemeMode } = await loadTheme();
+
+        setColorThemeMode("dark");
+
+        expect(link.href).toMatch(/dark-theme\/index\.css$/);
+    });
+
+    it("swaps the source-style href dark → light", async () => {
+        const link = setThemeLink("styles/dark-theme/index.css");
+        const { setColorThemeMode } = await loadTheme();
+
+        setColorThemeMode("light");
+
+        expect(link.href).toMatch(/light-theme\/index\.css$/);
+    });
+});

--- a/libs/modeler-types/src/theme.ts
+++ b/libs/modeler-types/src/theme.ts
@@ -92,9 +92,11 @@ function stopObserver(): void {
 }
 
 /**
- * Swaps the `#theme-link` stylesheet between `lightTheme.css` and
- * `darkTheme.css`.  Compares the current href to avoid unnecessary DOM
- * mutations.
+ * Swaps the `#theme-link` stylesheet between its light and dark variants.
+ * Handles both the built filenames (`lightTheme.css` ↔ `darkTheme.css`) and the
+ * directory-style source hrefs (`light-theme/index.css` ↔ `dark-theme/index.css`)
+ * that the demo app and the dmn-webview dev shell link. Compares the current
+ * href to avoid unnecessary DOM mutations.
  *
  * @param isDark `true` to apply the dark theme, `false` for the light theme.
  */
@@ -106,11 +108,15 @@ function applyTheme(isDark: boolean): void {
     }
 
     const href = theme.href;
-    const css = href.split("/").pop();
+    const next = isDark
+        ? href
+              .replace(/lightTheme\.css$/, "darkTheme.css")
+              .replace(/light-theme\/index\.css$/, "dark-theme/index.css")
+        : href
+              .replace(/darkTheme\.css$/, "lightTheme.css")
+              .replace(/dark-theme\/index\.css$/, "light-theme/index.css");
 
-    if (isDark && css === "lightTheme.css") {
-        theme.href = href.replace(/lightTheme\.css$/, "darkTheme.css");
-    } else if (!isDark && css === "darkTheme.css") {
-        theme.href = href.replace(/darkTheme\.css$/, "lightTheme.css");
+    if (next !== href) {
+        theme.href = next;
     }
 }

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -284,6 +284,72 @@ viewport subscriptions and `viewer.destroy()` to tear each pane down.
 flow-order heuristics that decide *where* an id sorts are not — they may change
 without a major bump.
 
+## Viewer
+
+`@miragon/bpmn-modeler/viewer` is a lean, **readonly** surface for view-only
+permissions and embedded previews. It wraps bpmn-js's `NavigatedViewer` (mouse +
+keyboard pan/zoom) plus the selection outline — and nothing else. The editor
+stack (camunda-bpmn-js, properties panel / preact, CodeMirror, token simulation,
+lint, i18n) is **guaranteed absent from its module graph**, so it survives
+single-file bundlers that inline everything reachable.
+
+```ts
+import { createViewer } from "@miragon/bpmn-modeler/viewer";
+import "@miragon/bpmn-modeler/viewer.css"; // the viewer's own lean stylesheet
+
+const viewer = await createViewer(document.querySelector("#canvas")!, {
+    theme: "automatic",
+});
+await viewer.loadDiagram(bpmnXml);
+
+viewer.selection.onSelectionChanged((ids) => console.log("selected", ids));
+```
+
+### `ViewerOptions`
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `theme` | `"light" \| "dark" \| "automatic"` | `"automatic"` | Colour theme; toggles a per-instance `data-bpmn-theme` attribute (same mechanism as the modeler). |
+| `moddleExtensions` | `Record<string, object>` | — | Extra moddle extensions for a host's own BPMN namespace. |
+| `additionalModules` | `unknown[]` | — | Escape hatch: extra render-only bpmn-js DI modules. |
+
+### `BpmnViewerHandle`
+
+`loadDiagram`, `exportDiagram`, `getDiagramSvg`, `viewport`, `selection`,
+`setTheme`, `getService`, and `destroy` — each **signature-identical** to its
+`BpmnModelerHandle` counterpart, so a modeler handle narrows to a viewer handle
+with no adapter (a compile-time acceptance criterion). There is no `newDiagram`,
+`setElementTemplates`, `setSettings`, linting, clipboard, capabilities, or
+events.
+
+`getService` is typed against `CoreViewerServices` — the readonly `Pick` of the
+[core services](#core-services--escape-hatch): `canvas`, `elementRegistry`,
+`eventBus`, `overlays`, `selection`. The editing services (`modeling`,
+`commandStack`) are **not registered** on a viewer, so resolving one throws —
+the surface is readonly by construction, not by convention.
+
+### Guaranteed absent from the module graph
+
+`camunda-bpmn-js`, `bpmn-js-properties-panel`, `@bpmn-io/properties-panel`,
+`preact`, `codemirror` / `@codemirror/*`, `bpmnlint` / `bpmn-js-bpmnlint`,
+`bpmn-js-token-simulation`, `bpmn-js-create-append-anything`,
+`camunda-transaction-boundaries`, `minisearch`, and
+`@miragon/bpmn-modeler-i18n`. A build-time gate
+(`scripts/check-viewer-pure-entry.mjs`) fails the build if any of them reappears.
+
+### Theming & stylesheet
+
+Load **`@miragon/bpmn-modeler/viewer.css`**, not `styles.css`: the viewer sheet
+carries only the bpmn-js base diagram/font CSS plus the dark-theme diagram
+overrides — none of the editor chrome. The two overlap, so do **not** load both
+on a viewer-only page.
+
+### `locale`
+
+Not supported in v1: the viewer has no translatable UI, and honoring `locale`
+would pull the i18n dictionaries into the lean graph. It is additive later
+(non-breaking).
+
 ## Lint
 
 `@miragon/bpmn-modeler/lint` is the injectable lint stack (`bpmn-js-bpmnlint`,

--- a/packages/bpmn-modeler/package.json
+++ b/packages/bpmn-modeler/package.json
@@ -46,19 +46,26 @@
             "types": "./dist/lint.d.ts",
             "import": "./dist/lint.js"
         },
+        "./viewer": {
+            "types": "./dist/viewer.d.ts",
+            "import": "./dist/viewer.js"
+        },
         "./styles.css": "./dist/bpmn-modeler.css",
+        "./viewer.css": "./dist/viewer.css",
         "./light-theme.css": "./dist/lightTheme.css",
         "./dark-theme.css": "./dist/darkTheme.css",
         "./package.json": "./package.json"
     },
     "scripts": {
         "typecheck": "tsc --noEmit",
-        "build": "npm-run-all -s typecheck build:lib build:themes check:dts check:diff-node check:lint-free check:dep-alignment",
+        "build": "npm-run-all -s typecheck build:lib build:themes build:viewer-css check:dts check:diff-node check:lint-free check:viewer-pure check:dep-alignment",
         "build:lib": "vite build",
         "build:themes": "vite build -c vite.themes.config.mts",
+        "build:viewer-css": "vite build -c vite.viewer-css.config.mts",
         "check:dts": "node scripts/check-dts.mjs",
         "check:diff-node": "node scripts/check-diff-node.mjs",
         "check:lint-free": "node scripts/check-lint-free-entry.mjs",
+        "check:viewer-pure": "node scripts/check-viewer-pure-entry.mjs",
         "check:dep-alignment": "yarn constraints",
         "test": "vitest run --coverage"
     },

--- a/packages/bpmn-modeler/scripts/check-dts.mjs
+++ b/packages/bpmn-modeler/scripts/check-dts.mjs
@@ -13,7 +13,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
 const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../dist");
-const ENTRY_DTS = ["index.d.ts", "diff.d.ts", "lint.d.ts"];
+const ENTRY_DTS = ["index.d.ts", "diff.d.ts", "lint.d.ts", "viewer.d.ts"];
 
 // Whole-word protocol type names + the private protocol package. The word gate
 // also covers public diff jsdoc: a bare `Query`/`Command`/`HostApi` in a

--- a/packages/bpmn-modeler/scripts/check-viewer-pure-entry.mjs
+++ b/packages/bpmn-modeler/scripts/check-viewer-pure-entry.mjs
@@ -1,0 +1,109 @@
+// Acceptance criterion for issue #1405, mechanised: the readonly viewer subpath
+// (`@miragon/bpmn-modeler/viewer`) must stay lean at the *module-graph* level —
+// no editor stack in its static import closure, in every bundling mode. Single-
+// file hosts (vite-plugin-singlefile) inline everything reachable, so a bare
+// import that survives here would land in the consumer's one bundle.
+//
+// Unlike the lint gate (which greps chunk *contents* for an inlined lib), the
+// heavy editor stacks are Vite `external`s — they survive as *bare import
+// specifiers* in dist/viewer.js and its relative chunks. So we start at
+// dist/viewer.js, follow only relative specifiers (the emitted chunks), and fail
+// if any bare specifier names a forbidden package. The content-grep for
+// `bpmnlint` is kept too, to catch an inlined-lib leak the same way the lint gate
+// does.
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve, relative } from "node:path";
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../dist");
+const ROOT_ENTRY = resolve(distDir, "viewer.js");
+
+// Forbidden bare specifiers — the editor stack the viewer must never reach.
+// Matched as a whole package name: `pkg` exactly or `pkg/<subpath>`.
+const FORBIDDEN_PREFIXES = [
+    "camunda-bpmn-js",
+    "bpmn-js-properties-panel",
+    "@bpmn-io/properties-panel",
+    "preact",
+    "codemirror",
+    "@codemirror",
+    "bpmnlint",
+    "bpmn-js-bpmnlint",
+    "@miragon/bpmnlint-plugin-rules",
+    "bpmn-js-token-simulation",
+    "bpmn-js-create-append-anything",
+    "camunda-transaction-boundaries",
+    "minisearch",
+    "@miragon/bpmn-modeler-i18n",
+];
+
+// A last-line content grep (mirrors check-lint-free-entry.mjs): catches the lint
+// stack even if it were inlined into a chunk rather than left external.
+const FORBIDDEN_CONTENT = /bpmnlint/;
+
+function isForbidden(spec) {
+    return FORBIDDEN_PREFIXES.some((prefix) => spec === prefix || spec.startsWith(`${prefix}/`));
+}
+
+// Static specifiers only: `import … from "x"`, bare `import "x"`, and
+// `export … from "x"`. `import(` (dynamic) is deliberately excluded — a reachable
+// dynamic import is a separate chunk a single-file bundler inlines anyway, so we
+// follow the static closure that decides the critical path.
+const STATIC_SPECIFIER_PATTERNS = [
+    /\bimport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
+    /\bexport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
+    /\bimport\s*["']([^"']+)["']/g,
+];
+
+function staticSpecifiers(code) {
+    return STATIC_SPECIFIER_PATTERNS.flatMap((pattern) =>
+        [...code.matchAll(pattern)].map((match) => match[1]),
+    );
+}
+
+function fail(message) {
+    console.error(`check-viewer-pure-entry: ${message}`);
+    process.exit(1);
+}
+
+if (!existsSync(ROOT_ENTRY)) {
+    fail(`${ROOT_ENTRY} not found — run the lib build first.`);
+}
+
+const visited = new Set();
+const offenders = [];
+const queue = [ROOT_ENTRY];
+
+while (queue.length > 0) {
+    const file = queue.pop();
+    if (visited.has(file)) continue;
+    visited.add(file);
+
+    const code = readFileSync(file, "utf8");
+    if (FORBIDDEN_CONTENT.test(code)) {
+        offenders.push(`${relative(distDir, file)} → inlined lint stack`);
+    }
+
+    for (const spec of staticSpecifiers(code)) {
+        if (spec.startsWith(".")) {
+            // Follow our own emitted chunks.
+            const resolved = resolve(dirname(file), spec);
+            if (existsSync(resolved)) queue.push(resolved);
+            continue;
+        }
+        if (isForbidden(spec)) {
+            offenders.push(`${relative(distDir, file)} → ${spec}`);
+        }
+    }
+}
+
+if (offenders.length > 0) {
+    fail(
+        `the viewer entry statically reaches the editor stack — the /viewer ` +
+            `subpath must stay lean:\n  ${[...new Set(offenders)].join("\n  ")}`,
+    );
+}
+
+console.log(
+    `check-viewer-pure-entry: dist/viewer.js and its ${visited.size - 1} static chunks are editor-free.`,
+);

--- a/packages/bpmn-modeler/scripts/smoke-consumer.mjs
+++ b/packages/bpmn-modeler/scripts/smoke-consumer.mjs
@@ -38,7 +38,16 @@ for (const field of [
 
 // 2. Every exports subpath resolves to a real file. The root entry is
 //    DOM-touching, so we resolve it (proves the mapping + file) but never import it.
-const SUBPATHS = [".", "./diff", "./lint", "./styles.css", "./light-theme.css", "./dark-theme.css"];
+const SUBPATHS = [
+    ".",
+    "./diff",
+    "./lint",
+    "./viewer",
+    "./styles.css",
+    "./viewer.css",
+    "./light-theme.css",
+    "./dark-theme.css",
+];
 for (const subpath of SUBPATHS) {
     const specifier = subpath === "." ? PKG : `${PKG}/${subpath.slice(2)}`;
     let resolved;

--- a/packages/bpmn-modeler/src/architecture.spec.ts
+++ b/packages/bpmn-modeler/src/architecture.spec.ts
@@ -174,6 +174,44 @@ describe("bpmn-modeler import direction", () => {
         ).toEqual([]);
     });
 
+    it("the viewer subpath + its shared helpers value-import only the lean set (#1405)", () => {
+        // The `/viewer` subpath must stay lean at the module-graph level: its
+        // sources — and the helpers they reuse — may value-import only bpmn-js,
+        // diagram-js, `@miragon/bpmn-modeler-types`, or relatives. A value import
+        // of the editor stack (camunda-bpmn-js, properties-panel, preact, …)
+        // here is exactly what a single-file bundler would inline into a
+        // viewer-only consumer. `import type` stays fine. The runtime graph is
+        // gated separately by `scripts/check-viewer-pure-entry.mjs`.
+        const VIEWER_DIR = join(PKG_SRC, "viewer");
+        const SHARED_HELPERS = new Set(
+            ["viewport.ts", "selection.ts", "theme.ts", "elementGeometry.ts"].map((f) =>
+                join(PKG_SRC, f),
+            ),
+        );
+        const isAllowed = (spec: string): boolean =>
+            spec.startsWith(".") ||
+            spec === "bpmn-js" ||
+            spec.startsWith("bpmn-js/") ||
+            spec === "diagram-js" ||
+            spec.startsWith("diagram-js/") ||
+            spec === "@miragon/bpmn-modeler-types";
+        const offenders: string[] = [];
+        for (const file of listSourceFiles(PKG_SRC)) {
+            if (!file.startsWith(VIEWER_DIR) && !SHARED_HELPERS.has(file)) continue;
+            for (const spec of valueImportedModules(readFileSync(file, "utf8"))) {
+                if (!isAllowed(spec)) {
+                    offenders.push(`${file.slice(PKG_SRC.length + 1)} → ${spec}`);
+                }
+            }
+        }
+        expect(
+            offenders,
+            `the viewer subpath must stay lean — value-import only bpmn-js/*, ` +
+                `diagram-js/*, @miragon/bpmn-modeler-types, or relatives ` +
+                `(use \`import type\` for anything else):\n${offenders.join("\n")}`,
+        ).toEqual([]);
+    });
+
     it("no libs/* source imports @miragon/bpmn-modeler", () => {
         const offenders: string[] = [];
         for (const file of listSourceFiles(LIBS_ROOT)) {

--- a/packages/bpmn-modeler/src/publicApi.spec.ts
+++ b/packages/bpmn-modeler/src/publicApi.spec.ts
@@ -14,6 +14,7 @@ import type {
     StableModelerSurface,
     ThemeMode,
 } from "./publicApi";
+import type { BpmnViewerHandle, CoreViewerServices, ViewerOptions } from "./viewer/publicApi";
 
 // A minimal stub of the injected `@miragon/bpmn-modeler/lint` namespace. The
 // on-tiers below all require a `module`, so migration failures are compile-time.
@@ -229,6 +230,64 @@ const _escapeHatch = (m: BpmnModelerHandle) => {
     void [custom, untyped];
 };
 void _escapeHatch;
+
+// ── Viewer subpath conformance (#1405) ──────────────────────────────────────
+
+// Subset compatibility (acceptance criterion): every BpmnViewerHandle member is
+// signature-identical to its BpmnModelerHandle counterpart, so a modeler handle
+// narrows to a viewer handle with no adapter. If a viewer member drifts from the
+// modeler's shape, this line stops compiling.
+const _modelerSatisfiesViewerHandle = (m: BpmnModelerHandle): BpmnViewerHandle => m;
+void _modelerSatisfiesViewerHandle;
+
+// CoreViewerServices is the readonly Pick of CoreModelerServices: each shared key
+// keeps its exact vendor type, and the editing keys are absent.
+const _coreViewerServices = (v: BpmnViewerHandle) => {
+    const canvas: CoreModelerServices["canvas"] = v.getService("canvas");
+    const elementRegistry: CoreModelerServices["elementRegistry"] = v.getService("elementRegistry");
+    const eventBus: CoreModelerServices["eventBus"] = v.getService("eventBus");
+    const overlays: CoreModelerServices["overlays"] = v.getService("overlays");
+    const selection: CoreModelerServices["selection"] = v.getService("selection");
+    void [canvas, elementRegistry, eventBus, overlays, selection];
+};
+void _coreViewerServices;
+
+type _ViewerServicesAreModelerSubset = keyof CoreViewerServices extends keyof CoreModelerServices
+    ? true
+    : never;
+const _viewerServicesSubset: _ViewerServicesAreModelerSubset = true;
+void _viewerServicesSubset;
+
+// ViewerOptions is minimal: no engine, no editor-only built-ins.
+const _viewerOptions = {
+    theme: "dark",
+    moddleExtensions: {
+        bpmiq: { name: "bpmiq", uri: "http://bpmiq/schema", prefix: "bpmiq", types: [] },
+    },
+    additionalModules: [{ __init__: [] }],
+} satisfies ViewerOptions;
+void _viewerOptions;
+
+const _viewerRejectsEngine = {
+    // @ts-expect-error — a viewer has no engine (bpmn-js's base viewer reads any BPMN).
+    engine: "c7",
+} satisfies ViewerOptions;
+void _viewerRejectsEngine;
+
+const _viewerRejectsLinting = {
+    // @ts-expect-error — linting is an editor-only built-in, absent from the viewer.
+    linting: false,
+} satisfies ViewerOptions;
+void _viewerRejectsLinting;
+
+// The viewer handle carries no editing methods.
+const _viewerHasNoEditing = (v: BpmnViewerHandle) => {
+    // @ts-expect-error — `newDiagram` is a modeler-only method.
+    void v.newDiagram;
+    // @ts-expect-error — `setElementTemplates` is a modeler-only method.
+    void v.setElementTemplates;
+};
+void _viewerHasNoEditing;
 
 describe("public API conformance", () => {
     it("is a type-only conformance spec; the guarantee is the tsc pass", () => {

--- a/packages/bpmn-modeler/src/styles/viewer.css
+++ b/packages/bpmn-modeler/src/styles/viewer.css
@@ -1,0 +1,12 @@
+/*
+ * The readonly viewer's stylesheet, built standalone as
+ * `@miragon/bpmn-modeler/viewer.css` (see `vite.viewer-css.config.mts`). It
+ * carries only the bpmn-js base diagram/font CSS plus the dark-theme diagram
+ * overrides scoped under `[data-bpmn-theme="dark"]` — none of the editor chrome
+ * (camunda-bpmn-js, properties-panel, token-simulation) the full `styles.css`
+ * loads. Do not also load `styles.css` on a viewer-only page; the two overlap.
+ */
+@import "bpmn-js/dist/assets/diagram-js.css";
+@import "bpmn-js/dist/assets/bpmn-js.css";
+@import "bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css";
+@import "./dark-theme/diagram-js.css";

--- a/packages/bpmn-modeler/src/viewer/createViewer.spec.ts
+++ b/packages/bpmn-modeler/src/viewer/createViewer.spec.ts
@@ -1,0 +1,135 @@
+import { beforeAll, afterEach, describe, expect, it } from "vitest";
+import { NoModelerError } from "@miragon/bpmn-modeler-types";
+import { createViewer } from "./createViewer";
+import type { BpmnViewer } from "./viewer";
+
+/**
+ * The first runtime-testable factory in the package: the viewer graph excludes
+ * camunda-bpmn-js's minimap CJS-interop (the jsdom blocker that keeps the full
+ * modeler untestable here, ADR 0011), so a real bpmn-js `NavigatedViewer` stands
+ * up in jsdom — with two stubs jsdom lacks (`getBBox`, `matchMedia`).
+ *
+ * The load-bearing assertion is the readonly proof — `getService("modeling")`
+ * and `getService("commandStack")` throw because those services are never
+ * registered on a viewer — and it needs no rendered diagram, so it runs for
+ * real. The render-dependent cases (`loadDiagram` and everything that reads a
+ * live element registry) are `it.skip`ped: jsdom lays nothing out, so bpmn-js's
+ * `canvas.viewbox()` dereferences an SVG `transform.baseVal` jsdom does not
+ * implement. Those paths are covered manually via the demo page
+ * (`apps/demo-webapp/bpmn/viewer.html`) and the Playwright/Chrome MCP flow in
+ * the PR's verification steps.
+ */
+
+const XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+beforeAll(() => {
+    // jsdom lays out nothing, so `getBBox` is missing on SVG elements; bpmn-js
+    // measures labels with it during construction.
+    if (!(SVGElement.prototype as any).getBBox) {
+        (SVGElement.prototype as any).getBBox = () => ({ x: 0, y: 0, width: 0, height: 0 });
+    }
+    // jsdom ships no `matchMedia`; the "automatic" theme reads it on the first
+    // frame. A never-matching stub resolves the default to light.
+    if (!window.matchMedia) {
+        (window as any).matchMedia = (query: string) => ({
+            matches: false,
+            media: query,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+        });
+    }
+});
+
+let viewer: BpmnViewer | undefined;
+let container: HTMLElement | undefined;
+
+function mount(): HTMLElement {
+    const el = document.createElement("div");
+    el.style.width = "800px";
+    el.style.height = "600px";
+    document.body.appendChild(el);
+    return el;
+}
+
+afterEach(() => {
+    viewer?.destroy();
+    viewer = undefined;
+    container?.remove();
+    container = undefined;
+});
+
+describe("createViewer (runtime, jsdom)", () => {
+    it("resolves a handle with viewport + selection accessors", async () => {
+        container = mount();
+        viewer = await createViewer(container);
+
+        expect(viewer.viewport).toBeDefined();
+        expect(viewer.selection).toBeDefined();
+    });
+
+    it("exposes the readonly core services and rejects editing ones", async () => {
+        container = mount();
+        viewer = await createViewer(container);
+
+        expect(viewer.getService("canvas")).toBeDefined();
+        expect(viewer.getService("elementRegistry")).toBeDefined();
+        expect(viewer.getService("eventBus")).toBeDefined();
+        expect(viewer.getService("overlays")).toBeDefined();
+        expect(viewer.getService("selection")).toBeDefined();
+
+        // The readonly proof: the editor services are never registered on a
+        // viewer, so resolving one throws. No rendered diagram required.
+        expect(() => viewer!.getService("modeling")).toThrow();
+        expect(() => viewer!.getService("commandStack")).toThrow();
+    });
+
+    it("engages theming and flips data-bpmn-theme on setTheme", async () => {
+        container = mount();
+        viewer = await createViewer(container, { theme: "light" });
+        expect(container.getAttribute("data-bpmn-theme")).toBe("light");
+
+        viewer.setTheme("dark");
+        expect(container.getAttribute("data-bpmn-theme")).toBe("dark");
+    });
+
+    it("throws NoModelerError from accessors after destroy", async () => {
+        container = mount();
+        viewer = await createViewer(container);
+        viewer.destroy();
+
+        expect(() => viewer!.viewport).toThrow(NoModelerError);
+        expect(() => viewer!.selection).toThrow(NoModelerError);
+        expect(() => viewer!.getService("canvas")).toThrow(NoModelerError);
+    });
+
+    // Render-dependent: jsdom has no SVG layout, so bpmn-js's viewbox transform
+    // throws on import. Covered manually via the demo page + Playwright.
+    it.skip("loads a diagram, selects an element, and round-trips XML/SVG", async () => {
+        container = mount();
+        viewer = await createViewer(container);
+
+        const result = await viewer.loadDiagram(XML);
+        expect(result.warnings).toEqual([]);
+
+        const changes: string[][] = [];
+        viewer.selection.onSelectionChanged((ids) => changes.push(ids));
+        viewer.selection.selectElementsByIds(["StartEvent_1"]);
+        expect(viewer.selection.getSelectedElementIds()).toEqual(["StartEvent_1"]);
+        expect(changes.at(-1)).toEqual(["StartEvent_1"]);
+
+        expect(await viewer.exportDiagram()).toContain("StartEvent_1");
+        expect(await viewer.getDiagramSvg()).toContain("<svg");
+    });
+});

--- a/packages/bpmn-modeler/src/viewer/createViewer.ts
+++ b/packages/bpmn-modeler/src/viewer/createViewer.ts
@@ -1,0 +1,24 @@
+import { BpmnViewer } from "./viewer";
+import type { ViewerOptions } from "./publicApi";
+
+/**
+ * Stands up one independent readonly viewer bound to `container`, then engages
+ * theming. Mirrors {@link createModeler} minus the editor-only setup (i18n,
+ * element templates, settings) — a viewer has no translatable UI, so the i18n
+ * dictionaries stay out of the lean graph (ADR 0014).
+ *
+ * Async for API-stability symmetry with {@link createModeler}.
+ */
+export async function createViewer(
+    container: HTMLElement,
+    options: ViewerOptions = {},
+): Promise<BpmnViewer> {
+    const viewer = new BpmnViewer(container, options);
+    await viewer.init();
+
+    // Always engage theming so the per-instance `data-bpmn-theme` attribute is
+    // set from the first frame; `"automatic"` then follows `prefers-color-scheme`.
+    viewer.setTheme(options.theme ?? "automatic");
+
+    return viewer;
+}

--- a/packages/bpmn-modeler/src/viewer/index.ts
+++ b/packages/bpmn-modeler/src/viewer/index.ts
@@ -1,0 +1,33 @@
+/**
+ * `@miragon/bpmn-modeler/viewer` — the host-free, readonly BPMN viewer subpath.
+ *
+ * A lean, view-only surface: it wraps bpmn-js's NavigatedViewer + outline and
+ * drags none of the editing stack (camunda-bpmn-js, properties-panel/preact,
+ * CodeMirror, token simulation, lint, i18n) into the module graph. That leanness
+ * is enforced at the graph level (`scripts/check-viewer-pure-entry.mjs` +
+ * `architecture.spec.ts`) so it holds under single-file bundlers. See ADR 0014.
+ *
+ * Deliberately imports **no CSS**: `cssCodeSplit: false` on the lib build would
+ * fold any stylesheet reachable from here into the shared `dist/bpmn-modeler.css`
+ * (the modeler's `styles.css`), pulling the editor chrome's CSS back in. The
+ * viewer's own sheet ships separately as `@miragon/bpmn-modeler/viewer.css`
+ * (built by `vite.viewer-css.config.mts`), which a consumer loads instead.
+ */
+
+// ── Public factory + API surface ─────────────────────────────────────────────
+export { createViewer } from "./createViewer";
+export type {
+    ViewerOptions,
+    BpmnViewerHandle,
+    CoreViewerServices,
+    CreateViewer,
+} from "./publicApi";
+export type { ThemeMode } from "../publicApi";
+
+// ── Viewport / selection — public, referenced by the viewer handle ───────────
+export { ViewportManager } from "../viewport";
+export type { ViewportData } from "../viewport";
+export { SelectionManager } from "../selection";
+
+// ── Re-export so the rolled-up `.d.ts` stays self-contained ──────────────────
+export { NoModelerError } from "@miragon/bpmn-modeler-types";

--- a/packages/bpmn-modeler/src/viewer/publicApi.ts
+++ b/packages/bpmn-modeler/src/viewer/publicApi.ts
@@ -1,0 +1,109 @@
+import type { ImportXMLResult } from "bpmn-js/lib/BaseViewer";
+import type { CoreModelerServices, ThemeMode } from "../publicApi";
+import type { ViewportManager } from "../viewport";
+import type { SelectionManager } from "../selection";
+
+/**
+ * The public TypeScript surface of `@miragon/bpmn-modeler/viewer`: the readonly
+ * analogue of the full modeler.
+ *
+ * The viewer is a lean, view-only surface for hosts with view-only permissions
+ * or embedded previews — it drags none of the editing stack (camunda-bpmn-js,
+ * properties-panel/preact, CodeMirror, token simulation, lint) into the module
+ * graph. Leanness holds at the *module-graph* level, not a runtime flag, so it
+ * survives single-file bundlers (`vite-plugin-singlefile`) that inline
+ * everything reachable — hence a separate subpath, mirroring the `/lint`
+ * precedent (ADR 0013). See ADR 0014.
+ *
+ * Every handle member below is signature-identical to its {@link
+ * BpmnModelerHandle} counterpart (subset compatibility is asserted in
+ * `publicApi.spec.ts`), so a host can narrow a modeler handle to a viewer handle
+ * without adapters. There is no `engine`, `propertiesPanel`, `linting`,
+ * `clipboard`, `capabilities`, events, or `locale`.
+ */
+
+/**
+ * The core diagram-js/bpmn-js services a viewer exposes through
+ * {@link BpmnViewerHandle.getService}. A `Pick` of {@link CoreModelerServices}
+ * (ADR 0011) — the readonly subset: no `modeling` or `commandStack`, so the
+ * absence of an editing surface is expressed in the type.
+ */
+export type CoreViewerServices = Pick<
+    CoreModelerServices,
+    "canvas" | "elementRegistry" | "eventBus" | "overlays" | "selection"
+>;
+
+/**
+ * Per-instance configuration for {@link createViewer}. Deliberately minimal: a
+ * viewer has no engine (bpmn-js's base viewer reads any BPMN), no properties
+ * panel, and no host capabilities.
+ */
+export interface ViewerOptions {
+    /**
+     * Colour theme — defaults to `"automatic"`. Theming always engages: the
+     * instance gets a `data-bpmn-theme` attribute from the first frame.
+     */
+    theme?: ThemeMode;
+
+    /**
+     * Escape hatch: extra moddle extensions for a host's own BPMN namespace.
+     * Matches bpmn-js's own `moddleExtensions`.
+     */
+    moddleExtensions?: Record<string, object>;
+
+    /**
+     * Escape hatch: extra render-only bpmn-js DI modules. Matches bpmn-js's own
+     * `additionalModules`.
+     */
+    additionalModules?: unknown[];
+}
+
+/**
+ * The instance handle {@link createViewer} resolves to — the readonly subset of
+ * {@link BpmnModelerHandle}.
+ */
+export interface BpmnViewerHandle {
+    /** Load BPMN 2.0 XML, replacing any current diagram, and fit it to view. */
+    loadDiagram(xml: string): Promise<ImportXMLResult>;
+
+    /** Serialise the current diagram to formatted XML. */
+    exportDiagram(): Promise<string>;
+
+    /** Export the current diagram as SVG markup. */
+    getDiagramSvg(): Promise<string>;
+
+    /** Viewport (zoom/scroll/fit) accessor. */
+    readonly viewport: ViewportManager;
+
+    /** Selection accessor — the viewer's base modules ship visible selection. */
+    readonly selection: SelectionManager;
+
+    /**
+     * Switch the colour theme live. Toggles this instance's `data-bpmn-theme`
+     * attribute and mirrors it to a legacy `#theme-link` when present.
+     */
+    setTheme(theme: ThemeMode): void;
+
+    /**
+     * Resolve a core diagram-js/bpmn-js service by name. The
+     * {@link CoreViewerServices} names — `canvas`, `elementRegistry`,
+     * `eventBus`, `overlays`, `selection` — are semver-stable across minor
+     * versions. Editing services (`modeling`, `commandStack`) are not
+     * registered on a viewer and throw.
+     */
+    getService<K extends keyof CoreViewerServices>(name: K): CoreViewerServices[K];
+    getService<T = unknown>(name: string): T;
+
+    /** Tear the instance down and free its bpmn-js DI graph and DOM. */
+    destroy(): void;
+}
+
+/**
+ * The `@miragon/bpmn-modeler/viewer` entry point: stand up one readonly viewer
+ * bound to `container` and resolve its {@link BpmnViewerHandle}. Async for API
+ * stability symmetry with {@link createModeler}.
+ */
+export type CreateViewer = (
+    container: HTMLElement,
+    options?: ViewerOptions,
+) => Promise<BpmnViewerHandle>;

--- a/packages/bpmn-modeler/src/viewer/viewer.ts
+++ b/packages/bpmn-modeler/src/viewer/viewer.ts
@@ -1,0 +1,174 @@
+import NavigatedViewer from "bpmn-js/lib/NavigatedViewer";
+import OutlineModule from "bpmn-js/lib/features/outline";
+import { ImportXMLError, ImportXMLResult, SaveXMLResult } from "bpmn-js/lib/BaseViewer";
+import { NoModelerError, observeCanvasSize } from "@miragon/bpmn-modeler-types";
+import { ThemeController } from "../theme";
+import { ViewportManager } from "../viewport";
+import { SelectionManager } from "../selection";
+import type { ThemeMode } from "../publicApi";
+import type { CoreViewerServices, ViewerOptions } from "./publicApi";
+
+/**
+ * Encapsulates one readonly bpmn-js viewer instance — the view-only analogue of
+ * {@link BpmnModeler}.
+ *
+ * Wraps `bpmn-js/lib/NavigatedViewer` (mouse + keyboard pan/zoom, no editing)
+ * plus `bpmn-js/lib/features/outline`, the one module the base viewer lacks for
+ * *visible* selection/hover. Viewport and selection concerns delegate to the
+ * shared {@link ViewportManager} / {@link SelectionManager}, so the same
+ * `ServiceAccessor`-based managers back both the modeler and the viewer.
+ *
+ * Per-instance by construction: bound to its own `container`, so several viewers
+ * (or a viewer beside a modeler) can coexist on a page. Use {@link createViewer}
+ * as the factory. Every accessor throws {@link NoModelerError} before
+ * {@link init} or after {@link destroy}.
+ */
+export class BpmnViewer {
+    private viewer: NavigatedViewer | undefined = undefined;
+
+    private _viewport: ViewportManager | undefined;
+
+    private _selection: SelectionManager | undefined;
+
+    // Per-instance theme controller, created lazily on the first setTheme.
+    private themeController?: ThemeController;
+
+    // Disposes the canvas-size observer installed by loadDiagram.
+    private stopObservingSize?: () => void;
+
+    /**
+     * @param container The canvas host element (bpmn-js `container`).
+     * @param options Per-instance config — see {@link ViewerOptions}.
+     */
+    constructor(
+        private readonly container: HTMLElement,
+        private readonly options: ViewerOptions,
+    ) {}
+
+    /** Access the viewport manager after {@link init}. */
+    get viewport(): ViewportManager {
+        if (!this._viewport) {
+            throw new NoModelerError();
+        }
+        return this._viewport;
+    }
+
+    /** Access the selection manager after {@link init}. */
+    get selection(): SelectionManager {
+        if (!this._selection) {
+            throw new NoModelerError();
+        }
+        return this._selection;
+    }
+
+    /**
+     * Creates and mounts the bpmn-js viewer, then wires the viewport/selection
+     * managers. Async for API-stability symmetry with {@link BpmnModeler.init}.
+     *
+     * @internal Construction step invoked by {@link createViewer}; not part of
+     *   the public handle.
+     */
+    async init(): Promise<void> {
+        this.viewer = new NavigatedViewer({
+            container: this.container,
+            moddleExtensions: this.options.moddleExtensions,
+            // Outline is Modeler-only upstream; it is the single addition that
+            // makes selection/hover visible on the otherwise chrome-free viewer.
+            additionalModules: [
+                OutlineModule,
+                ...((this.options.additionalModules as any[]) ?? []),
+            ],
+        });
+
+        const accessor = <T>(name: string): T => this.getViewer().get<T>(name);
+        this._viewport = new ViewportManager(accessor);
+        this._selection = new SelectionManager(accessor);
+    }
+
+    async loadDiagram(xml: string): Promise<ImportXMLResult> {
+        try {
+            const result = await this.getViewer().importXML(xml);
+            // The host may mount the container before laying it out, so the box
+            // can be zero when the import lands; the fit retries until it isn't.
+            this.stopObservingSize?.();
+            const canvas = this.getViewer().get<any>("canvas");
+            this.stopObservingSize = observeCanvasSize(canvas, canvas.getContainer(), {
+                applyInitialViewport: () => this._viewport!.fitViewport(),
+            });
+            this._viewport!.fitViewport();
+            return result;
+        } catch (error: unknown) {
+            if ((error as ImportXMLError).warnings) {
+                const importError = error as ImportXMLError;
+                throw new Error(`${importError.message} ${importError.warnings}`, {
+                    cause: error,
+                });
+            }
+            throw error;
+        }
+    }
+
+    async exportDiagram(): Promise<string> {
+        const result: SaveXMLResult = await this.getViewer().saveXML({ format: true });
+        if (result.xml) {
+            return result.xml;
+        } else if (result.error) {
+            throw result.error;
+        }
+        throw new Error("Failed to serialise the diagram!");
+    }
+
+    async getDiagramSvg(): Promise<string> {
+        const result = await this.getViewer().saveSVG();
+        return result.svg;
+    }
+
+    /**
+     * Switches the colour theme live. Toggles `data-bpmn-theme` on this
+     * instance's container (the authoritative per-instance mechanism) and
+     * mirrors the choice to a legacy page-global `#theme-link` when present.
+     */
+    setTheme(theme: ThemeMode): void {
+        if (!this.themeController) {
+            this.themeController = new ThemeController([this.container]);
+        }
+        this.themeController.setMode(theme);
+    }
+
+    /**
+     * Returns a service from the viewer's DI container. The
+     * {@link CoreViewerServices} names are semver-stable; every other name is an
+     * unstable escape hatch.
+     */
+    getService<K extends keyof CoreViewerServices>(name: K): CoreViewerServices[K];
+    getService<T = unknown>(name: string): T;
+    getService(name: string): any {
+        return this.getViewer().get(name);
+    }
+
+    /**
+     * Tears the instance down: stops the canvas-size observer, disposes the
+     * theme controller, and destroys the underlying bpmn-js viewer. A destroyed
+     * facade throws {@link NoModelerError} from every accessor.
+     */
+    destroy(): void {
+        this.stopObservingSize?.();
+        this.stopObservingSize = undefined;
+        this.themeController?.dispose();
+        this.viewer?.destroy();
+        this.viewer = undefined;
+        this._viewport = undefined;
+        this._selection = undefined;
+    }
+
+    /**
+     * @throws {NoModelerError} If {@link init} has not been called (or the
+     *   instance was destroyed).
+     */
+    private getViewer(): NavigatedViewer {
+        if (!this.viewer) {
+            throw new NoModelerError();
+        }
+        return this.viewer;
+    }
+}

--- a/packages/bpmn-modeler/vite.config.mts
+++ b/packages/bpmn-modeler/vite.config.mts
@@ -94,6 +94,13 @@ export default defineConfig({
                 // so it never lands in a `linting: false` consumer's bundle. Its
                 // CSS still folds into `dist/bpmn-modeler.css` (cssCodeSplit off).
                 lint: resolve(__dirname, "src/bpmnlint/index.ts"),
+                // Readonly viewer subpath (`@miragon/bpmn-modeler/viewer`, #1405):
+                // NavigatedViewer + outline only, none of the editor stack. It
+                // imports no CSS (so `cssCodeSplit: false` cannot fold any into
+                // `dist/bpmn-modeler.css`); its sheet ships as `dist/viewer.css`
+                // via `vite.viewer-css.config.mts`. Purity gated by
+                // `check-viewer-pure-entry.mjs`.
+                viewer: resolve(__dirname, "src/viewer/index.ts"),
             },
             formats: ["es"],
             cssFileName: "bpmn-modeler",

--- a/packages/bpmn-modeler/vite.viewer-css.config.mts
+++ b/packages/bpmn-modeler/vite.viewer-css.config.mts
@@ -1,0 +1,30 @@
+import { defineConfig } from "vite";
+import { resolve } from "node:path";
+
+// The readonly viewer's stylesheet ships as a standalone `dist/viewer.css`
+// entry (`@miragon/bpmn-modeler/viewer.css`), because the viewer's `index.ts`
+// imports no CSS: `cssCodeSplit: false` on the main lib build would otherwise
+// fold any viewer-reachable sheet into `dist/bpmn-modeler.css`, dragging the
+// editor chrome back in. CSS cannot be a Vite *lib* entry, so this is a separate
+// CSS-only rollup (the same pattern as `vite.themes.config.mts`), but WITHOUT
+// `stripThemeScope`: the viewer sheet keeps its `[data-bpmn-theme="dark"]`
+// scoping so per-instance theming works. `emptyOutDir: false` so it does not
+// wipe the lib build's `dist/`.
+export default defineConfig({
+    root: __dirname,
+    cacheDir: "../../node_modules/.vite/bpmn-modeler-viewer-css",
+    build: {
+        target: "es2021",
+        outDir: "dist",
+        emptyOutDir: false,
+        cssCodeSplit: true,
+        rollupOptions: {
+            input: {
+                viewer: resolve(__dirname, "src/styles/viewer.css"),
+            },
+            output: {
+                assetFileNames: "[name].[ext]",
+            },
+        },
+    },
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,6 +24,7 @@
             "@miragon/bpmn-modeler": ["./packages/bpmn-modeler/src/index.ts"],
             "@miragon/bpmn-modeler/diff": ["./packages/bpmn-modeler/src/diff/index.ts"],
             "@miragon/bpmn-modeler/lint": ["./packages/bpmn-modeler/src/bpmnlint/index.ts"],
+            "@miragon/bpmn-modeler/viewer": ["./packages/bpmn-modeler/src/viewer/index.ts"],
             "@miragon/bpmn-modeler-shared": ["./libs/shared/src/index.ts"],
             "@miragon/bpmn-modeler-types": ["./libs/modeler-types/src/index.ts"],
             "@miragon/bpmn-modeler-diff": ["./libs/bpmn-diff/src/index.ts"],


### PR DESCRIPTION
## Issue

Closes #1405

## Description

Adds a readonly diagram surface on a new `@miragon/bpmn-modeler/viewer` subpath: `createViewer(container, options?)` wraps an engine-agnostic bpmn-js `NavigatedViewer` (plus `bpmn-js/lib/features/outline` for visible click-select/hover) and returns a `BpmnViewerHandle` that is a compile-time-asserted subset of `BpmnModelerHandle`, reusing `ViewportManager`, `SelectionManager`, and the `data-bpmn-theme` `ThemeController` unchanged. The viewer ships a dedicated lean `viewer.css` export (built by a scope-preserving CSS-only Vite config), and a new `check-viewer-pure-entry.mjs` build gate plus architecture-test assertions guarantee the `/viewer` module graph never reaches camunda-bpmn-js, preact/properties-panel, CodeMirror, bpmnlint, token simulation, or the i18n dictionaries — the point of the subpath for single-file hosts. `locale` from the issue sketch is deliberately omitted in v1 (no translatable UI on this surface; additive later), and the DiffViewer refactor onto the viewer internals stays a follow-up — both recorded in [ADR 0014](docs/adr/0014-readonly-viewer-subpath.md). A demo page (`/bpmn/viewer.html`) serves as the epic's regression check, and `createViewer.spec.ts` is the package's first runtime-tested factory (jsdom). Roadmap step 6 of #1409.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [ ] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A — purely additive, hosts consume the package only via `apps/bpmn-webview`, which is untouched)