### PR TITLE
feat(bpmn-modeler): add opt-in readonly properties panel on /viewer

### DIFF
--- a/apps/demo-webapp/bpmn/viewer.html
+++ b/apps/demo-webapp/bpmn/viewer.html
@@ -9,20 +9,35 @@
             body {
                 margin: 0;
             }
-            /* A single readonly canvas — no palette, no properties panel. #app is
-               sized by the shared demo header (viewport minus header + footer). */
+            /* A readonly canvas beside a readonly properties panel — no palette,
+               no editing. #app is sized by the shared demo header (viewport minus
+               header + footer). */
             .viewer {
                 position: relative;
+                display: flex;
                 height: 100%;
             }
             .viewer .canvas {
-                position: absolute;
-                inset: 0;
+                position: relative;
+                flex: 1;
+                min-width: 0;
+            }
+            .viewer .properties {
+                width: 320px;
+                flex: none;
+                border-left: 1px solid #d7d9de;
+                overflow: auto;
+                background: #fff;
+            }
+            :root[data-bpmn-theme="dark"] .viewer .properties {
+                border-left-color: #3a3a3a;
+                background: #1d1d1d;
             }
             .viewer .toolbar {
                 position: absolute;
                 top: 12px;
-                right: 12px;
+                /* clear the 320px properties panel */
+                right: 332px;
                 z-index: 10;
                 display: flex;
                 gap: 10px;
@@ -52,6 +67,7 @@
         <div id="app" style="height: 100vh">
             <div class="viewer">
                 <div class="canvas" id="canvas"></div>
+                <div class="properties" id="properties"></div>
                 <div class="toolbar">
                     <span class="selection" id="selection">Nothing selected</span>
                 </div>

--- a/apps/demo-webapp/bpmn/viewer.ts
+++ b/apps/demo-webapp/bpmn/viewer.ts
@@ -7,8 +7,9 @@ import { MODELS } from "../src/registry";
 // separate from the modeler's `styles.css`. A JS import lets Vite process it (and
 // its node_modules `@import`s) in dev and build — a raw `<link>` to the package
 // source escapes the dev-server root and 404s. This is the epic's regression
-// check: the viewer page must render, select, hover, zoom/pan, and switch themes
-// with no editing affordance (no palette, context pad, or keyboard delete).
+// check: the viewer page must render, select, hover, zoom/pan, switch themes,
+// and show a readonly properties panel (every entry disabled) with no editing
+// affordance (no palette, context pad, or keyboard delete).
 import "../../../packages/bpmn-modeler/src/styles/viewer.css";
 
 /**
@@ -29,14 +30,18 @@ async function main(): Promise<void> {
     );
 
     const canvas = document.getElementById("canvas");
+    const properties = document.getElementById("properties");
     const selectionOut = document.getElementById("selection");
-    if (!canvas || !selectionOut) {
+    if (!canvas || !properties || !selectionOut) {
         throw new Error("viewer demo: missing host elements");
     }
 
     const model = MODELS.find((m) => m.type === "bpmn") ?? MODELS[0];
 
-    const viewer = await createViewer(canvas, { theme: themeMode as ThemeMode });
+    const viewer = await createViewer(canvas, {
+        theme: themeMode as ThemeMode,
+        propertiesPanel: { parent: properties },
+    });
     viewerRef.current = viewer;
     await viewer.loadDiagram(model.xml);
 

--- a/docs/adr/0014-readonly-viewer-subpath.md
+++ b/docs/adr/0014-readonly-viewer-subpath.md
@@ -140,3 +140,34 @@ called for `check-viewer-pure-entry.mjs` to still pass (maintainer decision,
 Peter). The neutral diff markers + legend CSS move into `src/styles/diffView.css`,
 shared by `viewer.css` (so `/viewer` diff consumers get a themed legend) and
 `diff.css` (so `styles.css`/bpmn-webview consumers see no change).
+
+## Amendment (#1443, 2026-09-04)
+
+`ViewerOptions` gains an **optional `propertiesPanel: { parent }`** — unlike on
+the modeler/design surfaces, where the panel is mandatory. When set, the viewer
+registers the engine-neutral panel's full design-parity module set
+(`PropertiesPanelModule` + `NeutralPropertiesProviderModule` +
+`ModeFilterModule` + `CustomGroupsModule`, ADR 0017) and passes
+`feelPopupContainer: container`; `setTheme` then scopes both the container and
+the panel parent. When omitted, none of the panel modules enter the DI graph —
+byte-identical to before.
+
+- **Readonly is derived, not configured.** The viewer still registers no
+  `modeling` / `commandStack`; the panel renderer derives its readonly flag from
+  the absent `modeling` service and disables every entry. The readonly-by-
+  construction guarantee (and its runtime proof in `createViewer.spec.ts`) is
+  unchanged *with the panel registered*.
+- **`@bpmn-io/properties-panel` / preact / CodeMirror enter the `/viewer`
+  closure** (they stay Vite externals, so tree-shaking hosts that skip the
+  option still drop them where their bundler can). This continues the
+  surface-accretion trajectory the #1439 amendment anticipated ("a preact-based
+  readonly panel is planned in #1443"); the purity gate stays retired, replaced
+  by a narrow `architecture.spec.ts` rule: `src/viewer/**` must deep-import the
+  panel lib, never its barrel.
+- **The viewer entry still imports no CSS** (load-bearing for
+  `cssCodeSplit: false`): the panel modules are deep-imported past the lib
+  barrel's CSS side-effect import. `viewer.css` gains the panel sheets
+  (`properties-panel.css` + the dark-theme overrides) instead.
+- **`locale` / `TranslateModule` remain omitted** — diagram-js's identity
+  `translate` satisfies the renderer (English labels); hosts can add the
+  translate module via `additionalModules`.

--- a/libs/properties-panel/src/provider/utils/ValidationUtil.ts
+++ b/libs/properties-panel/src/provider/utils/ValidationUtil.ts
@@ -1,6 +1,8 @@
 /**
  * Forked from bpmn-js-properties-panel v5.65.0 (MIT). See LICENSE-upstream.
- * Verbatim: BPMN id validation used by the neutral id / process-id entries.
+ * Neutral-mode delta: the id-uniqueness check tolerates a missing `$model.ids`
+ * registry — bpmn-js only creates it on modelers (`BaseModeler#_createModdle`),
+ * so on a readonly `NavigatedViewer` the entry must still render.
  */
 const SPACE_REGEX = /\s/;
 
@@ -15,7 +17,7 @@ export function isIdValid(
     idValue: string,
     translate: (template: string) => string,
 ): string | undefined {
-    const assigned = element.$model.ids.assigned(idValue);
+    const assigned = element.$model.ids?.assigned(idValue);
     const idAlreadyExists = assigned && assigned !== element;
 
     if (!idValue) {

--- a/libs/properties-panel/src/provider/utils/validationUtil.spec.ts
+++ b/libs/properties-panel/src/provider/utils/validationUtil.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isIdValid } from "./ValidationUtil";
+
+const translate = (template: string) => template;
+
+describe("isIdValid", () => {
+    it("tolerates a missing $model.ids registry (readonly viewer, #1443)", () => {
+        // bpmn-js creates `moddle.ids` only on modelers; on a NavigatedViewer
+        // the uniqueness check must degrade instead of crashing the entry.
+        expect(isIdValid({ $model: {} }, "task_1", translate)).toBeUndefined();
+    });
+
+    it("still reports duplicates through an existing registry", () => {
+        const element = { $model: { ids: { assigned: () => ({}) } } };
+        expect(isIdValid(element, "task_1", translate)).toBe("ID must be unique.");
+    });
+
+    it("still rejects empty and malformed ids", () => {
+        const element = { $model: {} };
+        expect(isIdValid(element, "", translate)).toBe("ID must not be empty.");
+        expect(isIdValid(element, "has space", translate)).toBe("ID must not contain spaces.");
+    });
+});

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -423,17 +423,21 @@ modeler.getService<{ registerGroups(ids: readonly string[]): void }>(
 ```
 
 Neutral BPMN groups survive automatically; only host-added groups need marking.
+The same `customPropertiesGroups` registry is available on the [design](#design-mode)
+surface and on the [viewer](#viewer)'s opt-in readonly panel.
 
 ## Viewer
 
 `@miragon/bpmn-modeler/viewer` is a **readonly** surface for view-only
 permissions and embedded previews. It wraps bpmn-js's `NavigatedViewer` (mouse +
-keyboard pan/zoom) plus the selection outline, and also carries the browser-only
+keyboard pan/zoom) plus the selection outline, an opt-in **readonly**
+engine-neutral properties panel (#1443), and the browser-only
 [diff rendering primitives](#diff) (`DiffViewer`, `DiffLegend`, `DiffNavigator`,
-`DiffPaneCoordinator`). The Camunda editor stack (camunda-bpmn-js, properties
-panel, CodeMirror, token simulation, lint) stays out of its module graph, so it
-survives single-file bundlers that inline everything reachable. The `DiffLegend`
-does pull the shared i18n translator in for its labels (#1439).
+`DiffPaneCoordinator`). The Camunda editor stack (camunda-bpmn-js, CodeMirror,
+token simulation, lint) stays out of its module graph, so it survives
+single-file bundlers that inline everything reachable. The `DiffLegend` does
+pull the shared i18n translator in for its labels (#1439), and opting into the
+panel pulls in `@bpmn-io/properties-panel`/preact.
 
 ```ts
 import { createViewer } from "@miragon/bpmn-modeler/viewer";
@@ -452,6 +456,7 @@ viewer.selection.onSelectionChanged((ids) => console.log("selected", ids));
 | Field | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `theme` | `"light" \| "dark" \| "automatic"` | `"automatic"` | Colour theme; toggles a per-instance `data-bpmn-theme` attribute (same mechanism as the modeler). |
+| `propertiesPanel` | `{ parent: HTMLElement }` | — | Opt-in **readonly** properties panel: the engine-neutral panel renders into `parent` with every entry disabled (the viewer registers no `modeling` service). Omitted ⇒ no panel modules load, no DOM added. |
 | `moddleExtensions` | `Record<string, object>` | — | Extra moddle extensions for a host's own BPMN namespace. |
 | `additionalModules` | `unknown[]` | — | Escape hatch: extra render-only bpmn-js DI modules. |
 
@@ -470,26 +475,30 @@ capabilities, or events.
 `getService` is typed against `CoreViewerServices` — the readonly `Pick` of the
 [core services](#core-services--escape-hatch): `canvas`, `elementRegistry`,
 `eventBus`, `overlays`, `selection`. The editing services (`modeling`,
-`commandStack`) are **not registered** on a viewer, so resolving one throws —
-the surface is readonly by construction, not by convention.
+`commandStack`) are **not registered** on a viewer — even with the properties
+panel registered — so resolving one throws: the surface is readonly by
+construction, not by convention.
 
 ### Kept out of the module graph
 
-`camunda-bpmn-js`, `bpmn-js-properties-panel`, `@bpmn-io/properties-panel`,
-`preact`, `codemirror` / `@codemirror/*`, `bpmnlint` / `bpmn-js-bpmnlint`,
-`bpmn-js-token-simulation`, `bpmn-js-create-append-anything`,
-`camunda-transaction-boundaries`, and `minisearch` — the full Camunda editor
-stack. The shared i18n translator (`@miragon/bpmn-modeler-i18n`) **is** now
-present, pulled in by `DiffLegend` for its labels (#1439). The dedicated
-build-time purity gate was retired in #1439 as the surface grows custom features;
-the viewer still imports **no CSS** and `check:dts` still guards the dist surface.
+`camunda-bpmn-js`, `codemirror` / `@codemirror/*`, `bpmnlint` /
+`bpmn-js-bpmnlint`, `bpmn-js-token-simulation`,
+`bpmn-js-create-append-anything`, `camunda-transaction-boundaries`, and
+`minisearch` — the Camunda editor stack. The shared i18n translator
+(`@miragon/bpmn-modeler-i18n`) **is** present, pulled in by `DiffLegend` for its
+labels (#1439), and the engine-neutral panel fork (with
+`@bpmn-io/properties-panel`/preact) enters the closure for the opt-in readonly
+panel (#1443). The dedicated build-time purity gate was retired in #1439 as the
+surface grows custom features; the viewer still imports **no CSS** and
+`check:dts` still guards the dist surface.
 
 ### Theming & stylesheet
 
 Load **`@miragon/bpmn-modeler/viewer.css`**, not `styles.css`: the viewer sheet
-carries the bpmn-js base diagram/font CSS, the dark-theme diagram overrides, and
-the neutral diff markers + legend chip (so a diff consumer needs no other sheet) —
-none of the editor chrome. The two overlap, so do **not** load both on a
+carries the bpmn-js base diagram/font CSS, the dark-theme diagram overrides,
+the neutral diff markers + legend chip (so a diff consumer needs no other
+sheet), and the properties-panel chrome for the opt-in readonly panel — none of
+the Camunda editor chrome. The two overlap, so do **not** load both on a
 viewer-only page.
 
 ## Design mode
@@ -509,7 +518,7 @@ Three surfaces close the feature matrix:
 | --- | --- | --- | --- | --- |
 | Modeler | `@miragon/bpmn-modeler` | yes | Camunda 7 / 8 | engine-bound |
 | Design | `@miragon/bpmn-modeler/design` | yes | none | plain BPMN |
-| Viewer | `@miragon/bpmn-modeler/viewer` | no | — | none |
+| Viewer | `@miragon/bpmn-modeler/viewer` | no | — | neutral, readonly (opt-in) |
 
 ### Mode-marker semantics
 

--- a/packages/bpmn-modeler/src/architecture.spec.ts
+++ b/packages/bpmn-modeler/src/architecture.spec.ts
@@ -217,6 +217,31 @@ describe("bpmn-modeler import direction", () => {
         ).toEqual([]);
     });
 
+    it("the /viewer subpath deep-imports the neutral panel, never its barrel (#1443)", () => {
+        // The lib barrel (`libs/properties-panel/src/index.ts`) side-effect
+        // imports its CSS, and the viewer entry must import no CSS —
+        // `cssCodeSplit: false` on the lib build would fold any reachable sheet
+        // into the shared `dist/bpmn-modeler.css`. The panel sheets ship via
+        // `dist/viewer.css` instead; deep (file-level) imports stay fine.
+        const VIEWER_DIR = join(PKG_SRC, "viewer");
+        const BARREL = "@miragon/bpmn-modeler-properties-panel";
+        const offenders: string[] = [];
+        for (const file of listSourceFiles(PKG_SRC)) {
+            if (!file.startsWith(VIEWER_DIR)) continue;
+            for (const spec of valueImportedModules(readFileSync(file, "utf8"))) {
+                if (spec === BARREL) {
+                    offenders.push(`${file.slice(PKG_SRC.length + 1)} → ${spec}`);
+                }
+            }
+        }
+        expect(
+            offenders,
+            `the /viewer subpath must deep-import ` +
+                `@miragon/bpmn-modeler-properties-panel/* (the barrel imports ` +
+                `CSS, and the viewer entry must stay CSS-free):\n${offenders.join("\n")}`,
+        ).toEqual([]);
+    });
+
     it("the /design and /viewer subpaths never reach the runtime-mode code (#1442)", () => {
         // Design/implement mode is a runtime toggle on the engine-tagged
         // `createModeler` instance only. The `/design` and `/viewer` subpaths are

--- a/packages/bpmn-modeler/src/publicApi.spec.ts
+++ b/packages/bpmn-modeler/src/publicApi.spec.ts
@@ -313,9 +313,11 @@ type _ViewerServicesAreModelerSubset = keyof CoreViewerServices extends keyof Co
 const _viewerServicesSubset: _ViewerServicesAreModelerSubset = true;
 void _viewerServicesSubset;
 
-// ViewerOptions is minimal: no engine, no editor-only built-ins.
+// ViewerOptions is minimal: no engine, no editor-only built-ins, and an
+// optional (readonly) properties panel.
 const _viewerOptions = {
     theme: "dark",
+    propertiesPanel: { parent: document.createElement("div") },
     moddleExtensions: {
         bpmiq: { name: "bpmiq", uri: "http://bpmiq/schema", prefix: "bpmiq", types: [] },
     },

--- a/packages/bpmn-modeler/src/styles/viewer.css
+++ b/packages/bpmn-modeler/src/styles/viewer.css
@@ -2,14 +2,17 @@
  * The readonly viewer's stylesheet, built standalone as
  * `@miragon/bpmn-modeler/viewer.css` (see `vite.viewer-css.config.mts`). It
  * carries the bpmn-js base diagram/font CSS, the dark-theme diagram overrides
- * scoped under `[data-bpmn-theme="dark"]`, and the neutral diff-view markers +
- * legend chip (`diffView.css`, #1439) so a `/viewer` diff consumer needs no
- * other sheet — none of the editor chrome (camunda-bpmn-js, properties-panel,
- * token-simulation) the full `styles.css` loads. Do not also load `styles.css`
- * on a viewer-only page; the two overlap.
+ * scoped under `[data-bpmn-theme="dark"]`, the neutral diff-view markers +
+ * legend chip (`diffView.css`, #1439), and the engine-neutral properties-panel
+ * chrome (readonly opt-in, #1443) so a `/viewer` consumer needs no other sheet
+ * — none of the Camunda editor chrome (camunda-bpmn-js, token-simulation) the
+ * full `styles.css` loads. Do not also load `styles.css` on a viewer-only
+ * page; the two overlap.
  */
 @import "bpmn-js/dist/assets/diagram-js.css";
 @import "bpmn-js/dist/assets/bpmn-js.css";
 @import "bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css";
+@import "../../../../libs/properties-panel/src/properties-panel.css";
 @import "./dark-theme/diagram-js.css";
+@import "./dark-theme/properties-panel.css";
 @import "./diffView.css";

--- a/packages/bpmn-modeler/src/viewer/createViewer.spec.ts
+++ b/packages/bpmn-modeler/src/viewer/createViewer.spec.ts
@@ -114,6 +114,73 @@ describe("createViewer (runtime, jsdom)", () => {
         expect(() => viewer!.getService("canvas")).toThrow(NoModelerError);
     });
 
+    describe("readonly properties panel (opt-in, #1443)", () => {
+        // Entry-level readonly behaviour (every input disabled, no add/remove
+        // affordances) is proven in the lib's own specs
+        // (`propertiesPanelRenderer.spec.tsx`, `applyReadonly.spec.ts`); the AC
+        // "interact with every entry, export unchanged" needs a rendered panel
+        // body and thus `importXML` — the jsdom SVG wall above. The demo page
+        // (`viewer.html`) is the manual/browser proof for that path.
+        let parent: HTMLElement;
+
+        afterEach(() => {
+            parent.remove();
+        });
+
+        it("mounts the panel and keeps modeling/commandStack unregistered", async () => {
+            container = mount();
+            parent = mount();
+            viewer = await createViewer(container, { propertiesPanel: { parent } });
+
+            // The renderer attaches on `diagram.init`, no importXML needed.
+            expect(parent.querySelector(".bio-properties-panel-container")).not.toBeNull();
+            expect(viewer.getService("propertiesPanel")).toBeDefined();
+
+            // The load-bearing readonly proof: registering the panel must not
+            // drag any editing service into the DI graph.
+            expect(() => viewer!.getService("modeling")).toThrow();
+            expect(() => viewer!.getService("commandStack")).toThrow();
+        });
+
+        it("exposes the host custom-group slot", async () => {
+            container = mount();
+            parent = mount();
+            viewer = await createViewer(container, { propertiesPanel: { parent } });
+
+            const registry = viewer.getService<{
+                registerGroups(ids: readonly string[]): void;
+                has(id: string): boolean;
+            }>("customPropertiesGroups");
+            registry.registerGroups(["myCustomGroup"]);
+            expect(registry.has("myCustomGroup")).toBe(true);
+        });
+
+        it("themes the panel parent alongside the container", async () => {
+            container = mount();
+            parent = mount();
+            viewer = await createViewer(container, {
+                theme: "light",
+                propertiesPanel: { parent },
+            });
+
+            expect(container.getAttribute("data-bpmn-theme")).toBe("light");
+            expect(parent.getAttribute("data-bpmn-theme")).toBe("light");
+
+            viewer.setTheme("dark");
+            expect(container.getAttribute("data-bpmn-theme")).toBe("dark");
+            expect(parent.getAttribute("data-bpmn-theme")).toBe("dark");
+        });
+
+        it("stays inert when the option is omitted", async () => {
+            container = mount();
+            parent = mount();
+            viewer = await createViewer(container);
+
+            expect(document.querySelector(".bio-properties-panel-container")).toBeNull();
+            expect(() => viewer!.getService("propertiesPanel")).toThrow();
+        });
+    });
+
     // Render-dependent: jsdom has no SVG layout, so bpmn-js's viewbox transform
     // throws on import. Covered manually via the demo page + Playwright.
     it.skip("loads a diagram, selects an element, and round-trips XML/SVG", async () => {

--- a/packages/bpmn-modeler/src/viewer/index.ts
+++ b/packages/bpmn-modeler/src/viewer/index.ts
@@ -2,10 +2,12 @@
  * `@miragon/bpmn-modeler/viewer` — the host-free, readonly BPMN viewer subpath.
  *
  * A view-only surface: it wraps bpmn-js's NavigatedViewer + outline and drags
- * none of the editing stack (camunda-bpmn-js, properties-panel/preact,
- * CodeMirror, token simulation, lint) into the module graph. It does carry the
- * browser-only diff rendering primitives and, through `DiffLegend`, the shared
- * i18n translator (#1439). See ADR 0014 and its #1439 amendment.
+ * none of the Camunda editing stack (camunda-bpmn-js, CodeMirror, token
+ * simulation, lint) into the module graph. It does carry the browser-only diff
+ * rendering primitives, the shared i18n translator via `DiffLegend` (#1439),
+ * and — when a consumer opts in via `propertiesPanel` — the engine-neutral
+ * readonly panel (preact via `@bpmn-io/properties-panel`, #1443). See ADR 0014
+ * and its amendments.
  *
  * Deliberately imports **no CSS**: `cssCodeSplit: false` on the lib build would
  * fold any stylesheet reachable from here into the shared `dist/bpmn-modeler.css`

--- a/packages/bpmn-modeler/src/viewer/publicApi.ts
+++ b/packages/bpmn-modeler/src/viewer/publicApi.ts
@@ -19,8 +19,8 @@ import type { ViewState } from "../viewState";
  * Every handle member below is signature-identical to its {@link
  * BpmnModelerHandle} counterpart (subset compatibility is asserted in
  * `publicApi.spec.ts`), so a host can narrow a modeler handle to a viewer handle
- * without adapters. There is no `engine`, `propertiesPanel`, `linting`,
- * `clipboard`, `capabilities`, events, or `locale`.
+ * without adapters. There is no `engine`, `linting`, `clipboard`,
+ * `capabilities`, events, or `locale`.
  */
 
 /**
@@ -36,10 +36,19 @@ export type CoreViewerServices = Pick<
 
 /**
  * Per-instance configuration for {@link createViewer}. Deliberately minimal: a
- * viewer has no engine (bpmn-js's base viewer reads any BPMN), no properties
- * panel, and no host capabilities.
+ * viewer has no engine (bpmn-js's base viewer reads any BPMN), no host
+ * capabilities, and only an opt-in readonly properties panel.
  */
 export interface ViewerOptions {
+    /**
+     * Opt-in readonly properties panel — optional, unlike on the modeler/design
+     * surfaces. When given, the engine-neutral panel renders into `parent` with
+     * every entry disabled: the viewer registers no `modeling` service, the
+     * exact marker the renderer derives readonly from. When omitted, none of
+     * the panel modules enter the DI graph and no DOM is added.
+     */
+    propertiesPanel?: { parent: HTMLElement };
+
     /**
      * Colour theme — defaults to `"automatic"`. Theming always engages: the
      * instance gets a `data-bpmn-theme` attribute from the first frame.

--- a/packages/bpmn-modeler/src/viewer/viewer.ts
+++ b/packages/bpmn-modeler/src/viewer/viewer.ts
@@ -1,6 +1,14 @@
 import NavigatedViewer from "bpmn-js/lib/NavigatedViewer";
 import OutlineModule from "bpmn-js/lib/features/outline";
 import { ImportXMLError, ImportXMLResult, SaveXMLResult } from "bpmn-js/lib/BaseViewer";
+// Deep imports on purpose: the lib barrel side-effect-imports its CSS, and the
+// viewer entry must stay CSS-free (`cssCodeSplit: false` would fold any
+// reachable sheet into the shared `dist/bpmn-modeler.css`). Gated by
+// `architecture.spec.ts`; the panel sheets ship via `viewer.css` instead.
+import PropertiesPanelModule from "@miragon/bpmn-modeler-properties-panel/render/index";
+import NeutralPropertiesProviderModule from "@miragon/bpmn-modeler-properties-panel/provider/index";
+import { ModeFilterModule } from "@miragon/bpmn-modeler-properties-panel/modeFilter/ModeFilterProvider";
+import { CustomGroupsModule } from "@miragon/bpmn-modeler-properties-panel/customGroups/CustomGroupsRegistry";
 import { NoModelerError, observeCanvasSize } from "@miragon/bpmn-modeler-types";
 import { ThemeController } from "../theme";
 import { ViewportManager } from "../viewport";
@@ -23,6 +31,11 @@ import type { CoreViewerServices, ViewerOptions } from "./publicApi";
  * *visible* selection/hover. Viewport and selection concerns delegate to the
  * shared {@link ViewportManager} / {@link SelectionManager}, so the same
  * `ServiceAccessor`-based managers back both the modeler and the viewer.
+ *
+ * With `options.propertiesPanel` set, the engine-neutral properties panel
+ * (`@miragon/bpmn-modeler-properties-panel`) mounts readonly: the renderer
+ * derives readonly from the absent `modeling` service and disables every entry.
+ * Without the option, none of the panel modules enter the DI graph.
  *
  * Per-instance by construction: bound to its own `container`, so several viewers
  * (or a viewer beside a modeler) can coexist on a page. Use {@link createViewer}
@@ -112,13 +125,35 @@ export class BpmnViewer {
      *   the public handle.
      */
     async init(): Promise<void> {
+        const panel = this.options.propertiesPanel;
         this.viewer = new NavigatedViewer({
             container: this.container,
             moddleExtensions: this.options.moddleExtensions,
+            ...(panel && {
+                propertiesPanel: {
+                    parent: panel.parent,
+                    // Mount the FEEL popup (an unconditional panel dependency)
+                    // inside the instance container — it defaults to
+                    // document.body, outside this instance's theme scope.
+                    feelPopupContainer: this.container,
+                },
+            }),
             // Outline is Modeler-only upstream; it is the single addition that
             // makes selection/hover visible on the otherwise chrome-free viewer.
             additionalModules: [
                 OutlineModule,
+                // The full design-parity panel set: renderer + neutral provider
+                // + mode filter (identity here, no engine provider to reduce) +
+                // the host custom-group slot. The renderer attaches on
+                // `diagram.init` and renders readonly (no `modeling` service).
+                ...(panel
+                    ? [
+                          PropertiesPanelModule,
+                          NeutralPropertiesProviderModule,
+                          ModeFilterModule,
+                          CustomGroupsModule,
+                      ]
+                    : []),
                 ...((this.options.additionalModules as any[]) ?? []),
             ],
         });
@@ -174,7 +209,10 @@ export class BpmnViewer {
      */
     setTheme(theme: ThemeMode): void {
         if (!this.themeController) {
-            this.themeController = new ThemeController([this.container]);
+            const panel = this.options.propertiesPanel;
+            this.themeController = new ThemeController(
+                panel ? [this.container, panel.parent] : [this.container],
+            );
         }
         this.themeController.setMode(theme);
     }

--- a/packages/bpmn-modeler/vitest.config.ts
+++ b/packages/bpmn-modeler/vitest.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from "vitest/config";
 import { resolve } from "node:path";
 
 export default defineConfig({
+    // The neutral panel's forked `.tsx` files carry a per-file `@jsxImportSource
+    // @bpmn-io/properties-panel/preact` pragma; that package ships no
+    // `jsx-dev-runtime`, so force the production runtime (mirrors
+    // libs/properties-panel/vitest.config.ts).
+    oxc: { jsx: { development: false } },
     test: {
         name: "bpmn-modeler",
         environment: "jsdom",
@@ -34,6 +39,12 @@ export default defineConfig({
             "@miragon/bpmn-modeler-clipboard": resolve(
                 __dirname,
                 "../../libs/bpmn-clipboard/src/index.ts",
+            ),
+            // Directory (not index.ts) so the viewer's deep imports
+            // (`.../render/index` etc.) resolve through the same alias.
+            "@miragon/bpmn-modeler-properties-panel": resolve(
+                __dirname,
+                "../../libs/properties-panel/src",
             ),
         },
         coverage: {


### PR DESCRIPTION
## Issue

Closes #1443

## Description

`ViewerOptions` gains an optional `propertiesPanel: { parent }` that registers the engine-neutral panel (renderer + neutral provider + mode filter + custom-group slot, #1451) on the `NavigatedViewer`; readonly is derived, not configured — the viewer still registers no `modeling`/`commandStack`, so every entry renders disabled and `getService("modeling")` keeps throwing. The panel lib is deep-imported past its CSS-importing barrel (new `architecture.spec.ts` guard) so the viewer entry stays CSS-free, while `viewer.css` gains the panel + dark-theme sheets; `setTheme` scopes both the canvas and the panel parent. The lib's `isIdValid` now tolerates the missing `$model.ids` registry on viewers (bpmn-js only creates it on modelers), and the demo viewer page mounts the panel as the browser proof. Amends [ADR 0014](docs/adr/0014-readonly-viewer-subpath.md); the retired purity gate is not reintroduced (#1449).

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [ ] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
