### PR TITLE
feat(bpmn-modeler): add public view-state capture/restore on all handles

### DIFF
--- a/apps/bpmn-webview/src/state.spec.ts
+++ b/apps/bpmn-webview/src/state.spec.ts
@@ -26,11 +26,19 @@ function setup(
     const onSelectionChanged = vi.fn();
     const getSelectedElementIds = vi.fn().mockReturnValue([]);
     const selectElementsByIds = vi.fn();
+    const captureViewState = vi.fn().mockReturnValue({
+        rootElementId: undefined,
+        viewport: { x: 0, y: 0, width: 1, height: 1 },
+        selectedElementIds: [],
+    });
+    const applyViewState = vi.fn();
     const host = { getState, updateState, setState } as any;
     const modeler = {
         viewport: { setViewport, fitViewport, getViewport, onViewportChanged },
         rootElement: { setRootElementById, getRootElementId, onRootChanged },
         selection: { getSelectedElementIds, selectElementsByIds, onSelectionChanged },
+        captureViewState,
+        applyViewState,
     } as any;
     return {
         manager: new WebviewStateManager(host, modeler, panelRoot),
@@ -41,6 +49,8 @@ function setup(
         getViewport,
         getSelectedElementIds,
         selectElementsByIds,
+        captureViewState,
+        applyViewState,
         updateState,
     };
 }
@@ -139,54 +149,33 @@ describe("WebviewStateManager.restoreViewport", () => {
 });
 
 describe("WebviewStateManager.captureViewState / applyViewState", () => {
-    it("round-trips the canvas view state", () => {
-        const {
-            manager,
-            getRootElementId,
-            getViewport,
-            getSelectedElementIds,
-            setRootElementById,
-            setViewport,
-            selectElementsByIds,
-        } = setup(undefined);
+    // The composition (root → viewport → selection ordering, implicit-root
+    // handling) now lives in the package handle and is unit-tested there
+    // (`viewState.spec.ts`); the manager only delegates.
+    it("delegates capture to the modeler handle", () => {
+        const { manager, captureViewState } = setup(undefined);
+        const snapshot = {
+            rootElementId: "SubProcess_1_plane",
+            viewport: { x: 100, y: 200, width: 500, height: 300 },
+            selectedElementIds: ["Task_1", "Task_2"],
+        };
+        captureViewState.mockReturnValue(snapshot);
 
-        getRootElementId.mockReturnValue("SubProcess_1_plane");
-        getViewport.mockReturnValue({ x: 100, y: 200, width: 500, height: 300 });
-        getSelectedElementIds.mockReturnValue(["Task_1", "Task_2"]);
-
-        const snapshot = manager.captureViewState();
-        manager.applyViewState(snapshot);
-
-        expect(setRootElementById).toHaveBeenCalledWith("SubProcess_1_plane");
-        expect(setViewport).toHaveBeenCalledWith({ x: 100, y: 200, width: 500, height: 300 });
-        expect(selectElementsByIds).toHaveBeenCalledWith(["Task_1", "Task_2"]);
+        expect(manager.captureViewState()).toBe(snapshot);
+        expect(captureViewState).toHaveBeenCalledOnce();
     });
 
-    it("applies root before viewbox in applyViewState", () => {
-        const { manager, setRootElementById, setViewport, getRootElementId, getViewport } =
-            setup(undefined);
-
-        getRootElementId.mockReturnValue("SubProcess_1_plane");
-        getViewport.mockReturnValue({ x: 0, y: 0, width: 1000, height: 800 });
-
-        const snapshot = manager.captureViewState();
-        manager.applyViewState(snapshot);
-
-        const rootOrder = setRootElementById.mock.invocationCallOrder[0]!;
-        const viewportOrder = setViewport.mock.invocationCallOrder[0]!;
-        expect(rootOrder).toBeLessThan(viewportOrder);
-    });
-
-    it("handles capture with no drill-down (top-level process)", () => {
-        const { manager, getRootElementId, setRootElementById } = setup(undefined);
-        getRootElementId.mockReturnValue(undefined);
-
-        const snapshot = manager.captureViewState();
-        expect(snapshot.rootElementId).toBeUndefined();
+    it("delegates apply to the modeler handle", () => {
+        const { manager, applyViewState } = setup(undefined);
+        const snapshot = {
+            rootElementId: "SubProcess_1_plane",
+            viewport: { x: 0, y: 0, width: 1000, height: 800 },
+            selectedElementIds: ["Task_1"],
+        };
 
         manager.applyViewState(snapshot);
-        // setRootElementById(undefined) returns false — no plane switch
-        expect(setRootElementById).toHaveBeenCalledWith(undefined);
+
+        expect(applyViewState).toHaveBeenCalledWith(snapshot);
     });
 });
 

--- a/apps/bpmn-webview/src/state.ts
+++ b/apps/bpmn-webview/src/state.ts
@@ -226,26 +226,20 @@ export class WebviewStateManager {
     /**
      * Snapshots the live canvas state — drill-down plane, viewbox, and
      * selection — so it can be re-applied after a destructive re-import
-     * (undo/redo host push, language switch).
+     * (undo/redo host push, language switch). Delegates to the package handle,
+     * which owns the composition (root → viewport → selection ordering).
      */
     captureViewState(): CanvasViewState {
-        return {
-            rootElementId: this.modeler.rootElement.getRootElementId(),
-            viewport: this.modeler.viewport.getViewport(),
-            selectedElementIds: this.modeler.selection.getSelectedElementIds(),
-        };
+        return this.modeler.captureViewState();
     }
 
     /**
-     * Re-applies a previously captured view state after a re-import.
-     *
-     * Order matters: root first (viewbox coordinates are plane-relative),
-     * then viewbox, then selection.
+     * Re-applies a previously captured view state after a re-import. The handle
+     * enforces the required order: root first (viewbox coordinates are
+     * plane-relative), then viewbox, then selection.
      */
     applyViewState(snapshot: CanvasViewState): void {
-        this.modeler.rootElement.setRootElementById(snapshot.rootElementId);
-        this.modeler.viewport.setViewport(snapshot.viewport);
-        this.modeler.selection.selectElementsByIds(snapshot.selectedElementIds);
+        this.modeler.applyViewState(snapshot);
     }
 
     private getSavedState(): WebviewState | undefined {

--- a/apps/bpmn-webview/src/webviewState.ts
+++ b/apps/bpmn-webview/src/webviewState.ts
@@ -3,19 +3,18 @@
  * `WebviewStateManager`. Not part of the public modeler API.
  */
 
-import type { ViewportData } from "@miragon/bpmn-modeler";
+import type { ViewportData, ViewState } from "@miragon/bpmn-modeler";
 
 /**
- * Snapshot of the canvas view that can be captured from the live
- * modeler and re-applied after a re-import (undo/redo, XML push,
- * language switch) to preserve the user's drill-down plane, viewport,
- * and selection.
+ * Snapshot of the canvas view that can be captured from the live modeler and
+ * re-applied after a re-import (undo/redo, XML push, language switch) to
+ * preserve the user's drill-down plane, viewport, and selection.
+ *
+ * Aliases the package's public {@link ViewState} — the handle owns the
+ * capture/apply composition now (the fields are identical), so the webview
+ * carries no separate copy of the shape.
  */
-export interface CanvasViewState {
-    rootElementId?: string;
-    viewport: ViewportData;
-    selectedElementIds: string[];
-}
+export type CanvasViewState = ViewState;
 
 /**
  * Webview state persisted via the host's `setState` / `getState`.

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -202,6 +202,48 @@ bpmn-js/diagram-js-documented shapes across minor versions. Every other
 `getService` name is unstable and may change or disappear without a major bump —
 prefer a typed option/method, and open an issue if a name you need is missing.
 
+## View state (capture / restore)
+
+`handle.captureViewState()` snapshots *where the user is looking* — the
+drill-down plane, the viewbox, and the selection — into a plain `ViewState`, and
+`handle.applyViewState(state)` restores it. The same two methods and the same
+`ViewState` type are on all three handles (`BpmnModelerHandle`,
+`BpmnViewerHandle`, `BpmnDesignerHandle`), so they compose across a mode switch.
+
+```ts
+interface ViewState {
+    viewport: ViewportData;
+    rootElementId?: string;      // undefined ⇒ top-level plane
+    selectedElementIds: string[];
+}
+```
+
+The intended use is an **instance switch** (View ↔ Design ↔ Implement, which
+destroys one bpmn-js instance and stands up another): capture on the old handle,
+`destroy()` it, create the new one, `loadDiagram(...)`, then apply.
+
+```ts
+const state = current.captureViewState();
+current.destroy();
+const next = await createViewer(container);   // or createModeler / createDesigner
+await next.loadDiagram(xml);
+next.applyViewState(state);                    // same plane, viewbox, selection
+```
+
+Semantics:
+
+- **Apply order is fixed: root → viewport → selection.** Viewbox coordinates are
+  plane-relative, so the plane must switch first; the internals enforce this
+  order, so callers never have to.
+- **The top-level plane is never a stored id.** bpmn-js regenerates the implicit
+  root's id on every import, so a top-level snapshot carries
+  `rootElementId: undefined`, and applying `undefined` leaves the canvas on the
+  top-level plane.
+- **Stale references degrade gracefully.** A `rootElementId` whose sub-process no
+  longer exists falls back to the top-level plane, and `selectedElementIds` that
+  are gone are silently skipped — a snapshot taken against a since-edited diagram
+  still applies without throwing.
+
 ## Clipboard wire format
 
 Copy/paste defaults to the native browser clipboard; a sandboxed host
@@ -322,11 +364,14 @@ viewer.selection.onSelectionChanged((ids) => console.log("selected", ids));
 ### `BpmnViewerHandle`
 
 `loadDiagram`, `exportDiagram`, `getDiagramSvg`, `viewport`, `selection`,
-`setTheme`, `getService`, and `destroy` — each **signature-identical** to its
-`BpmnModelerHandle` counterpart, so a modeler handle narrows to a viewer handle
-with no adapter (a compile-time acceptance criterion). There is no `newDiagram`,
-`setElementTemplates`, `setSettings`, linting, clipboard, capabilities, or
-events.
+`captureViewState`, `applyViewState`, `setTheme`, `getService`, and `destroy` —
+each **signature-identical** to its `BpmnModelerHandle` counterpart, so a modeler
+handle narrows to a viewer handle with no adapter (a compile-time acceptance
+criterion). `captureViewState` / `applyViewState` (see
+[View state](#view-state-capture--restore)) make the viewer a valid target for a
+mode switch — capture on the editor, apply on the viewer. There is no
+`newDiagram`, `setElementTemplates`, `setSettings`, linting, clipboard,
+capabilities, or events.
 
 `getService` is typed against `CoreViewerServices` — the readonly `Pick` of the
 [core services](#core-services--escape-hatch): `canvas`, `elementRegistry`,
@@ -414,9 +459,12 @@ There is no `engine`, `linting`, `elementTemplates`, `settings`, or
 ### `BpmnDesignerHandle`
 
 `loadDiagram`, `exportDiagram`, `newDiagram`, `getDiagramSvg`, `viewport`,
-`selection`, `setTheme`, `getService`, and `destroy` — each
-**signature-identical** to its `BpmnModelerHandle` counterpart, so a modeler
-handle narrows to a designer handle with no adapter. `getService` is typed
+`selection`, `captureViewState`, `applyViewState`, `setTheme`, `getService`, and
+`destroy` — each **signature-identical** to its `BpmnModelerHandle` counterpart,
+so a modeler handle narrows to a designer handle with no adapter.
+`captureViewState` / `applyViewState` (see
+[View state](#view-state-capture--restore)) carry the user's plane, viewbox, and
+selection across a mode switch. `getService` is typed
 against `CoreDesignerServices`, which equals the full
 [core services](#core-services--escape-hatch) set (`modeling` and `commandStack`
 included) — the surface is editable by construction. `newDiagram()` uses the
@@ -482,6 +530,11 @@ importing the subpath brings no extra stylesheet wiring.
   `options.locale` sets the language for the whole page, not per instance. With
   several modelers on one page, the last `locale` wins. (A documented `0.1.0`
   limitation.)
+- **Undo history does not survive an instance switch.** `captureViewState` /
+  `applyViewState` carry the plane, viewbox, and selection across a
+  `destroy()` + create, but the bpmn-js command stack belongs to the destroyed
+  instance — the new instance starts with an empty undo history. Only the view
+  state is preserved, not the edit history.
 - **Bundler dedupe.** The modeler and its plugins must share single copies of
   `preact` and the properties-panel / CodeMirror stack. If you build with Vite,
   add these to `resolve.dedupe`:

--- a/packages/bpmn-modeler/src/design/designer.ts
+++ b/packages/bpmn-modeler/src/design/designer.ts
@@ -17,6 +17,12 @@ import { installContentEditableClipboardPolyfill } from "../propertiesPanelClipb
 import { ThemeController } from "../theme";
 import { ViewportManager } from "../viewport";
 import { SelectionManager } from "../selection";
+import { RootElementManager } from "../rootElement";
+import {
+    applyViewState as applyViewStateComposition,
+    captureViewState as captureViewStateComposition,
+    type ViewState,
+} from "../viewState";
 import { installKeyboardFocus } from "../keyboardFocus";
 import { installCanvasFocusIndicator } from "../canvasFocusIndicator";
 import type { ThemeMode } from "../publicApi";
@@ -46,6 +52,11 @@ export class BpmnDesigner {
     private _viewport: ViewportManager | undefined;
 
     private _selection: SelectionManager | undefined;
+
+    // Drill-down plane tracking, composed into captureViewState/applyViewState.
+    // Kept private (no public handle getter) — the designer exposes only the
+    // composed view-state methods.
+    private _rootElement: RootElementManager | undefined;
 
     // Per-instance theme controller, created lazily on the first setTheme.
     private themeController?: ThemeController;
@@ -83,6 +94,38 @@ export class BpmnDesigner {
             throw new NoModelerError();
         }
         return this._selection;
+    }
+
+    /**
+     * Snapshots the drill-down plane, viewbox, and selection so they survive an
+     * instance switch (View ↔ Design ↔ Implement) — capture here, `destroy()`,
+     * create the next instance, `loadDiagram`, then {@link applyViewState}. See
+     * {@link ViewState} for the plane/selection degradation rules.
+     */
+    captureViewState(): ViewState {
+        return captureViewStateComposition(this.viewStateManagers());
+    }
+
+    /**
+     * Re-applies a {@link captureViewState} snapshot, restoring plane, viewbox,
+     * and selection in the required root → viewport → selection order.
+     */
+    applyViewState(state: ViewState): void {
+        applyViewStateComposition(this.viewStateManagers(), state);
+    }
+
+    /**
+     * The three managers backing view-state capture/apply. Reading `viewport`
+     * throws {@link NoModelerError} before {@link init}; the root manager is
+     * created and cleared in lockstep with it, so the assertion never fires
+     * after that guard passes.
+     */
+    private viewStateManagers() {
+        return {
+            viewport: this.viewport,
+            selection: this.selection,
+            rootElement: this._rootElement!,
+        };
     }
 
     /**
@@ -147,6 +190,7 @@ export class BpmnDesigner {
         const accessor = <T>(name: string): T => this.getModeler().get<T>(name);
         this._viewport = new ViewportManager(accessor);
         this._selection = new SelectionManager(accessor);
+        this._rootElement = new RootElementManager(accessor);
 
         this.installFocusFeatures();
 
@@ -310,6 +354,7 @@ export class BpmnDesigner {
         this.modeler = undefined;
         this._viewport = undefined;
         this._selection = undefined;
+        this._rootElement = undefined;
     }
 
     /**

--- a/packages/bpmn-modeler/src/design/index.ts
+++ b/packages/bpmn-modeler/src/design/index.ts
@@ -42,6 +42,7 @@ export type { DetectedEngine } from "../detectEngine";
 export { ViewportManager } from "../viewport";
 export type { ViewportData } from "../viewport";
 export { SelectionManager } from "../selection";
+export type { ViewState } from "../viewState";
 
 // ── Re-exports so the rolled-up `.d.ts` stays self-contained ─────────────────
 export { NoModelerError } from "@miragon/bpmn-modeler-types";

--- a/packages/bpmn-modeler/src/design/publicApi.ts
+++ b/packages/bpmn-modeler/src/design/publicApi.ts
@@ -7,6 +7,7 @@ import type {
 } from "../publicApi";
 import type { ViewportManager } from "../viewport";
 import type { SelectionManager } from "../selection";
+import type { ViewState } from "../viewState";
 
 /**
  * The public TypeScript surface of `@miragon/bpmn-modeler/design`: an
@@ -117,6 +118,20 @@ export interface BpmnDesignerHandle {
 
     /** Selection accessor. */
     readonly selection: SelectionManager;
+
+    /**
+     * Snapshot the drill-down plane, viewbox, and selection so they survive an
+     * instance switch — capture here, `destroy()`, create the next instance,
+     * `loadDiagram`, then {@link applyViewState}. See {@link ViewState}.
+     */
+    captureViewState(): ViewState;
+
+    /**
+     * Re-apply a {@link captureViewState} snapshot: plane, viewbox, and
+     * selection are restored root → viewport → selection; a stale plane or
+     * missing element ids degrade gracefully.
+     */
+    applyViewState(state: ViewState): void;
 
     /**
      * Switch the colour theme live. Toggles this instance's `data-bpmn-theme`

--- a/packages/bpmn-modeler/src/index.ts
+++ b/packages/bpmn-modeler/src/index.ts
@@ -49,6 +49,7 @@ export type { ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
 export { ViewportManager } from "./viewport";
 export type { ViewportData } from "./viewport";
 export { SelectionManager } from "./selection";
+export type { ViewState } from "./viewState";
 
 // ── Diff view — moved to `@miragon/bpmn-modeler/viewer` (#1439) ───────────────
 // Local value+type aliases rather than `export … from`: api-extractor attaches a

--- a/packages/bpmn-modeler/src/modeler.ts
+++ b/packages/bpmn-modeler/src/modeler.ts
@@ -40,6 +40,11 @@ import { capabilityModules } from "./capabilityModules";
 import { ViewportManager } from "./viewport";
 import { SelectionManager } from "./selection";
 import { RootElementManager } from "./rootElement";
+import {
+    applyViewState as applyViewStateComposition,
+    captureViewState as captureViewStateComposition,
+    type ViewState,
+} from "./viewState";
 import { deriveEngines } from "./engines";
 import { installKeyboardFocus } from "./keyboardFocus";
 import { installCanvasFocusIndicator } from "./canvasFocusIndicator";
@@ -149,6 +154,35 @@ export class BpmnModeler {
             throw new NoModelerError();
         }
         return this._rootElement;
+    }
+
+    /**
+     * Snapshots the drill-down plane, viewbox, and selection so they survive an
+     * instance switch (View ↔ Design ↔ Implement) — capture here, `destroy()`,
+     * create the next instance, `loadDiagram`, then {@link applyViewState}. See
+     * {@link ViewState} for the plane/selection degradation rules.
+     */
+    captureViewState(): ViewState {
+        return captureViewStateComposition({
+            viewport: this.viewport,
+            rootElement: this.rootElement,
+            selection: this.selection,
+        });
+    }
+
+    /**
+     * Re-applies a {@link captureViewState} snapshot, restoring plane, viewbox,
+     * and selection in the required root → viewport → selection order.
+     */
+    applyViewState(state: ViewState): void {
+        applyViewStateComposition(
+            {
+                viewport: this.viewport,
+                rootElement: this.rootElement,
+                selection: this.selection,
+            },
+            state,
+        );
     }
 
     /**

--- a/packages/bpmn-modeler/src/publicApi.spec.ts
+++ b/packages/bpmn-modeler/src/publicApi.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import type { ModelNavigationPort } from "@miragon/bpmn-model-navigation";
 import { BpmnModeler } from "./modeler";
+import { BpmnViewer } from "./viewer/viewer";
+import { BpmnDesigner } from "./design/designer";
 import type { CreateModelerOptions } from "./createModeler";
 import type {
     BpmnModelerHandle,
@@ -14,6 +16,7 @@ import type {
     StableModelerSurface,
     ThemeMode,
 } from "./publicApi";
+import type { ViewState } from "./viewState";
 import type { BpmnViewerHandle, CoreViewerServices, ViewerOptions } from "./viewer/publicApi";
 import type { BpmnDesignerHandle, CoreDesignerServices, DesignerOptions } from "./design/publicApi";
 
@@ -37,6 +40,29 @@ const _lintModule: LintModule = { createLintModule: () => ({}) };
 // refactor reshapes one of these members, this line stops compiling.
 const _conformance = (modeler: BpmnModeler): BpmnModelerHandle => modeler;
 void _conformance;
+
+// Class→handle conformance for the viewer and designer too: a forgotten method
+// on either class (e.g. a missing captureViewState) is a compile error here
+// rather than a runtime `undefined` on the handle the factory returns.
+const _viewerConformance = (v: BpmnViewer): BpmnViewerHandle => v;
+void _viewerConformance;
+const _designerConformance = (d: BpmnDesigner): BpmnDesignerHandle => d;
+void _designerConformance;
+
+// The captured view-state shape is frozen: viewport, an optional plane id, and
+// the selection id list. A field drop/rename breaks this literal.
+const _viewState = {
+    viewport: { x: 0, y: 0, width: 100, height: 100 },
+    rootElementId: "SubProcess_1_plane",
+    selectedElementIds: ["Task_1"],
+} satisfies ViewState;
+void _viewState;
+// rootElementId is optional — a top-level-plane snapshot omits it.
+const _viewStateTopLevel = {
+    viewport: { x: 0, y: 0, width: 100, height: 100 },
+    selectedElementIds: [],
+} satisfies ViewState;
+void _viewStateTopLevel;
 
 // Structural sanity check that the frozen stable subset stays a subset of the
 // full handle as the surface grows.

--- a/packages/bpmn-modeler/src/publicApi.ts
+++ b/packages/bpmn-modeler/src/publicApi.ts
@@ -21,6 +21,7 @@ import type { LintCallbacks, LintTierInit } from "./bpmnlint/LintConfigService";
 import type { ModelerCapabilities } from "./capabilities";
 import type { ViewportManager } from "./viewport";
 import type { SelectionManager } from "./selection";
+import type { ViewState } from "./viewState";
 
 /**
  * The public TypeScript surface of the `@miragon/bpmn-modeler` package:
@@ -257,6 +258,20 @@ export interface BpmnModelerHandle {
     /** [A] Selection accessor. */
     readonly selection: SelectionManager;
 
+    /**
+     * [A] Snapshot the drill-down plane, viewbox, and selection so they survive
+     * an instance switch — capture here, `destroy()`, create the next instance,
+     * `loadDiagram`, then {@link applyViewState}. See {@link ViewState}.
+     */
+    captureViewState(): ViewState;
+
+    /**
+     * [A] Re-apply a {@link captureViewState} snapshot: plane, viewbox, and
+     * selection are restored root → viewport → selection; a stale plane or
+     * missing element ids degrade gracefully.
+     */
+    applyViewState(state: ViewState): void;
+
     /** [A] Tear the instance down and free its bpmn-js DI graph and DOM. */
     destroy(): void;
 
@@ -347,6 +362,8 @@ export type StableModelerSurface = Pick<
     | "setSettings"
     | "viewport"
     | "selection"
+    | "captureViewState"
+    | "applyViewState"
     | "destroy"
     | "getService"
     | "applyLintResults"

--- a/packages/bpmn-modeler/src/viewState.spec.ts
+++ b/packages/bpmn-modeler/src/viewState.spec.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { applyViewState, captureViewState, type ViewStateManagers } from "./viewState";
+
+/**
+ * Hand-rolled fakes for the three managers (same pattern as
+ * `rootElement.spec.ts`) — the composition is tiny, so faking is clearer than
+ * standing up real bpmn-js. `getRootElementId` defaults to a drilled-in plane;
+ * override per test for the top-level case.
+ */
+function setup() {
+    const getViewport = vi.fn().mockReturnValue({ x: 10, y: 20, width: 800, height: 600 });
+    const setViewport = vi.fn();
+    const getRootElementId = vi.fn().mockReturnValue("SubProcess_1_plane");
+    const setRootElementById = vi.fn();
+    const getSelectedElementIds = vi.fn().mockReturnValue(["Task_1", "Task_2"]);
+    const selectElementsByIds = vi.fn();
+
+    const managers = {
+        viewport: { getViewport, setViewport },
+        rootElement: { getRootElementId, setRootElementById },
+        selection: { getSelectedElementIds, selectElementsByIds },
+    } as unknown as ViewStateManagers;
+
+    return {
+        managers,
+        getViewport,
+        setViewport,
+        getRootElementId,
+        setRootElementById,
+        getSelectedElementIds,
+        selectElementsByIds,
+    };
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("captureViewState", () => {
+    it("composes the plane, viewbox, and selection into a single snapshot", () => {
+        const { managers } = setup();
+
+        expect(captureViewState(managers)).toEqual({
+            rootElementId: "SubProcess_1_plane",
+            viewport: { x: 10, y: 20, width: 800, height: 600 },
+            selectedElementIds: ["Task_1", "Task_2"],
+        });
+    });
+
+    it("captures undefined rootElementId on the top-level (implicit) plane", () => {
+        const { managers, getRootElementId } = setup();
+        getRootElementId.mockReturnValue(undefined);
+
+        expect(captureViewState(managers).rootElementId).toBeUndefined();
+    });
+});
+
+describe("applyViewState", () => {
+    it("applies root before viewport before selection", () => {
+        const { managers, setRootElementById, setViewport, selectElementsByIds } = setup();
+
+        applyViewState(managers, {
+            rootElementId: "SubProcess_1_plane",
+            viewport: { x: 0, y: 0, width: 1000, height: 800 },
+            selectedElementIds: ["Task_1"],
+        });
+
+        expect(setRootElementById).toHaveBeenCalledWith("SubProcess_1_plane");
+        expect(setViewport).toHaveBeenCalledWith({ x: 0, y: 0, width: 1000, height: 800 });
+        expect(selectElementsByIds).toHaveBeenCalledWith(["Task_1"]);
+
+        // Order is load-bearing: viewbox coordinates are plane-relative, and the
+        // drill-down centring on `root.set` must be overwritten by the viewbox.
+        const rootOrder = setRootElementById.mock.invocationCallOrder[0]!;
+        const viewportOrder = setViewport.mock.invocationCallOrder[0]!;
+        const selectionOrder = selectElementsByIds.mock.invocationCallOrder[0]!;
+        expect(rootOrder).toBeLessThan(viewportOrder);
+        expect(viewportOrder).toBeLessThan(selectionOrder);
+    });
+
+    it("passes an undefined rootElementId through (top-level plane, no switch)", () => {
+        const { managers, setRootElementById } = setup();
+
+        const snapshot = captureViewState({
+            ...managers,
+            rootElement: { getRootElementId: () => undefined } as never,
+        });
+        applyViewState(managers, snapshot);
+
+        expect(snapshot.rootElementId).toBeUndefined();
+        expect(setRootElementById).toHaveBeenCalledWith(undefined);
+    });
+});

--- a/packages/bpmn-modeler/src/viewState.ts
+++ b/packages/bpmn-modeler/src/viewState.ts
@@ -1,0 +1,65 @@
+import type { ViewportData, ViewportManager } from "./viewport";
+import type { RootElementManager } from "./rootElement";
+import type { SelectionManager } from "./selection";
+
+/**
+ * A snapshot of everything about *where the user is looking* — the drill-down
+ * plane, the viewbox, and the selection — captured from a live instance and
+ * re-applied to another after an instance switch (View ↔ Design ↔ Implement) or
+ * a destructive re-import (undo/redo host push, language switch).
+ *
+ * The point of a switch is to land the user back on the same plane, at the same
+ * viewbox and selection, on the freshly created instance. Capture on the old
+ * handle, `destroy()` it, create the new one, `loadDiagram(...)`, then apply.
+ *
+ * - `rootElementId` is the active canvas root (a collapsed sub-process
+ *   drill-down). It is `undefined` when the canvas is on the top-level process
+ *   plane: the implicit root's id is regenerated on every import, so it is never
+ *   captured and applying `undefined` leaves the canvas on the top-level plane.
+ * - `selectedElementIds` that no longer exist on apply are silently skipped, so
+ *   a snapshot taken against a since-edited diagram still degrades gracefully.
+ */
+export interface ViewState {
+    viewport: ViewportData;
+    rootElementId?: string;
+    selectedElementIds: string[];
+}
+
+/**
+ * The three managers the capture/apply composition reads and writes. Kept
+ * module-internal — consumers reach this through the composed
+ * `captureViewState` / `applyViewState` handle methods, never the managers
+ * directly.
+ */
+export interface ViewStateManagers {
+    viewport: ViewportManager;
+    rootElement: RootElementManager;
+    selection: SelectionManager;
+}
+
+/**
+ * Reads the live plane, viewbox, and selection off the managers into a plain
+ * {@link ViewState}.
+ */
+export function captureViewState(m: ViewStateManagers): ViewState {
+    return {
+        rootElementId: m.rootElement.getRootElementId(),
+        viewport: m.viewport.getViewport(),
+        selectedElementIds: m.selection.getSelectedElementIds(),
+    };
+}
+
+/**
+ * Re-applies a captured {@link ViewState}, in the one order that works:
+ * **root → viewport → selection**. Viewbox coordinates are plane-relative, so
+ * the root must switch first; and the drill-down centring handler scrolls on
+ * `root.set`, which the subsequent viewbox apply must overwrite — reversing the
+ * two would leave the canvas centred on the plane rather than at the saved
+ * viewbox. A missing root id (top-level plane) or missing element ids degrade
+ * gracefully rather than throwing.
+ */
+export function applyViewState(m: ViewStateManagers, state: ViewState): void {
+    m.rootElement.setRootElementById(state.rootElementId);
+    m.viewport.setViewport(state.viewport);
+    m.selection.selectElementsByIds(state.selectedElementIds);
+}

--- a/packages/bpmn-modeler/src/viewer/index.ts
+++ b/packages/bpmn-modeler/src/viewer/index.ts
@@ -28,6 +28,7 @@ export type { ThemeMode } from "../publicApi";
 export { ViewportManager } from "../viewport";
 export type { ViewportData } from "../viewport";
 export { SelectionManager } from "../selection";
+export type { ViewState } from "../viewState";
 
 // ── Diff view — public rendering primitives + in-page coordinator ────────────
 // The data layer (`computeDiff`/`sideView`) is the Node-safe

--- a/packages/bpmn-modeler/src/viewer/publicApi.ts
+++ b/packages/bpmn-modeler/src/viewer/publicApi.ts
@@ -2,6 +2,7 @@ import type { ImportXMLResult } from "bpmn-js/lib/BaseViewer";
 import type { CoreModelerServices, ThemeMode } from "../publicApi";
 import type { ViewportManager } from "../viewport";
 import type { SelectionManager } from "../selection";
+import type { ViewState } from "../viewState";
 
 /**
  * The public TypeScript surface of `@miragon/bpmn-modeler/viewer`: the readonly
@@ -77,6 +78,20 @@ export interface BpmnViewerHandle {
 
     /** Selection accessor — the viewer's base modules ship visible selection. */
     readonly selection: SelectionManager;
+
+    /**
+     * Snapshot the drill-down plane, viewbox, and selection so they survive an
+     * instance switch — capture here, `destroy()`, create the next instance,
+     * `loadDiagram`, then {@link applyViewState}. See {@link ViewState}.
+     */
+    captureViewState(): ViewState;
+
+    /**
+     * Re-apply a {@link captureViewState} snapshot: plane, viewbox, and
+     * selection are restored root → viewport → selection; a stale plane or
+     * missing element ids degrade gracefully.
+     */
+    applyViewState(state: ViewState): void;
 
     /**
      * Switch the colour theme live. Toggles this instance's `data-bpmn-theme`

--- a/packages/bpmn-modeler/src/viewer/viewer.ts
+++ b/packages/bpmn-modeler/src/viewer/viewer.ts
@@ -5,6 +5,12 @@ import { NoModelerError, observeCanvasSize } from "@miragon/bpmn-modeler-types";
 import { ThemeController } from "../theme";
 import { ViewportManager } from "../viewport";
 import { SelectionManager } from "../selection";
+import { RootElementManager } from "../rootElement";
+import {
+    applyViewState as applyViewStateComposition,
+    captureViewState as captureViewStateComposition,
+    type ViewState,
+} from "../viewState";
 import type { ThemeMode } from "../publicApi";
 import type { CoreViewerServices, ViewerOptions } from "./publicApi";
 
@@ -29,6 +35,11 @@ export class BpmnViewer {
     private _viewport: ViewportManager | undefined;
 
     private _selection: SelectionManager | undefined;
+
+    // Drill-down plane tracking, composed into captureViewState/applyViewState.
+    // Kept private (no public handle getter) — the viewer exposes only the
+    // composed view-state methods.
+    private _rootElement: RootElementManager | undefined;
 
     // Per-instance theme controller, created lazily on the first setTheme.
     private themeController?: ThemeController;
@@ -62,6 +73,38 @@ export class BpmnViewer {
     }
 
     /**
+     * Snapshots the drill-down plane, viewbox, and selection so they survive an
+     * instance switch (View ↔ Design ↔ Implement) — capture here, `destroy()`,
+     * create the next instance, `loadDiagram`, then {@link applyViewState}. See
+     * {@link ViewState} for the plane/selection degradation rules.
+     */
+    captureViewState(): ViewState {
+        return captureViewStateComposition(this.viewStateManagers());
+    }
+
+    /**
+     * Re-applies a {@link captureViewState} snapshot, restoring plane, viewbox,
+     * and selection in the required root → viewport → selection order.
+     */
+    applyViewState(state: ViewState): void {
+        applyViewStateComposition(this.viewStateManagers(), state);
+    }
+
+    /**
+     * The three managers backing view-state capture/apply. Reading `viewport`
+     * throws {@link NoModelerError} before {@link init}; the root manager is
+     * created and cleared in lockstep with it, so the assertion never fires
+     * after that guard passes.
+     */
+    private viewStateManagers() {
+        return {
+            viewport: this.viewport,
+            selection: this.selection,
+            rootElement: this._rootElement!,
+        };
+    }
+
+    /**
      * Creates and mounts the bpmn-js viewer, then wires the viewport/selection
      * managers. Async for API-stability symmetry with {@link BpmnModeler.init}.
      *
@@ -83,6 +126,7 @@ export class BpmnViewer {
         const accessor = <T>(name: string): T => this.getViewer().get<T>(name);
         this._viewport = new ViewportManager(accessor);
         this._selection = new SelectionManager(accessor);
+        this._rootElement = new RootElementManager(accessor);
     }
 
     async loadDiagram(xml: string): Promise<ImportXMLResult> {
@@ -159,6 +203,7 @@ export class BpmnViewer {
         this.viewer = undefined;
         this._viewport = undefined;
         this._selection = undefined;
+        this._rootElement = undefined;
     }
 
     /**


### PR DESCRIPTION
## Issue

Closes #1440

## Description

Exposes `captureViewState()` / `applyViewState()` and a frozen `ViewState` type (`viewport`, `rootElementId?`, `selectedElementIds`) on all three handles — `BpmnModelerHandle`, `BpmnViewerHandle`, `BpmnDesignerHandle` — so the drill-down plane, viewbox, and selection survive an instance switch (View ↔ Design ↔ Implement, foundation for #1438). The composition lives once in `viewState.ts` (root → viewport → selection order, implicit `__implicitroot*` roots never captured, stale ids degrade gracefully), while `RootElementManager` stays `@internal`; the viewer and designer now instantiate it privately. The webview's `WebviewStateManager` delegates to the handle instead of composing the managers itself, and `CanvasViewState` becomes an alias of the public `ViewState` — `reloadXmlPreservingView` behaviour is unchanged. `publicApi.spec.ts` gains class→handle conformance checks for viewer/designer plus `ViewState` subset assertions; decision recorded in ADR 0017.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [ ] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
