### PR TITLE
feat(bpmn-modeler): add engine-neutral createDesigner() on /design subpath

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -657,6 +657,9 @@ jobs:
           test -f packages/bpmn-modeler/dist/viewer.js
           test -f packages/bpmn-modeler/dist/viewer.d.ts
           test -f packages/bpmn-modeler/dist/viewer.css
+          test -f packages/bpmn-modeler/dist/design.js
+          test -f packages/bpmn-modeler/dist/design.d.ts
+          test -f packages/bpmn-modeler/dist/design.css
           test -f packages/bpmn-modeler/dist/bpmn-modeler.css
           test -f packages/bpmn-modeler/dist/lightTheme.css
           test -f packages/bpmn-modeler/dist/darkTheme.css

--- a/apps/demo-webapp/bpmn/design.html
+++ b/apps/demo-webapp/bpmn/design.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Miragon Modeler — Design Mode Demo</title>
+        <style>
+            body {
+                margin: 0;
+            }
+            /* An editable canvas beside an engine-neutral properties panel.
+               #app is sized by the shared demo header (viewport minus header +
+               footer). */
+            .design {
+                display: flex;
+                height: 100%;
+            }
+            .design .canvas {
+                position: relative;
+                flex: 1;
+                min-width: 0;
+            }
+            .design .properties {
+                width: 320px;
+                flex: none;
+                border-left: 1px solid #d7d9de;
+                overflow: auto;
+                background: #fff;
+            }
+            :root[data-bpmn-theme="dark"] .design .properties {
+                border-left-color: #3a3a3a;
+                background: #1d1d1d;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="app" style="height: 100vh">
+            <div class="design">
+                <div class="canvas" id="canvas"></div>
+                <div class="properties" id="properties"></div>
+            </div>
+        </div>
+        <script src="/design.ts" type="module"></script>
+    </body>
+</html>

--- a/apps/demo-webapp/bpmn/design.ts
+++ b/apps/demo-webapp/bpmn/design.ts
@@ -1,0 +1,44 @@
+import { createDesigner } from "@miragon/bpmn-modeler/design";
+import type { ThemeMode } from "@miragon/bpmn-modeler/design";
+import { mountDemoHeader } from "../src";
+import { MODELS } from "../src/registry";
+
+// The design surface ships its own lean stylesheet
+// (`@miragon/bpmn-modeler/design.css`), separate from the modeler's `styles.css`.
+// A JS import lets Vite process it (and its node_modules `@import`s) in dev and
+// build. This is the epic's regression check: the design page must edit
+// (palette / context pad / append menu), show only the engine-neutral panel (no
+// Camunda tabs), and export XML carrying no `modeler:executionPlatform`.
+import "../../../packages/bpmn-modeler/src/styles/design.css";
+
+/**
+ * In-page engine-neutral design demo — the in-repo consumer of the `/design`
+ * subpath. No host, no bootstrap: one `createDesigner` handle over a registry
+ * model. Theme comes from the shared demo header, which seeds the initial mode
+ * and routes later changes to the public `designer.setTheme` API.
+ */
+async function main(): Promise<void> {
+    const designerRef: { current?: Awaited<ReturnType<typeof createDesigner>> } = {};
+    const { themeMode } = mountDemoHeader(
+        "design",
+        {},
+        { onThemeChange: (mode) => designerRef.current?.setTheme(mode as ThemeMode) },
+    );
+
+    const canvas = document.getElementById("canvas");
+    const panel = document.getElementById("properties");
+    if (!canvas || !panel) {
+        throw new Error("design demo: missing host elements");
+    }
+
+    const model = MODELS.find((m) => m.type === "bpmn") ?? MODELS[0];
+
+    const designer = await createDesigner(canvas, {
+        propertiesPanel: { parent: panel },
+        theme: themeMode as ThemeMode,
+    });
+    designerRef.current = designer;
+    await designer.loadDiagram(model.xml);
+}
+
+void main();

--- a/apps/demo-webapp/src/demoHeader.ts
+++ b/apps/demo-webapp/src/demoHeader.ts
@@ -6,11 +6,12 @@ export interface DemoHeaderLinks {
     docs: string;
 }
 
-// The demo has three views: the single-model modeler (bpmn/dmn), the two-pane
-// diff, and the readonly viewer. `"diff"` and `"viewer"` are not `ModelType`s —
-// they have no active model — so the model dropdown is hidden there; the view
-// switcher is how users cross between them.
-export type DemoPage = ModelType | "diff" | "viewer";
+// The demo has four views: the single-model modeler (bpmn/dmn), the two-pane
+// diff, the readonly viewer, and the engine-neutral design surface. `"diff"`,
+// `"viewer"`, and `"design"` are not `ModelType`s — they have no active model —
+// so the model dropdown is hidden there; the view switcher is how users cross
+// between them.
+export type DemoPage = ModelType | "diff" | "viewer" | "design";
 
 // The header's single theme control. `"automatic"` follows the OS
 // `prefers-color-scheme`; `"light"`/`"dark"` force a fixed choice.
@@ -82,6 +83,7 @@ function applyDemoTheme(mode: DemoThemeMode): void {
 
 const DIFF_HREF = "/bpmn/diff.html";
 const VIEWER_HREF = "/bpmn/viewer.html";
+const DESIGN_HREF = "/bpmn/design.html";
 
 // Where the "Modeler" view link points from the diff page — the first bpmn model.
 const DEFAULT_MODELER_HREF = modelHref(MODELS.find((m) => m.type === "bpmn") ?? MODELS[0]);
@@ -103,9 +105,10 @@ export function mountDemoHeader(
     const l = { ...DEFAULT_LINKS, ...links };
     const isDiff = page === "diff";
     const isViewer = page === "viewer";
-    // The diff/viewer views have no active model; their "Modeler" link falls
-    // back to the default bpmn model so users always land somewhere sensible.
-    const noModel = isDiff || isViewer;
+    const isDesign = page === "design";
+    // The diff/viewer/design views have no active model; their "Modeler" link
+    // falls back to the default bpmn model so users always land somewhere sensible.
+    const noModel = isDiff || isViewer || isDesign;
     const modelerHref = noModel ? DEFAULT_MODELER_HREF : modelHref(getActiveModel(page));
 
     const style = document.createElement("style");
@@ -264,6 +267,7 @@ export function mountDemoHeader(
             <a href="${modelerHref}"${noModel ? "" : activeAttr}>Modeler</a>
             <a href="${DIFF_HREF}"${isDiff ? activeAttr : ""}>Diff</a>
             <a href="${VIEWER_HREF}"${isViewer ? activeAttr : ""}>Viewer</a>
+            <a href="${DESIGN_HREF}"${isDesign ? activeAttr : ""}>Design</a>
         </nav>`;
 
     const header = document.createElement("header");

--- a/apps/demo-webapp/vite.config.mts
+++ b/apps/demo-webapp/vite.config.mts
@@ -40,8 +40,9 @@ export default defineConfig(({ mode }) => {
             emptyOutDir: true,
             // The bpmn page ships extra entries — the two-instance regression
             // proof at /bpmn/dual.html, the two-pane diff demo at /bpmn/diff.html,
-            // and the readonly viewer demo at /bpmn/viewer.html. The dev server
-            // serves them automatically; only the build needs the extra inputs.
+            // the readonly viewer demo at /bpmn/viewer.html, and the engine-neutral
+            // design demo at /bpmn/design.html. The dev server serves them
+            // automatically; only the build needs the extra inputs.
             rollupOptions:
                 target === "bpmn"
                     ? {
@@ -50,6 +51,7 @@ export default defineConfig(({ mode }) => {
                               dual: resolve(__dirname, "bpmn/dual.html"),
                               diff: resolve(__dirname, "bpmn/diff.html"),
                               viewer: resolve(__dirname, "bpmn/viewer.html"),
+                              design: resolve(__dirname, "bpmn/design.html"),
                           },
                       }
                     : undefined,

--- a/docs/adr/0016-design-mode-subpath.md
+++ b/docs/adr/0016-design-mode-subpath.md
@@ -1,0 +1,119 @@
+# 0016 — Engine-neutral design mode via the `@miragon/bpmn-modeler/design` subpath
+
+- Status: accepted (#1196)
+- Date: 2026-09-02
+- Category: bpmn-webview
+
+Roadmap step 7 — the last — of the bpm-iq embeddability epic (#1409), building on the subpath-injection precedent [ADR 0013](0013-injectable-lint-stack.md)
+for `/lint`, the readonly-surface precedent
+[ADR 0014](0014-readonly-viewer-subpath.md) for `/viewer`, the `Pick`-able
+core-service contract of [ADR 0011](0011-stable-core-service-contract.md), and the
+container-scoped theming of [ADR 0012](0012-container-scoped-theming.md).
+
+## Context
+
+The package exposed a full Camunda editor (`createModeler`) and a readonly viewer
+(`createViewer`), but nothing for **engine-neutral, editable** documentation or
+conceptual modelling — a BPMN surface a user can edit with no Camunda 7/8
+properties panel and no execution platform. The full modeler cannot serve this by
+hiding chrome at runtime: it drags camunda-bpmn-js, element templates, token
+simulation, transaction boundaries, and the lint stack into the graph regardless.
+
+The same forcing function as #1405/#1407 applies: single-file hosts embed through
+`vite-plugin-singlefile`, which inlines everything *reachable*, so bundle
+composition must be decidable at the **entry point**, not by a runtime `mode`
+flag. Hence a separate subpath the bundler can keep apart.
+
+**The mode marker is the absence of `modeler:executionPlatform` on
+`bpmn:Definitions`.** Absent ⇒ Design; present ⇒ Implement, routed through the
+already-exported `detectEngine(xml)` (#1404). Fallback for undetected XML is
+*editable* Design, not readonly.
+
+## Decision
+
+Ship a **new subpath `@miragon/bpmn-modeler/design`** exporting an async
+`createDesigner(container, options)` that resolves a `BpmnDesignerHandle`
+(naming: `createDesigner` / `BpmnDesignerHandle` / `DesignerOptions` / class
+`BpmnDesigner`).
+
+- **Base bpmn-js `Modeler` + a neutral properties panel.** The design surface
+  wraps `bpmn-js/lib/Modeler` (palette, context pad, modelling, keyboard,
+  copy-paste, snapping, searchPad, outline) plus `BpmnPropertiesPanelModule` +
+  `BpmnPropertiesProviderModule` from `bpmn-js-properties-panel` (engine-neutral
+  general / documentation groups). Neutral UX comes from `TranslateModule`, our
+  `AppendMenuModule` decorating the base `CreateAppendAnythingModule`,
+  `FlowNavigationModule`, and `diagram-js-minimap` (`minimap: { open: false }`).
+  Shared installs (`ThemeController`, `ViewportManager`, `SelectionManager`,
+  keyboard/canvas focus, clipboard) reuse as-is.
+- **Full core services (0011).** `CoreDesignerServices = CoreModelerServices` —
+  the *whole* seven, `modeling` and `commandStack` included, the inverse of the
+  viewer's readonly `Pick`. The editable surface is expressed in the type.
+- **Subset-compatible handle.** Every `BpmnDesignerHandle` member is
+  signature-identical to its `BpmnModelerHandle` counterpart (asserted in
+  `publicApi.spec.ts`: `(m: BpmnModelerHandle): BpmnDesignerHandle => m`).
+- **Scope-preserving `design.css` via the CSS-only build.** `src/design/index.ts`
+  imports no CSS (`cssCodeSplit: false` would fold any reachable sheet into the
+  shared `dist/bpmn-modeler.css`); its sheet ships as
+  `@miragon/bpmn-modeler/design.css`, a second input on
+  `vite.viewer-css.config.mts`, keeping its `[data-bpmn-theme="dark"]` scoping.
+- **Theming + locale engage (0012).** `createDesigner` calls `i18n.extend(...)` →
+  `setTheme(theme ?? "automatic")` → optional `i18n.setLanguage(locale)` — Design
+  mode has translatable UI, unlike the viewer.
+
+### v1 exclusions (all additive later, nothing foreclosed)
+
+- **No `linting` option.** `buildLintModules` needs an `Engine` for its default
+  config; the injectable `/lint` pattern (0013) makes a future engine-neutral
+  ruleset purely additive.
+- **No conversion helpers.** `stampExecutionPlatform` / `stripExecutionPlatform`
+  (host-side mode switching) are deferred; `detectEngine` already covers routing.
+  Switching = host stamps/strips the XML, `destroy()`, other factory.
+- **No align-to-origin / grid / colour-picker chrome.** Each would add a new
+  direct dependency (camunda-bpmn-js base chrome). `favouriteBpmnElements` is
+  lifted to a first-class option since Design mode has no `settings`.
+  - **Minimap included** (revised from the original plan). The plan deferred it
+    partly "to keep the jsdom runtime spec feasible" (minimap's CJS interop is a
+    known jsdom blocker, 0011). But the engine-neutral properties panel already
+    makes a runtime spec infeasible (see Consequences), so that rationale is void
+    for `/design` — nothing is left to protect. The only real cost is one small
+    new direct dependency, `diagram-js-minimap` (already transitively present via
+    camunda-bpmn-js), which the purity gate does not forbid; it ships collapsed
+    (`minimap: { open: false }`) with its dark-theme sheet already scoped.
+- **No host UX.** The creation-time Design/Implement choice and a mode-switch chip
+  in VS Code / IntelliJ are follow-up work outside this package-only PR.
+
+### Mechanised gates
+
+- **`scripts/check-design-pure-entry.mjs`** (new, wired into `build`): walks the
+  static import graph from `dist/design.js` and fails if any bare specifier names
+  the Camunda engine or lint stack (camunda-bpmn-js, the C7/C8 moddles +
+  behaviours, transaction boundaries, element templates, token simulation,
+  `@miragon/create-append-c7`, minisearch, bpmnlint). Unlike `/viewer`,
+  `bpmn-js-properties-panel`, `@bpmn-io/properties-panel`, `preact`, CodeMirror,
+  and `bpmn-js-create-append-anything` are **allowed**.
+- **`src/architecture.spec.ts`**: every value-import in `src/design/**` must be a
+  relative, `bpmn-js/*`, `diagram-js/*`, `@miragon/bpmn-modeler-types`, the
+  neutral panel/menu packages, or the neutral `@miragon/*` libs (i18n, i18n-extras,
+  append-menu, flow-navigation, clipboard). `import type` stays fine.
+- **`scripts/check-dts.mjs`**, the CI dist-artefact list, and
+  `scripts/smoke-consumer.mjs` gain the `design.js` / `design.d.ts` / `design.css`
+  entries and the `./design` / `./design.css` subpaths.
+
+## Consequences
+
+- **Feature matrix closed:** `createModeler` (c7/c8 editable) | `/design`
+  (engine-neutral editable) | `/viewer` (readonly).
+- **Additive, non-breaking.** No host (vscode/intellij) change — #1196 is
+  package-only per the epic's Host-impact constraint. The regression check is the
+  demo page `apps/demo-webapp/bpmn/design.html`.
+- **`preact`, CodeMirror, and `diagram-js-minimap` are legitimately in the design
+  closure** — the first two are the engine-neutral properties panel's own
+  dependencies, the last is the minimap module; the purity gate allows all three
+  (unlike `/viewer`, which forbids the panel and minimap alike).
+- **No runtime spec, unlike `/viewer`.** The engine-neutral properties panel
+  (`bpmn-js-properties-panel`) reaches bpmn-js internals through extensionless
+  ESM imports that Vitest's module runner resolves with Node's native loader,
+  which rejects them — the same jsdom wall (0011) that leaves the full modeler
+  untested. `createDesigner.spec.ts` documents the intended runtime contract via
+  skipped, dynamic-import tests; the real runtime proof is the demo page plus the
+  type-level conformance in `publicApi.spec.ts`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,3 +59,4 @@ contributor-facing record, not user documentation.
 | [0012](0012-container-scoped-theming.md) | Container-scoped theming via a per-instance `data-bpmn-theme` attribute; `#theme-link` swap kept as permanent legacy fallback | accepted |
 | [0013](0013-injectable-lint-stack.md) | Injectable lint stack via the `@miragon/bpmn-modeler/lint` subpath; omitted `linting` now means off | accepted |
 | [0014](0014-readonly-viewer-subpath.md) | Readonly `createViewer` via the `@miragon/bpmn-modeler/viewer` subpath: NavigatedViewer + outline, `Pick`'d services, scope-preserving `viewer.css`, `locale` omitted | accepted |
+| [0016](0016-design-mode-subpath.md) | Engine-neutral `createDesigner` via the `@miragon/bpmn-modeler/design` subpath: base bpmn-js + plain-BPMN panel, `executionPlatform` absence as mode marker, Camunda/lint stack gated out | accepted |

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -43,7 +43,13 @@
         "apps/demo-webapp": {
             // dual.ts / diff.ts are reached only via their .html files, which the
             // vite plugin does not walk (single-mode root), so list them.
-            "entry": ["dmn/main.ts", "bpmn/dual.ts", "bpmn/diff.ts", "bpmn/viewer.ts"]
+            "entry": [
+                "dmn/main.ts",
+                "bpmn/dual.ts",
+                "bpmn/diff.ts",
+                "bpmn/viewer.ts",
+                "bpmn/design.ts"
+            ]
         },
         "packages/bpmn-modeler": {
             // `src/bpmnlint/index.ts` is the public `@miragon/bpmn-modeler/lint`
@@ -54,7 +60,8 @@
                 "src/index.ts",
                 "src/bpmnlint/index.ts",
                 "src/diff/index.ts",
-                "src/viewer/index.ts"
+                "src/viewer/index.ts",
+                "src/design/index.ts"
             ],
             // minisearch (via model-navigation), lodash (via modeler-types'
             // asyncDebounce), and bpmn-js-differ (via the inlined bpmn-diff lib)

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -350,6 +350,96 @@ Not supported in v1: the viewer has no translatable UI, and honoring `locale`
 would pull the i18n dictionaries into the lean graph. It is additive later
 (non-breaking).
 
+## Design mode
+
+`@miragon/bpmn-modeler/design` is an **engine-neutral, editable** surface for
+documentation and conceptual modelling. It wraps the base bpmn-js `Modeler`
+(palette, context pad, modelling, copy-paste, keyboard, search) plus an
+engine-neutral properties panel (general / documentation groups only), a minimap,
+and the neutral UX modules (translate, append menu, flow navigation). It loads
+**none** of the Camunda editor stack — no camunda-bpmn-js, element templates, token
+simulation, transaction boundaries, or lint — so it never carries an execution
+platform.
+
+Three surfaces close the feature matrix:
+
+| Surface | Entry | Editable | Engine | Properties panel |
+| --- | --- | --- | --- | --- |
+| Modeler | `@miragon/bpmn-modeler` | yes | Camunda 7 / 8 | engine-bound |
+| Design | `@miragon/bpmn-modeler/design` | yes | none | plain BPMN |
+| Viewer | `@miragon/bpmn-modeler/viewer` | no | — | none |
+
+### Mode-marker semantics
+
+The marker is the **absence of `modeler:executionPlatform`** on
+`bpmn:Definitions`. Route with the exported `detectEngine(xml)`: `undefined` ⇒
+Design (editable), a detected engine ⇒ Implement (`createModeler`). Fallback for
+undetected XML is *editable Design*, not readonly. Switching modes is a host
+concern — stamp or strip the execution platform on the XML, `destroy()` the
+instance, and stand up the other factory. The stamp/strip conversion helpers are
+deferred to a follow-up (ADR 0016); `detectEngine` already covers routing.
+
+```ts
+import { createDesigner, detectEngine } from "@miragon/bpmn-modeler/design";
+import "@miragon/bpmn-modeler/design.css"; // the design surface's own stylesheet
+
+const designer = await createDesigner(document.querySelector("#canvas")!, {
+    propertiesPanel: { parent: document.querySelector("#panel")! },
+    theme: "automatic",
+});
+await designer.loadDiagram(bpmnXml); // detectEngine(bpmnXml) === undefined
+
+designer.getService("commandStack"); // editable: modelling services are present
+```
+
+### `DesignerOptions`
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `propertiesPanel` | `{ parent: HTMLElement }` | — (required) | The panel host, as in `createModeler`. Shows only the general / documentation groups. |
+| `theme` | `"light" \| "dark" \| "automatic"` | `"automatic"` | Colour theme; toggles a per-instance `data-bpmn-theme` attribute. |
+| `locale` | `string` | `"en"` | UI locale — Design mode has translatable UI (unlike the viewer). |
+| `favouriteBpmnElements` | `string[]` | — | Element types offered first in the append/create menu. |
+| `clipboard` | `ClipboardOptions` | native | Clipboard override for sandboxed hosts. |
+| `moddleExtensions` | `Record<string, object>` | — | Extra moddle extensions for a host's own BPMN namespace. |
+| `additionalModules` | `unknown[]` | — | Escape hatch: extra bpmn-js DI modules. |
+| `onContentSaved` | `(e: ContentSavedEvent) => void` | — | Debounced diagram content (300 ms / 1000 ms maxWait). |
+
+There is no `engine`, `linting`, `elementTemplates`, `settings`, or
+`capabilities` — each is engine-bound and rejected at compile time.
+
+### `BpmnDesignerHandle`
+
+`loadDiagram`, `exportDiagram`, `newDiagram`, `getDiagramSvg`, `viewport`,
+`selection`, `setTheme`, `getService`, and `destroy` — each
+**signature-identical** to its `BpmnModelerHandle` counterpart, so a modeler
+handle narrows to a designer handle with no adapter. `getService` is typed
+against `CoreDesignerServices`, which equals the full
+[core services](#core-services--escape-hatch) set (`modeling` and `commandStack`
+included) — the surface is editable by construction. `newDiagram()` uses the
+base bpmn-js template, which carries **no** `modeler:executionPlatform`, so a
+fresh diagram stays in Design mode.
+
+### Guaranteed absent from the module graph
+
+`camunda-bpmn-js`, `camunda-bpmn-moddle` / `zeebe-bpmn-moddle`,
+`camunda-bpmn-js-behaviors`, `camunda-transaction-boundaries`,
+`bpmn-js-token-simulation`, `bpmn-js-element-templates`,
+`@miragon/create-append-c7`, `minisearch`, and the lint stack (`bpmnlint` /
+`bpmn-js-bpmnlint` / `@miragon/bpmnlint-plugin-rules`). A build-time gate
+(`scripts/check-design-pure-entry.mjs`) fails the build if any reappears. Unlike
+`/viewer`, `preact` and CodeMirror (`@codemirror/*`) **are** present (legitimate
+dependencies of the engine-neutral properties panel), as is `diagram-js-minimap`
+(the engine-neutral minimap, a direct dependency of the package).
+
+### Theming & stylesheet
+
+Load **`@miragon/bpmn-modeler/design.css`**, not `styles.css`: the design sheet
+carries the bpmn-js base diagram/font CSS, the engine-neutral panel and
+append-menu chrome, the minimap, and the canvas focus indicator, plus the
+dark-theme overrides — none of the Camunda editor chrome. The two overlap, so do **not**
+load both on a design-only page.
+
 ## Lint
 
 `@miragon/bpmn-modeler/lint` is the injectable lint stack (`bpmn-js-bpmnlint`,

--- a/packages/bpmn-modeler/package.json
+++ b/packages/bpmn-modeler/package.json
@@ -50,15 +50,20 @@
             "types": "./dist/viewer.d.ts",
             "import": "./dist/viewer.js"
         },
+        "./design": {
+            "types": "./dist/design.d.ts",
+            "import": "./dist/design.js"
+        },
         "./styles.css": "./dist/bpmn-modeler.css",
         "./viewer.css": "./dist/viewer.css",
+        "./design.css": "./dist/design.css",
         "./light-theme.css": "./dist/lightTheme.css",
         "./dark-theme.css": "./dist/darkTheme.css",
         "./package.json": "./package.json"
     },
     "scripts": {
         "typecheck": "tsc --noEmit",
-        "build": "npm-run-all -s typecheck build:lib build:themes build:viewer-css check:dts check:diff-node check:lint-free check:viewer-pure check:dep-alignment",
+        "build": "npm-run-all -s typecheck build:lib build:themes build:viewer-css check:dts check:diff-node check:lint-free check:viewer-pure check:design-pure check:dep-alignment",
         "build:lib": "vite build",
         "build:themes": "vite build -c vite.themes.config.mts",
         "build:viewer-css": "vite build -c vite.viewer-css.config.mts",
@@ -66,6 +71,7 @@
         "check:diff-node": "node scripts/check-diff-node.mjs",
         "check:lint-free": "node scripts/check-lint-free-entry.mjs",
         "check:viewer-pure": "node scripts/check-viewer-pure-entry.mjs",
+        "check:design-pure": "node scripts/check-design-pure-entry.mjs",
         "check:dep-alignment": "yarn constraints",
         "test": "vitest run --coverage"
     },
@@ -89,6 +95,7 @@
         "camunda-bpmn-moddle": "7.0.2",
         "camunda-transaction-boundaries": "1.1.2",
         "diagram-js": "15.24.1",
+        "diagram-js-minimap": "5.4.1",
         "lodash": "4.18.1",
         "minisearch": "7.2.0",
         "preact": "10.29.3",

--- a/packages/bpmn-modeler/scripts/check-design-pure-entry.mjs
+++ b/packages/bpmn-modeler/scripts/check-design-pure-entry.mjs
@@ -1,0 +1,113 @@
+// Acceptance criterion for issue #1196, mechanised: the engine-neutral design
+// subpath (`@miragon/bpmn-modeler/design`) must stay free of the Camunda editor
+// stack at the *module-graph* level — in every bundling mode. Single-file hosts
+// (vite-plugin-singlefile) inline everything reachable, so a bare import that
+// survives here would land in the consumer's one bundle.
+//
+// Unlike `/viewer`, the design surface DOES ship the engine-neutral properties
+// panel — so `bpmn-js-properties-panel`, `@bpmn-io/properties-panel`, `preact`,
+// CodeMirror, and `bpmn-js-create-append-anything` are all *allowed*. What must
+// never appear is the Camunda engine stack (camunda-bpmn-js, the C7/C8 moddles
+// and behaviours, transaction boundaries, element templates, token simulation)
+// and the lint stack.
+//
+// The heavy stacks are Vite `external`s — they survive as *bare import
+// specifiers* in dist/design.js and its relative chunks. So we start at
+// dist/design.js, follow only relative specifiers (the emitted chunks), and fail
+// if any bare specifier names a forbidden package. A content-grep for `bpmnlint`
+// catches an inlined-lib leak too.
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve, relative } from "node:path";
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../dist");
+const ROOT_ENTRY = resolve(distDir, "design.js");
+
+// Forbidden bare specifiers — the Camunda engine + lint stacks the design
+// surface must never reach. Matched as a whole package name: `pkg` exactly or
+// `pkg/<subpath>`.
+const FORBIDDEN_PREFIXES = [
+    "camunda-bpmn-js",
+    "camunda-bpmn-moddle",
+    "zeebe-bpmn-moddle",
+    "camunda-bpmn-js-behaviors",
+    "camunda-transaction-boundaries",
+    "bpmn-js-token-simulation",
+    "bpmn-js-element-templates",
+    "@miragon/create-append-c7",
+    "minisearch",
+    "bpmnlint",
+    "bpmn-js-bpmnlint",
+    "@miragon/bpmnlint-plugin-rules",
+];
+
+// A last-line content grep (mirrors check-lint-free-entry.mjs): catches the lint
+// stack even if it were inlined into a chunk rather than left external.
+const FORBIDDEN_CONTENT = /bpmnlint/;
+
+function isForbidden(spec) {
+    return FORBIDDEN_PREFIXES.some((prefix) => spec === prefix || spec.startsWith(`${prefix}/`));
+}
+
+// Static specifiers only: `import … from "x"`, bare `import "x"`, and
+// `export … from "x"`. `import(` (dynamic) is deliberately excluded — a reachable
+// dynamic import is a separate chunk a single-file bundler inlines anyway, so we
+// follow the static closure that decides the critical path.
+const STATIC_SPECIFIER_PATTERNS = [
+    /\bimport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
+    /\bexport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
+    /\bimport\s*["']([^"']+)["']/g,
+];
+
+function staticSpecifiers(code) {
+    return STATIC_SPECIFIER_PATTERNS.flatMap((pattern) =>
+        [...code.matchAll(pattern)].map((match) => match[1]),
+    );
+}
+
+function fail(message) {
+    console.error(`check-design-pure-entry: ${message}`);
+    process.exit(1);
+}
+
+if (!existsSync(ROOT_ENTRY)) {
+    fail(`${ROOT_ENTRY} not found — run the lib build first.`);
+}
+
+const visited = new Set();
+const offenders = [];
+const queue = [ROOT_ENTRY];
+
+while (queue.length > 0) {
+    const file = queue.pop();
+    if (visited.has(file)) continue;
+    visited.add(file);
+
+    const code = readFileSync(file, "utf8");
+    if (FORBIDDEN_CONTENT.test(code)) {
+        offenders.push(`${relative(distDir, file)} → inlined lint stack`);
+    }
+
+    for (const spec of staticSpecifiers(code)) {
+        if (spec.startsWith(".")) {
+            // Follow our own emitted chunks.
+            const resolved = resolve(dirname(file), spec);
+            if (existsSync(resolved)) queue.push(resolved);
+            continue;
+        }
+        if (isForbidden(spec)) {
+            offenders.push(`${relative(distDir, file)} → ${spec}`);
+        }
+    }
+}
+
+if (offenders.length > 0) {
+    fail(
+        `the design entry statically reaches the Camunda/lint stack — the ` +
+            `/design subpath must stay engine-neutral:\n  ${[...new Set(offenders)].join("\n  ")}`,
+    );
+}
+
+console.log(
+    `check-design-pure-entry: dist/design.js and its ${visited.size - 1} static chunks are Camunda-free.`,
+);

--- a/packages/bpmn-modeler/scripts/check-dts.mjs
+++ b/packages/bpmn-modeler/scripts/check-dts.mjs
@@ -13,7 +13,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
 const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../dist");
-const ENTRY_DTS = ["index.d.ts", "diff.d.ts", "lint.d.ts", "viewer.d.ts"];
+const ENTRY_DTS = ["index.d.ts", "diff.d.ts", "lint.d.ts", "viewer.d.ts", "design.d.ts"];
 
 // Whole-word protocol type names + the private protocol package. The word gate
 // also covers public diff jsdoc: a bare `Query`/`Command`/`HostApi` in a

--- a/packages/bpmn-modeler/scripts/smoke-consumer.mjs
+++ b/packages/bpmn-modeler/scripts/smoke-consumer.mjs
@@ -43,8 +43,10 @@ const SUBPATHS = [
     "./diff",
     "./lint",
     "./viewer",
+    "./design",
     "./styles.css",
     "./viewer.css",
+    "./design.css",
     "./light-theme.css",
     "./dark-theme.css",
 ];

--- a/packages/bpmn-modeler/src/architecture.spec.ts
+++ b/packages/bpmn-modeler/src/architecture.spec.ts
@@ -212,6 +212,49 @@ describe("bpmn-modeler import direction", () => {
         ).toEqual([]);
     });
 
+    it("the design subpath value-imports only the engine-neutral set (#1196)", () => {
+        // The `/design` subpath must stay free of the Camunda engine stack at the
+        // module-graph level. Unlike `/viewer` it legitimately ships the
+        // engine-neutral properties panel and append/create menu, so those (plus
+        // preact via the panel) are allowed — but a value import of
+        // camunda-bpmn-js, element templates, token simulation, transaction
+        // boundaries, or the lint stack here is exactly what a single-file bundler
+        // would inline into a design-only consumer. `import type` stays fine. The
+        // runtime graph is gated separately by `check-design-pure-entry.mjs`.
+        const DESIGN_DIR = join(PKG_SRC, "design");
+        const isAllowed = (spec: string): boolean =>
+            spec.startsWith(".") ||
+            spec === "bpmn-js" ||
+            spec.startsWith("bpmn-js/") ||
+            spec === "diagram-js" ||
+            spec.startsWith("diagram-js/") ||
+            spec === "bpmn-js-properties-panel" ||
+            spec === "bpmn-js-create-append-anything" ||
+            spec === "diagram-js-minimap" ||
+            spec === "@miragon/bpmn-modeler-types" ||
+            spec === "@miragon/bpmn-modeler-i18n" ||
+            spec === "@miragon/bpmn-modeler-i18n-extras" ||
+            spec === "@miragon/bpmn-modeler-append-menu" ||
+            spec === "@miragon/bpmn-modeler-flow-navigation" ||
+            spec === "@miragon/bpmn-modeler-clipboard";
+        const offenders: string[] = [];
+        for (const file of listSourceFiles(PKG_SRC)) {
+            if (!file.startsWith(DESIGN_DIR)) continue;
+            for (const spec of valueImportedModules(readFileSync(file, "utf8"))) {
+                if (!isAllowed(spec)) {
+                    offenders.push(`${file.slice(PKG_SRC.length + 1)} → ${spec}`);
+                }
+            }
+        }
+        expect(
+            offenders,
+            `the design subpath must stay engine-neutral — value-import only ` +
+                `bpmn-js/*, diagram-js/*, the neutral panel/menu packages, or the ` +
+                `neutral @miragon libs (use \`import type\` for anything else):\n` +
+                `${offenders.join("\n")}`,
+        ).toEqual([]);
+    });
+
     it("no libs/* source imports @miragon/bpmn-modeler", () => {
         const offenders: string[] = [];
         for (const file of listSourceFiles(LIBS_ROOT)) {

--- a/packages/bpmn-modeler/src/design/createDesigner.spec.ts
+++ b/packages/bpmn-modeler/src/design/createDesigner.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Runtime spec for the engine-neutral design surface — currently skipped.
+ *
+ * Unlike the readonly viewer (whose NavigatedViewer stands up in jsdom, so
+ * `createViewer.spec.ts` runs for real), the design surface mounts the
+ * engine-neutral **properties panel** (`bpmn-js-properties-panel`). That package
+ * reaches into bpmn-js internals through extensionless ESM imports
+ * (`label-editing → ../../util/LabelUtil`) that Vitest's module runner resolves
+ * with Node's native ESM loader — which rejects the missing extension. bpmn-js is
+ * authored ESM-in-a-CJS-typed-package and is only ever bundled by a real bundler
+ * (the Vite lib build handles it fine); no Vitest `deps.inline` / `optimizer`
+ * combination makes the deep peer-dep import resolve. This is the same jsdom wall
+ * that leaves the full modeler with no runtime spec (ADR 0011) — the panel is
+ * exactly the piece that cannot mount here.
+ *
+ * A static `import { createDesigner }` would poison collection (the panel loads
+ * transitively at import time), so these tests dynamic-import inside skipped
+ * bodies: they document the intended runtime contract and are ready to un-skip if
+ * the resolution wall is ever lifted. The real runtime proof lives in the demo
+ * page `apps/demo-webapp/bpmn/design.html` (the epic's acceptance check) and the
+ * type-level conformance in `publicApi.spec.ts`.
+ */
+describe.skip("createDesigner (runtime, jsdom — blocked by the properties-panel resolution wall)", () => {
+    it("exposes the editable core services (inverse of the viewer's readonly proof)", async () => {
+        const { createDesigner } = await import("./createDesigner");
+        const container = document.createElement("div");
+        const panel = document.createElement("div");
+        document.body.append(container, panel);
+
+        const designer = await createDesigner(container, { propertiesPanel: { parent: panel } });
+
+        // Editable: the modelling services a viewer never registers ARE present.
+        expect(designer.getService("modeling")).toBeDefined();
+        expect(designer.getService("commandStack")).toBeDefined();
+        // Engine-neutral: none of the Camunda services are registered.
+        expect(() => designer.getService("elementTemplates")).toThrow();
+        expect(() => designer.getService("transactionBoundaries")).toThrow();
+        // The panel renders under the supplied parent.
+        expect(panel.querySelector(".bio-properties-panel")).not.toBeNull();
+
+        designer.destroy();
+    });
+
+    it("creates a new diagram and exports XML with no execution platform", async () => {
+        const { createDesigner } = await import("./createDesigner");
+        const container = document.createElement("div");
+        const panel = document.createElement("div");
+        document.body.append(container, panel);
+
+        const designer = await createDesigner(container, { propertiesPanel: { parent: panel } });
+        await designer.newDiagram();
+        const xml = await designer.exportDiagram();
+        // The mode marker: a fresh Design diagram carries no execution platform.
+        expect(xml).not.toContain("modeler:executionPlatform");
+
+        designer.destroy();
+    });
+});

--- a/packages/bpmn-modeler/src/design/createDesigner.ts
+++ b/packages/bpmn-modeler/src/design/createDesigner.ts
@@ -1,0 +1,38 @@
+import { i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
+import { extras as i18nExtras } from "@miragon/bpmn-modeler-i18n-extras";
+import { BpmnDesigner } from "./designer";
+import type { DesignerOptions } from "./publicApi";
+
+/**
+ * Stands up one independent engine-neutral designer bound to `container` and its
+ * own `propertiesPanel.parent`, then engages theming and the locale. Mirrors
+ * {@link createModeler} minus the engine-bound setup (element templates,
+ * settings) — Design mode has no execution platform — while keeping the i18n
+ * merge, because Design mode (unlike the readonly viewer) has translatable UI.
+ *
+ * Async for API-stability symmetry with {@link createModeler}.
+ */
+export async function createDesigner(
+    container: HTMLElement,
+    options: DesignerOptions,
+): Promise<BpmnDesigner> {
+    // Merge the modeler's internal / dmn-js strings onto the shared library's
+    // dictionaries before anything translates. Idempotent, so a second instance
+    // (or the bootstrap's own call) re-invoking it is harmless.
+    i18n.extend(i18nExtras);
+
+    const designer = new BpmnDesigner(container, options);
+    await designer.init();
+
+    // Always engage theming so the per-instance `data-bpmn-theme` attribute is
+    // set from the first frame; `"automatic"` then follows `prefers-color-scheme`.
+    designer.setTheme(options.theme ?? "automatic");
+    // The i18n instance is a page-global singleton, so a locale set here is
+    // page-wide; only touch it when the caller is explicit, or a default call
+    // would stomp a language the host already set.
+    if (options.locale) {
+        i18n.setLanguage(options.locale as SupportedLocale);
+    }
+
+    return designer;
+}

--- a/packages/bpmn-modeler/src/design/designer.ts
+++ b/packages/bpmn-modeler/src/design/designer.ts
@@ -1,0 +1,325 @@
+import Modeler from "bpmn-js/lib/Modeler";
+import { ImportXMLError, ImportXMLResult, SaveXMLResult } from "bpmn-js/lib/BaseViewer";
+import { BpmnPropertiesPanelModule, BpmnPropertiesProviderModule } from "bpmn-js-properties-panel";
+import { CreateAppendAnythingModule } from "bpmn-js-create-append-anything";
+import MinimapModule from "diagram-js-minimap";
+import { AppendMenuModule } from "@miragon/bpmn-modeler-append-menu";
+import { FlowNavigationModule } from "@miragon/bpmn-modeler-flow-navigation";
+import { createClipboardModules } from "@miragon/bpmn-modeler-clipboard";
+import { TranslateModule } from "@miragon/bpmn-modeler-i18n";
+import {
+    asyncDebounce,
+    type AsyncDebounced,
+    NoModelerError,
+    observeCanvasSize,
+} from "@miragon/bpmn-modeler-types";
+import { installContentEditableClipboardPolyfill } from "../propertiesPanelClipboard";
+import { ThemeController } from "../theme";
+import { ViewportManager } from "../viewport";
+import { SelectionManager } from "../selection";
+import { installKeyboardFocus } from "../keyboardFocus";
+import { installCanvasFocusIndicator } from "../canvasFocusIndicator";
+import type { ThemeMode } from "../publicApi";
+import type { CoreDesignerServices, DesignerOptions } from "./publicApi";
+
+/**
+ * Encapsulates one engine-neutral, editable bpmn-js modeler instance — the
+ * Design-mode analogue of {@link BpmnModeler} and {@link BpmnViewer}.
+ *
+ * Wraps the base `bpmn-js/lib/Modeler` (palette, context pad, modelling,
+ * keyboard, copy-paste, snapping, searchPad, outline) plus an engine-neutral
+ * properties panel (`bpmn-js-properties-panel`, general / documentation groups
+ * only) and our neutral UX modules (translate, append menu, flow navigation). It
+ * loads none of the Camunda editing stack (camunda-bpmn-js, element templates,
+ * token simulation, transaction boundaries, lint), so it never carries an
+ * execution platform — the absence of `modeler:executionPlatform` on the model
+ * is exactly the mode marker a host routes on.
+ *
+ * Per-instance by construction: bound to its own `container` and
+ * `propertiesPanel.parent`, so several surfaces can coexist on a page. Use
+ * {@link createDesigner} as the factory. Every accessor throws
+ * {@link NoModelerError} before {@link init} or after {@link destroy}.
+ */
+export class BpmnDesigner {
+    private modeler: Modeler | undefined = undefined;
+
+    private _viewport: ViewportManager | undefined;
+
+    private _selection: SelectionManager | undefined;
+
+    // Per-instance theme controller, created lazily on the first setTheme.
+    private themeController?: ThemeController;
+
+    // Disposes the canvas-size observer installed by loadDiagram.
+    private stopObservingSize?: () => void;
+
+    // Teardown for the container-scoped focus features installed in init().
+    private focusDisposers: Array<() => void> = [];
+
+    // The debounced content-saved emitter, live only when `onContentSaved` was
+    // supplied. Held so {@link destroy} can cancel a pending trailing export.
+    private contentSaved?: AsyncDebounced<() => Promise<void>>;
+
+    /**
+     * @param container The canvas host element (bpmn-js `container`).
+     * @param options Per-instance config — see {@link DesignerOptions}.
+     */
+    constructor(
+        private readonly container: HTMLElement,
+        private readonly options: DesignerOptions,
+    ) {}
+
+    /** Access the viewport manager after {@link init}. */
+    get viewport(): ViewportManager {
+        if (!this._viewport) {
+            throw new NoModelerError();
+        }
+        return this._viewport;
+    }
+
+    /** Access the selection manager after {@link init}. */
+    get selection(): SelectionManager {
+        if (!this._selection) {
+            throw new NoModelerError();
+        }
+        return this._selection;
+    }
+
+    /**
+     * Creates and mounts the engine-neutral bpmn-js modeler, then wires the
+     * viewport/selection managers, focus features, and the debounced
+     * content-saved subscription.
+     *
+     * @internal Construction step invoked by {@link createDesigner}; not part of
+     *   the public handle.
+     */
+    async init(): Promise<void> {
+        this.disposeFocusFeatures();
+
+        // Clipboard is a built-in: omitting `clipboard` leaves bpmn-js's native
+        // (browser) clipboard in charge; a sandboxed host supplies a bridge.
+        const clip = this.options.clipboard;
+        const clipModules = clip
+            ? createClipboardModules({ element: clip.bridge, text: clip.text })
+            : [];
+        if (clip) {
+            // The label overlay lives outside the bpmn-js DI context, so the DI
+            // clipboard modules don't reach it; this document-level polyfill
+            // bridges its Cmd/Ctrl+C/V through the text bridge. Idempotent.
+            const textBridge = clip.text ?? clip.bridge;
+            installContentEditableClipboardPolyfill(
+                () => textBridge.requestClipboard(),
+                (text) => textBridge.writeClipboard(text),
+            );
+        }
+        const extra = (this.options.additionalModules as any[]) ?? [];
+
+        this.modeler = new Modeler({
+            container: this.container,
+            propertiesPanel: {
+                parent: this.options.propertiesPanel.parent,
+                // Mount the FEEL/documentation popups inside the instance
+                // container (they default to document.body, outside this
+                // instance's theme scope). Safe because the popup is fixed.
+                feelPopupContainer: this.container,
+            },
+            // Ship the minimap collapsed; the toggle lives in the canvas corner.
+            // diagram-js-minimap is engine-neutral (no camunda-bpmn-js), so it is
+            // a first-class design affordance here rather than editor chrome.
+            minimap: { open: false },
+            moddleExtensions: this.options.moddleExtensions,
+            additionalModules: [
+                TranslateModule,
+                BpmnPropertiesPanelModule,
+                BpmnPropertiesProviderModule,
+                // The base create/append overlay our AppendMenuModule decorates.
+                // Engine-neutral: with no `elementTemplates` service registered it
+                // shows just the standard-BPMN panel, and powers favourites.
+                CreateAppendAnythingModule,
+                AppendMenuModule,
+                FlowNavigationModule,
+                MinimapModule,
+                ...clipModules,
+                ...extra,
+            ],
+        });
+
+        const accessor = <T>(name: string): T => this.getModeler().get<T>(name);
+        this._viewport = new ViewportManager(accessor);
+        this._selection = new SelectionManager(accessor);
+
+        this.installFocusFeatures();
+
+        if (this.options.favouriteBpmnElements) {
+            const appendMenuOverride = this.getModeler().get<any>("appendMenuOverride", false);
+            appendMenuOverride?.setFavourites(this.options.favouriteBpmnElements);
+        }
+
+        // The package-owned debounced content event: one full export per burst of
+        // model changes (300ms / 1000ms maxWait). destroy() cancels a pending
+        // trailing export.
+        const onContentSaved = this.options.onContentSaved;
+        if (onContentSaved) {
+            this.contentSaved = asyncDebounce(
+                async () => onContentSaved({ xml: await this.exportDiagram() }),
+                300,
+                { maxWait: 1000 },
+            );
+            this.getModeler()
+                .get<any>("eventBus")
+                .on("commandStack.changed", () => void this.contentSaved!());
+        }
+    }
+
+    /**
+     * Composes the container-scopable focus features onto the fresh modeler: the
+     * "Escape → focus canvas" guard and the canvas focus reticle. Both are scoped
+     * to this instance's canvas container and panel parent so several surfaces on
+     * one page never cross-fire.
+     */
+    private installFocusFeatures(): void {
+        const canvas = this.getModeler().get<{
+            getContainer(): HTMLElement;
+            focus(): void;
+            isFocused(): boolean;
+        }>("canvas");
+        const canvasContainer = canvas.getContainer();
+        const eventBus = () => this.getModeler().get<any>("eventBus");
+        const selection = () => this.getModeler().get<{ get(): unknown[] }>("selection");
+
+        this.focusDisposers.push(
+            installKeyboardFocus({
+                roots: [canvasContainer, this.options.propertiesPanel.parent],
+                focusCanvas: () => canvas.focus(),
+                isCanvasFocused: () => canvas.isFocused(),
+                hasSelection: () => selection().get().length > 0,
+                clearSelection: () =>
+                    this.getModeler()
+                        .get<{ select(elements: null): void }>("selection")
+                        .select(null),
+                isSearchPadOpen: () =>
+                    this.getModeler().get<{ isOpen(): boolean }>("searchPad").isOpen(),
+                closeSearchPad: () => this.getModeler().get<{ close(): void }>("searchPad").close(),
+            }),
+        );
+
+        this.focusDisposers.push(
+            installCanvasFocusIndicator({
+                parent: canvasContainer,
+                isFocused: () => canvas.isFocused(),
+                onFocusChanged: (listener) =>
+                    eventBus().on("canvas.focus.changed", (e: { focused: boolean }) =>
+                        listener(e.focused),
+                    ),
+                hasSelection: () => selection().get().length > 0,
+                onSelectionChanged: (listener) =>
+                    eventBus().on("selection.changed", (e: { newSelection: unknown[] }) =>
+                        listener(e.newSelection.length > 0),
+                    ),
+            }),
+        );
+    }
+
+    private disposeFocusFeatures(): void {
+        for (const dispose of this.focusDisposers.splice(0)) {
+            dispose();
+        }
+    }
+
+    async newDiagram(): Promise<ImportXMLResult> {
+        return this.getModeler().createDiagram();
+    }
+
+    async loadDiagram(xml: string): Promise<ImportXMLResult> {
+        try {
+            const result = await this.getModeler().importXML(xml);
+            // The host may mount the container before laying it out, so the box
+            // can be zero when the import lands; the fit retries until it isn't.
+            this.stopObservingSize?.();
+            const canvas = this.getModeler().get<any>("canvas");
+            this.stopObservingSize = observeCanvasSize(canvas, canvas.getContainer(), {
+                applyInitialViewport: () => this._viewport!.fitViewport(),
+            });
+            this._viewport!.fitViewport();
+            return result;
+        } catch (error: unknown) {
+            if ((error as ImportXMLError).warnings) {
+                const importError = error as ImportXMLError;
+                throw new Error(`${importError.message} ${importError.warnings}`, {
+                    cause: error,
+                });
+            }
+            throw error;
+        }
+    }
+
+    async exportDiagram(): Promise<string> {
+        const result: SaveXMLResult = await this.getModeler().saveXML({ format: true });
+        if (result.xml) {
+            return result.xml;
+        } else if (result.error) {
+            throw result.error;
+        }
+        throw new Error("Failed to serialise the diagram!");
+    }
+
+    async getDiagramSvg(): Promise<string> {
+        const result = await this.getModeler().saveSVG();
+        return result.svg;
+    }
+
+    /**
+     * Switches the colour theme live. Toggles `data-bpmn-theme` on this
+     * instance's container + panel parent and mirrors the choice to a legacy
+     * page-global `#theme-link` when present.
+     */
+    setTheme(theme: ThemeMode): void {
+        if (!this.themeController) {
+            this.themeController = new ThemeController([
+                this.container,
+                this.options.propertiesPanel.parent,
+            ]);
+        }
+        this.themeController.setMode(theme);
+    }
+
+    /**
+     * Returns a service from the modeler's DI container. The
+     * {@link CoreDesignerServices} names are semver-stable; every other name is
+     * an unstable escape hatch.
+     */
+    getService<K extends keyof CoreDesignerServices>(name: K): CoreDesignerServices[K];
+    getService<T = unknown>(name: string): T;
+    getService(name: string): any {
+        return this.getModeler().get(name);
+    }
+
+    /**
+     * Tears the instance down: cancels the debounced export, stops the
+     * canvas-size observer, disposes the focus features and theme controller, and
+     * destroys the underlying bpmn-js modeler. A destroyed facade throws
+     * {@link NoModelerError} from every accessor.
+     */
+    destroy(): void {
+        this.contentSaved?.cancel();
+        this.stopObservingSize?.();
+        this.stopObservingSize = undefined;
+        this.themeController?.dispose();
+        this.disposeFocusFeatures();
+        this.modeler?.destroy();
+        this.modeler = undefined;
+        this._viewport = undefined;
+        this._selection = undefined;
+    }
+
+    /**
+     * @throws {NoModelerError} If {@link init} has not been called (or the
+     *   instance was destroyed).
+     */
+    private getModeler(): Modeler {
+        if (!this.modeler) {
+            throw new NoModelerError();
+        }
+        return this.modeler;
+    }
+}

--- a/packages/bpmn-modeler/src/design/index.ts
+++ b/packages/bpmn-modeler/src/design/index.ts
@@ -1,0 +1,48 @@
+/**
+ * `@miragon/bpmn-modeler/design` — the host-free, engine-neutral BPMN design
+ * surface.
+ *
+ * A fully editable but engine-neutral surface for documentation / conceptual
+ * modelling: the base bpmn-js Modeler plus a plain-BPMN properties panel
+ * (general / documentation groups) and neutral UX (translate, append menu, flow
+ * navigation). It drags none of the Camunda editing stack (camunda-bpmn-js,
+ * element templates, token simulation, transaction boundaries, lint) into the
+ * module graph. That leanness is enforced at the graph level
+ * (`scripts/check-design-pure-entry.mjs` + `architecture.spec.ts`) so it holds
+ * under single-file bundlers. See ADR 0016.
+ *
+ * The mode marker is the absence of `modeler:executionPlatform` on
+ * `bpmn:Definitions` — route with `detectEngine(xml)` (`undefined` ⇒ Design).
+ *
+ * Deliberately imports **no CSS**: `cssCodeSplit: false` on the lib build would
+ * fold any stylesheet reachable from here into the shared `dist/bpmn-modeler.css`
+ * (the modeler's `styles.css`), pulling the editor chrome's CSS back in. The
+ * design surface's own sheet ships separately as
+ * `@miragon/bpmn-modeler/design.css` (built by `vite.viewer-css.config.mts`),
+ * which a consumer loads instead. Note that the properties panel does pull preact
+ * and CodeMirror (its FEEL/JSON editors) into the graph — legitimately, unlike
+ * the readonly `/viewer`.
+ */
+
+// ── Public factory + API surface ─────────────────────────────────────────────
+export { createDesigner } from "./createDesigner";
+export type {
+    DesignerOptions,
+    BpmnDesignerHandle,
+    CoreDesignerServices,
+    CreateDesigner,
+} from "./publicApi";
+export type { ThemeMode, ClipboardOptions, ContentSavedEvent } from "../publicApi";
+
+// ── Mode routing — re-exported for hosts that decide Design vs Implement ──────
+export { detectEngine } from "../detectEngine";
+export type { DetectedEngine } from "../detectEngine";
+
+// ── Viewport / selection — public, referenced by the designer handle ─────────
+export { ViewportManager } from "../viewport";
+export type { ViewportData } from "../viewport";
+export { SelectionManager } from "../selection";
+
+// ── Re-exports so the rolled-up `.d.ts` stays self-contained ─────────────────
+export { NoModelerError } from "@miragon/bpmn-modeler-types";
+export type { ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";

--- a/packages/bpmn-modeler/src/design/publicApi.ts
+++ b/packages/bpmn-modeler/src/design/publicApi.ts
@@ -1,0 +1,148 @@
+import type { ImportXMLResult } from "bpmn-js/lib/BaseViewer";
+import type {
+    ClipboardOptions,
+    ContentSavedEvent,
+    CoreModelerServices,
+    ThemeMode,
+} from "../publicApi";
+import type { ViewportManager } from "../viewport";
+import type { SelectionManager } from "../selection";
+
+/**
+ * The public TypeScript surface of `@miragon/bpmn-modeler/design`: an
+ * engine-neutral, editable BPMN surface for documentation / conceptual modelling.
+ *
+ * Design mode sits between the full {@link BpmnModelerHandle} (Camunda 7/8, with
+ * an engine-bound properties panel) and the readonly {@link BpmnViewerHandle}: it
+ * is fully editable — palette, context pad, modelling, copy-paste — but carries
+ * only plain-BPMN properties (general / documentation groups), none of the
+ * Camunda stack. It never loads camunda-bpmn-js, element templates, token
+ * simulation, transaction boundaries, or the lint stack.
+ *
+ * **The mode marker is the absence of `modeler:executionPlatform` on
+ * `bpmn:Definitions`.** A host routes a document with `detectEngine(xml) ===
+ * undefined` here (editable Design), and one with a detected engine to
+ * {@link createModeler} (Implement). Switching modes is a host concern: stamp or
+ * strip the execution platform on the XML, `destroy()` this instance, and stand
+ * up the other factory — the conversion helpers are deferred (see ADR 0016).
+ *
+ * Leanness holds at the *module-graph* level, not a runtime flag, so it survives
+ * single-file bundlers (`vite-plugin-singlefile`) that inline everything
+ * reachable — hence a separate subpath, mirroring the `/viewer` (ADR 0014) and
+ * `/lint` (ADR 0013) precedents. See ADR 0016.
+ */
+
+/**
+ * The core diagram-js/bpmn-js services a designer exposes through
+ * {@link BpmnDesignerHandle.getService}. Identical to {@link CoreModelerServices}
+ * (ADR 0011) — Design mode is fully editable, so `modeling` and `commandStack`
+ * are present, unlike the readonly viewer's `Pick`.
+ */
+export type CoreDesignerServices = CoreModelerServices;
+
+/**
+ * Per-instance configuration for {@link createDesigner}. Deliberately minimal:
+ * Design mode has no engine (there is no execution platform to bind), no element
+ * templates, no linting, and no host capabilities — every field that survives is
+ * engine-neutral.
+ */
+export interface DesignerOptions {
+    /**
+     * The panel host. Required (as in {@link createModeler}): each instance owns
+     * its own properties-panel parent so several surfaces can coexist on a page.
+     * The panel shows only the engine-neutral general / documentation groups.
+     */
+    propertiesPanel: { parent: HTMLElement };
+
+    /**
+     * Colour theme — defaults to `"automatic"`. Theming always engages: the
+     * instance gets a `data-bpmn-theme` attribute from the first frame.
+     */
+    theme?: ThemeMode;
+
+    /** UI locale (BCP-47-ish tag) — Design mode has translatable UI. Defaults to `"en"`. */
+    locale?: string;
+
+    /**
+     * Element types offered first in the append/create menu — the neutral
+     * counterpart of the modeler setting of the same name, lifted to a
+     * first-class option (Design mode has no `settings`).
+     */
+    favouriteBpmnElements?: string[];
+
+    /** Clipboard override — omit for the native browser clipboard. */
+    clipboard?: ClipboardOptions;
+
+    /**
+     * Escape hatch: extra moddle extensions for a host's own BPMN namespace.
+     * Matches bpmn-js's own `moddleExtensions`.
+     */
+    moddleExtensions?: Record<string, object>;
+
+    /**
+     * Escape hatch: extra bpmn-js DI modules. Matches bpmn-js's own
+     * `additionalModules`.
+     */
+    additionalModules?: unknown[];
+
+    /** Debounced diagram content — see {@link ContentSavedEvent}. */
+    onContentSaved?: (event: ContentSavedEvent) => void;
+}
+
+/**
+ * The instance handle {@link createDesigner} resolves to — the editable,
+ * engine-neutral analogue of {@link BpmnModelerHandle}. Every member is
+ * signature-identical to its modeler counterpart (subset compatibility is
+ * asserted in `publicApi.spec.ts`).
+ */
+export interface BpmnDesignerHandle {
+    /** Load BPMN 2.0 XML, replacing any current diagram, and fit it to view. */
+    loadDiagram(xml: string): Promise<ImportXMLResult>;
+
+    /** Serialise the current diagram to formatted XML. */
+    exportDiagram(): Promise<string>;
+
+    /**
+     * Replace the diagram with a new empty one. The base bpmn-js template carries
+     * no `modeler:executionPlatform`, so a fresh Design diagram stays in Design
+     * mode by the mode-marker semantics above.
+     */
+    newDiagram(): Promise<ImportXMLResult>;
+
+    /** Export the current diagram as SVG markup. */
+    getDiagramSvg(): Promise<string>;
+
+    /** Viewport (zoom/scroll/fit) accessor. */
+    readonly viewport: ViewportManager;
+
+    /** Selection accessor. */
+    readonly selection: SelectionManager;
+
+    /**
+     * Switch the colour theme live. Toggles this instance's `data-bpmn-theme`
+     * attribute and mirrors it to a legacy `#theme-link` when present.
+     */
+    setTheme(theme: ThemeMode): void;
+
+    /**
+     * Resolve a core diagram-js/bpmn-js service by name. The
+     * {@link CoreDesignerServices} names are semver-stable; every other name is an
+     * unstable escape hatch.
+     */
+    getService<K extends keyof CoreDesignerServices>(name: K): CoreDesignerServices[K];
+    getService<T = unknown>(name: string): T;
+
+    /** Tear the instance down and free its bpmn-js DI graph and DOM. */
+    destroy(): void;
+}
+
+/**
+ * The `@miragon/bpmn-modeler/design` entry point: stand up one engine-neutral,
+ * editable designer bound to `container` and resolve its
+ * {@link BpmnDesignerHandle}. Async for API-stability symmetry with
+ * {@link createModeler}.
+ */
+export type CreateDesigner = (
+    container: HTMLElement,
+    options: DesignerOptions,
+) => Promise<BpmnDesignerHandle>;

--- a/packages/bpmn-modeler/src/publicApi.spec.ts
+++ b/packages/bpmn-modeler/src/publicApi.spec.ts
@@ -15,6 +15,7 @@ import type {
     ThemeMode,
 } from "./publicApi";
 import type { BpmnViewerHandle, CoreViewerServices, ViewerOptions } from "./viewer/publicApi";
+import type { BpmnDesignerHandle, CoreDesignerServices, DesignerOptions } from "./design/publicApi";
 
 // A minimal stub of the injected `@miragon/bpmn-modeler/lint` namespace. The
 // on-tiers below all require a `module`, so migration failures are compile-time.
@@ -288,6 +289,68 @@ const _viewerHasNoEditing = (v: BpmnViewerHandle) => {
     void v.setElementTemplates;
 };
 void _viewerHasNoEditing;
+
+// ── Designer subpath conformance (#1196) ────────────────────────────────────
+
+// Subset compatibility: every BpmnDesignerHandle member is signature-identical
+// to its BpmnModelerHandle counterpart, so a modeler handle narrows to a designer
+// handle with no adapter. If a designer member drifts from the modeler's shape,
+// this line stops compiling.
+const _modelerSatisfiesDesignerHandle = (m: BpmnModelerHandle): BpmnDesignerHandle => m;
+void _modelerSatisfiesDesignerHandle;
+
+// Design mode is fully editable, so CoreDesignerServices is the full
+// CoreModelerServices set (not the viewer's readonly Pick): each of the seven
+// keys resolves to its exact vendor type, including modeling + commandStack.
+const _coreDesignerServices = (d: BpmnDesignerHandle) => {
+    const canvas: CoreModelerServices["canvas"] = d.getService("canvas");
+    const commandStack: CoreModelerServices["commandStack"] = d.getService("commandStack");
+    const modeling: CoreModelerServices["modeling"] = d.getService("modeling");
+    void [canvas, commandStack, modeling];
+};
+void _coreDesignerServices;
+
+type _DesignerServicesEqualModeler = keyof CoreDesignerServices extends keyof CoreModelerServices
+    ? keyof CoreModelerServices extends keyof CoreDesignerServices
+        ? true
+        : never
+    : never;
+const _designerServicesEqual: _DesignerServicesEqualModeler = true;
+void _designerServicesEqual;
+
+// DesignerOptions requires the panel host and accepts the engine-neutral knobs.
+const _designerOptions = {
+    propertiesPanel: { parent: document.createElement("div") },
+    theme: "dark",
+    locale: "de",
+    favouriteBpmnElements: ["bpmn:Task"],
+    moddleExtensions: {
+        bpmiq: { name: "bpmiq", uri: "http://bpmiq/schema", prefix: "bpmiq", types: [] },
+    },
+    additionalModules: [{ __init__: [] }],
+} satisfies DesignerOptions;
+void _designerOptions;
+
+const _designerRejectsEngine = {
+    propertiesPanel: { parent: document.createElement("div") },
+    // @ts-expect-error — Design mode has no engine (no execution platform to bind).
+    engine: "c7",
+} satisfies DesignerOptions;
+void _designerRejectsEngine;
+
+const _designerRejectsLinting = {
+    propertiesPanel: { parent: document.createElement("div") },
+    // @ts-expect-error — linting is an engine-bound built-in, absent from the designer.
+    linting: false,
+} satisfies DesignerOptions;
+void _designerRejectsLinting;
+
+const _designerRejectsElementTemplates = {
+    propertiesPanel: { parent: document.createElement("div") },
+    // @ts-expect-error — element templates are engine-bound, absent from the designer.
+    elementTemplates: [],
+} satisfies DesignerOptions;
+void _designerRejectsElementTemplates;
 
 describe("public API conformance", () => {
     it("is a type-only conformance spec; the guarantee is the tsc pass", () => {

--- a/packages/bpmn-modeler/src/styles/design.css
+++ b/packages/bpmn-modeler/src/styles/design.css
@@ -1,0 +1,22 @@
+/*
+ * The engine-neutral design surface's stylesheet, built standalone as
+ * `@miragon/bpmn-modeler/design.css` (see `vite.viewer-css.config.mts`). It
+ * carries the bpmn-js base diagram/font CSS, the engine-neutral properties panel
+ * and append-menu chrome, the minimap, and the canvas focus indicator — plus the
+ * dark-theme overrides scoped under `[data-bpmn-theme="dark"]`. It loads none of
+ * the Camunda
+ * editor chrome (camunda-bpmn-js, element templates, token simulation) the full
+ * `styles.css` carries. Do not also load `styles.css` on a design-only page; the
+ * two overlap.
+ */
+@import "bpmn-js/dist/assets/diagram-js.css";
+@import "bpmn-js/dist/assets/bpmn-js.css";
+@import "bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css";
+@import "@bpmn-io/properties-panel/dist/assets/properties-panel.css";
+@import "diagram-js-minimap/assets/diagram-js-minimap.css";
+@import "../../../../libs/append-menu/src/append-menu.css";
+@import "./canvasFocusIndicator.css";
+@import "./dark-theme/diagram-js.css";
+@import "./dark-theme/properties-panel.css";
+@import "./dark-theme/append-menu.css";
+@import "./dark-theme/minimap.css";

--- a/packages/bpmn-modeler/src/types/bpmn-js.d.ts
+++ b/packages/bpmn-modeler/src/types/bpmn-js.d.ts
@@ -1,5 +1,7 @@
 declare module "bpmn-js-properties-panel" {
     export const useService;
+    export const BpmnPropertiesPanelModule;
+    export const BpmnPropertiesProviderModule;
 }
 
 declare module "@bpmn-io/properties-panel" {
@@ -28,11 +30,17 @@ declare module "bpmn-js-token-simulation" {
 
 declare module "bpmn-js-create-append-anything" {
     export const CreateAppendElementTemplatesModule;
+    export const CreateAppendAnythingModule;
 }
 
 declare module "camunda-transaction-boundaries/lib/index.js" {
     const TransactionBoundariesModule;
     export default TransactionBoundariesModule;
+}
+
+declare module "diagram-js-minimap" {
+    const MinimapModule;
+    export default MinimapModule;
 }
 
 declare module "bpmn-js-native-copy-paste/lib/PasteUtil.js" {

--- a/packages/bpmn-modeler/vite.config.mts
+++ b/packages/bpmn-modeler/vite.config.mts
@@ -101,6 +101,13 @@ export default defineConfig({
                 // via `vite.viewer-css.config.mts`. Purity gated by
                 // `check-viewer-pure-entry.mjs`.
                 viewer: resolve(__dirname, "src/viewer/index.ts"),
+                // Engine-neutral design subpath (`@miragon/bpmn-modeler/design`,
+                // #1196): base bpmn-js Modeler + a plain-BPMN properties panel,
+                // none of the Camunda editor stack. Like `/viewer` it imports no
+                // CSS (its sheet ships as `dist/design.css` via
+                // `vite.viewer-css.config.mts`); purity gated by
+                // `check-design-pure-entry.mjs`.
+                design: resolve(__dirname, "src/design/index.ts"),
             },
             formats: ["es"],
             cssFileName: "bpmn-modeler",

--- a/packages/bpmn-modeler/vite.viewer-css.config.mts
+++ b/packages/bpmn-modeler/vite.viewer-css.config.mts
@@ -21,6 +21,7 @@ export default defineConfig({
         rollupOptions: {
             input: {
                 viewer: resolve(__dirname, "src/styles/viewer.css"),
+                design: resolve(__dirname, "src/styles/design.css"),
             },
             output: {
                 assetFileNames: "[name].[ext]",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,7 @@
             "@miragon/bpmn-modeler/diff": ["./packages/bpmn-modeler/src/diff/index.ts"],
             "@miragon/bpmn-modeler/lint": ["./packages/bpmn-modeler/src/bpmnlint/index.ts"],
             "@miragon/bpmn-modeler/viewer": ["./packages/bpmn-modeler/src/viewer/index.ts"],
+            "@miragon/bpmn-modeler/design": ["./packages/bpmn-modeler/src/design/index.ts"],
             "@miragon/bpmn-modeler-shared": ["./libs/shared/src/index.ts"],
             "@miragon/bpmn-modeler-types": ["./libs/modeler-types/src/index.ts"],
             "@miragon/bpmn-modeler-diff": ["./libs/bpmn-diff/src/index.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4153,6 +4153,7 @@ __metadata:
     camunda-bpmn-moddle: "npm:7.0.2"
     camunda-transaction-boundaries: "npm:1.1.2"
     diagram-js: "npm:15.24.1"
+    diagram-js-minimap: "npm:5.4.1"
     didi: "npm:11.0.0"
     jsdom: "npm:30.0.1"
     lodash: "npm:4.18.1"
@@ -11949,7 +11950,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diagram-js-minimap@npm:^5.4.1":
+"diagram-js-minimap@npm:5.4.1, diagram-js-minimap@npm:^5.4.1":
   version: 5.4.1
   resolution: "diagram-js-minimap@npm:5.4.1"
   dependencies:


### PR DESCRIPTION
## Issue

Closes #1196

## Description

Adds an engine-neutral, editable Design-mode surface on a new `@miragon/bpmn-modeler/design` subpath: `createDesigner(container, options)` wraps the base bpmn-js `Modeler` plus the plain-BPMN properties panel (general/documentation groups), our custom append menu, flow navigation, i18n, minimap, and the shared theme/viewport/selection/clipboard internals — while the module graph provably omits the entire Camunda layer (camunda-bpmn-js, element templates, token simulation, transaction boundaries, lint), enforced by a new `check-design-pure-entry.mjs` build gate and architecture-test assertions. The absence of `modeler:executionPlatform` on `bpmn:Definitions` is the mode marker (hosts route via the re-exported `detectEngine`; `newDiagram()` produces neutral XML), closing the engine × editability matrix alongside `createModeler` and the `/viewer` subpath. `BpmnDesignerHandle` is a compile-time-asserted editable subset of `BpmnModelerHandle`, and a lean `design.css` ships via the shared CSS-only Vite config. Conversion helpers (stamp/strip `executionPlatform`) and a `linting` option are deferred — recorded in [ADR 0016](docs/adr/0016-design-mode-subpath.md). A demo page (`/bpmn/design.html`) serves as the epic's regression check; roadmap step 7 (final) of #1409.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (N/A — purely additive, hosts consume the package only via `apps/bpmn-webview`, which is untouched)
