### PR TITLE
feat(bpmn-modeler): add capabilities.modelNavigation on /design

### DIFF
--- a/apps/demo-webapp/bpmn/design.ts
+++ b/apps/demo-webapp/bpmn/design.ts
@@ -1,6 +1,6 @@
 import { createDesigner } from "@miragon/bpmn-modeler/design";
 import type { ThemeMode } from "@miragon/bpmn-modeler/design";
-import { mountDemoHeader } from "../src";
+import { mountDemoHeader, modelHref, resolveReference } from "../src";
 import { MODELS } from "../src/registry";
 
 // The design surface ships its own lean stylesheet
@@ -36,6 +36,23 @@ async function main(): Promise<void> {
     const designer = await createDesigner(canvas, {
         propertiesPanel: { parent: panel },
         theme: themeMode as ThemeMode,
+        // The one engine-neutral host capability on /design (#1444): a Call
+        // Activity / Business Rule Task / linked form gets a "Navigate to
+        // referenced model" context-pad entry. Omitting `capabilities` renders no
+        // entry. C8-shaped references need `moddleExtensions: { zeebe }` to parse.
+        capabilities: {
+            modelNavigation: {
+                openReference: ({ id, kind }) => {
+                    if (kind === "form") {
+                        return;
+                    }
+                    const target = resolveReference(id, kind);
+                    if (target) {
+                        window.location.href = modelHref(target);
+                    }
+                },
+            },
+        },
     });
     designerRef.current = designer;
     await designer.loadDiagram(model.xml);

--- a/docs/adr/0016-design-mode-subpath.md
+++ b/docs/adr/0016-design-mode-subpath.md
@@ -83,6 +83,17 @@ Ship a **new subpath `@miragon/bpmn-modeler/design`** exporting an async
     new direct dependency, `diagram-js-minimap` (already transitively present via
     camunda-bpmn-js), which the purity gate does not forbid; it ships collapsed
     (`minimap: { open: false }`) with its dark-theme sheet already scoped.
+- **No host capabilities.** `DesignerOptions` carried none of the
+  `ModelerCapabilities` ports in v1. **Amended (#1444):** the foreseen additive
+  step landed — `DesignerOptions.capabilities` now accepts a narrower
+  `DesignerCapabilities` with the single engine-neutral `modelNavigation` port
+  (the engine-bound `codeLink` / `scripting` stay compile-time-rejected). The lib
+  `@miragon/bpmn-model-navigation` is already inlined into the package build
+  (INLINED_LIBS, api-extractor `bundledPackages`), its only bare runtime import
+  is `bpmn-js/lib/util/ModelUtil`, and `designer.ts` inlines the one conditional
+  rather than reusing `src/capabilityModules.ts` (which value-imports code-link +
+  inline-scripting, the latter dragging a CSS side-effect into the CSS-free design
+  entry). The purity gate stays green: nothing new becomes external.
 - **No host UX.** The creation-time Design/Implement choice and a mode-switch chip
   in VS Code / IntelliJ are follow-up work outside this package-only PR.
 

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -85,7 +85,7 @@ The three optional capability ports (`ModelerCapabilities`) are:
 
 | Capability | Port | Wires up |
 | --- | --- | --- |
-| `modelNavigation` | `ModelNavigationPort` | jump-to-element / model navigation |
+| `modelNavigation` | `ModelNavigationPort` | jump-to-element / model navigation (engine-neutral — **also available on `/design`** via its narrower `DesignerCapabilities`) |
 | `codeLink` | `CodeLinkPort` | code ↔ diagram linking |
 | `scripting` | `InlineScriptingPort` | inline script editing (**C7 only** — the C8 modeler leaves it unregistered even if the port is supplied) |
 
@@ -560,10 +560,22 @@ designer.getService("commandStack"); // editable: modelling services are present
 | `clipboard` | `ClipboardOptions` | native | Clipboard override for sandboxed hosts. |
 | `moddleExtensions` | `Record<string, object>` | — | Extra moddle extensions for a host's own BPMN namespace. |
 | `additionalModules` | `unknown[]` | — | Escape hatch: extra bpmn-js DI modules. |
+| `capabilities` | `DesignerCapabilities` | — | Engine-neutral host ports. Navigation-only: `{ modelNavigation }`. |
 | `onContentSaved` | `(e: ContentSavedEvent) => void` | — | Debounced diagram content (300 ms / 1000 ms maxWait). |
 
-There is no `engine`, `linting`, `elementTemplates`, `settings`, or
-`capabilities` — each is engine-bound and rejected at compile time.
+There is no `engine`, `linting`, `elementTemplates`, or `settings` — each is
+engine-bound and rejected at compile time. Unlike the root
+`ModelerCapabilities`, the design `capabilities` set is **navigation-only**: it
+accepts `modelNavigation` (engine-neutral) and compile-time-rejects the
+engine-bound `codeLink` / `scripting`.
+
+> **C8 caveat.** Without a zeebe moddle, C8-shaped references
+> (`zeebe:CalledElement` / `CalledDecision` / `FormDefinition`) parse as generic
+> elements whose `$type` keeps the raw XML qname casing (`"zeebe:calledElement"`),
+> so the exact `$type` match never fires and no navigate entry appears. Standard
+> and C7 references (`calledElement`, `camunda:decisionRef`) work out of the box.
+> A consumer who wants C8 navigation on `/design` passes
+> `moddleExtensions: { zeebe: … }`.
 
 ### `BpmnDesignerHandle`
 

--- a/packages/bpmn-modeler/src/architecture.spec.ts
+++ b/packages/bpmn-modeler/src/architecture.spec.ts
@@ -198,7 +198,11 @@ describe("bpmn-modeler import direction", () => {
             spec === "@miragon/bpmn-modeler-i18n-extras" ||
             spec === "@miragon/bpmn-modeler-append-menu" ||
             spec === "@miragon/bpmn-modeler-flow-navigation" ||
-            spec === "@miragon/bpmn-modeler-clipboard";
+            spec === "@miragon/bpmn-modeler-clipboard" ||
+            // Engine-neutral navigation capability (#1444): designer.ts value-imports
+            // createModelNavigationModule. The lib's only bare runtime import is
+            // bpmn-js/lib/util/ModelUtil, so it drags in no Camunda stack.
+            spec === "@miragon/bpmn-model-navigation";
         const offenders: string[] = [];
         for (const file of listSourceFiles(PKG_SRC)) {
             if (!file.startsWith(DESIGN_DIR)) continue;

--- a/packages/bpmn-modeler/src/design/designer.ts
+++ b/packages/bpmn-modeler/src/design/designer.ts
@@ -11,6 +11,7 @@ import MinimapModule from "diagram-js-minimap";
 import { AppendMenuModule } from "@miragon/bpmn-modeler-append-menu";
 import { FlowNavigationModule } from "@miragon/bpmn-modeler-flow-navigation";
 import { createClipboardModules } from "@miragon/bpmn-modeler-clipboard";
+import { createModelNavigationModule } from "@miragon/bpmn-model-navigation";
 import { TranslateModule } from "@miragon/bpmn-modeler-i18n";
 import {
     asyncDebounce,
@@ -163,6 +164,14 @@ export class BpmnDesigner {
         }
         const extra = (this.options.additionalModules as any[]) ?? [];
 
+        // Inline the one navigation capability rather than reusing
+        // src/capabilityModules.ts — that value-imports code-link and
+        // inline-scripting (the latter even side-effect-imports CSS, which would
+        // pollute the CSS-free design entry) and takes an Engine. An absent
+        // capability registers no provider, so no context-pad entry renders.
+        const navigationPort = this.options.capabilities?.modelNavigation;
+        const capModules = navigationPort ? [createModelNavigationModule(navigationPort)] : [];
+
         this.modeler = new Modeler({
             container: this.container,
             propertiesPanel: {
@@ -193,6 +202,7 @@ export class BpmnDesigner {
                 AppendMenuModule,
                 FlowNavigationModule,
                 MinimapModule,
+                ...capModules,
                 ...clipModules,
                 ...extra,
             ],

--- a/packages/bpmn-modeler/src/design/index.ts
+++ b/packages/bpmn-modeler/src/design/index.ts
@@ -28,11 +28,19 @@
 export { createDesigner } from "./createDesigner";
 export type {
     DesignerOptions,
+    DesignerCapabilities,
     BpmnDesignerHandle,
     CoreDesignerServices,
     CreateDesigner,
 } from "./publicApi";
 export type { ThemeMode, ClipboardOptions, ContentSavedEvent } from "../publicApi";
+
+// ── Model-navigation capability — the one engine-neutral host port on /design ─
+export type {
+    ModelNavigationPort,
+    ModelReference,
+    ReferenceKind,
+} from "@miragon/bpmn-model-navigation";
 
 // ── Mode routing — re-exported for hosts that decide Design vs Implement ──────
 export { detectEngine } from "../detectEngine";

--- a/packages/bpmn-modeler/src/design/publicApi.ts
+++ b/packages/bpmn-modeler/src/design/publicApi.ts
@@ -1,4 +1,5 @@
 import type { ImportXMLResult } from "bpmn-js/lib/BaseViewer";
+import type { ModelNavigationPort } from "@miragon/bpmn-model-navigation";
 import type {
     ClipboardOptions,
     ContentSavedEvent,
@@ -42,10 +43,27 @@ import type { ViewState } from "../viewState";
 export type CoreDesignerServices = CoreModelerServices;
 
 /**
+ * The host capabilities a designer can opt into. Unlike the root
+ * {@link ModelerCapabilities}, this is navigation-only: `modelNavigation`
+ * ("Navigate to referenced model" on Call Activities / Business Rule Tasks /
+ * linked forms) is engine-neutral, so it belongs on the design surface. The
+ * engine-bound ports (`codeLink`, `scripting`) are deliberately absent so they
+ * are compile-time-rejected here, mirroring how {@link DesignerOptions} rejects
+ * `engine` / `linting` / `elementTemplates`.
+ *
+ * Present ⇒ the feature's DI module is registered and its context-pad entry
+ * appears; absent ⇒ no provider is registered and no entry renders.
+ */
+export interface DesignerCapabilities {
+    modelNavigation?: ModelNavigationPort;
+}
+
+/**
  * Per-instance configuration for {@link createDesigner}. Deliberately minimal:
  * Design mode has no engine (there is no execution platform to bind), no element
- * templates, no linting, and no host capabilities — every field that survives is
- * engine-neutral.
+ * templates, and no linting — every field that survives is engine-neutral. Its
+ * only host capability is the engine-neutral `modelNavigation` (see
+ * {@link DesignerCapabilities}).
  */
 export interface DesignerOptions {
     /**
@@ -85,6 +103,14 @@ export interface DesignerOptions {
      * `additionalModules`.
      */
     additionalModules?: unknown[];
+
+    /**
+     * Engine-neutral host capabilities to opt into — currently only
+     * `modelNavigation`. Omit a capability and its DI module is never
+     * registered, so its context-pad entry never renders. See
+     * {@link DesignerCapabilities}.
+     */
+    capabilities?: DesignerCapabilities;
 
     /** Debounced diagram content — see {@link ContentSavedEvent}. */
     onContentSaved?: (event: ContentSavedEvent) => void;

--- a/packages/bpmn-modeler/src/index.ts
+++ b/packages/bpmn-modeler/src/index.ts
@@ -31,6 +31,11 @@ export type {
     StableModelerSurface,
 } from "./publicApi";
 export type { ModelerCapabilities } from "./capabilities";
+export type {
+    ModelNavigationPort,
+    ModelReference,
+    ReferenceKind,
+} from "@miragon/bpmn-model-navigation";
 export { UnsupportedEngineError } from "./modeler";
 
 // ── Re-exports so the rolled-up `.d.ts` stays self-contained ─────────────────

--- a/packages/bpmn-modeler/src/publicApi.spec.ts
+++ b/packages/bpmn-modeler/src/publicApi.spec.ts
@@ -19,7 +19,24 @@ import type {
 } from "./publicApi";
 import type { ViewState } from "./viewState";
 import type { BpmnViewerHandle, CoreViewerServices, ViewerOptions } from "./viewer/publicApi";
-import type { BpmnDesignerHandle, CoreDesignerServices, DesignerOptions } from "./design/publicApi";
+import type {
+    BpmnDesignerHandle,
+    CoreDesignerServices,
+    DesignerCapabilities,
+    DesignerOptions,
+} from "./design/publicApi";
+// The three model-navigation types must be re-exported from both barrels — the
+// public proof that a /design consumer can name the port and its references.
+import type {
+    ModelNavigationPort as ModelNavigationPortFromRoot,
+    ModelReference as ModelReferenceFromRoot,
+    ReferenceKind as ReferenceKindFromRoot,
+} from "./index";
+import type {
+    ModelNavigationPort as ModelNavigationPortFromDesign,
+    ModelReference as ModelReferenceFromDesign,
+    ReferenceKind as ReferenceKindFromDesign,
+} from "./design/index";
 
 // A minimal stub of the injected `@miragon/bpmn-modeler/lint` namespace. The
 // on-tiers below all require a `module`, so migration failures are compile-time.
@@ -407,6 +424,43 @@ const _designerRejectsElementTemplates = {
     elementTemplates: [],
 } satisfies DesignerOptions;
 void _designerRejectsElementTemplates;
+
+// The one engine-neutral host capability: modelNavigation is accepted, …
+const _designerAcceptsNavigation = {
+    propertiesPanel: { parent: document.createElement("div") },
+    capabilities: { modelNavigation: _asyncNavigation },
+} satisfies DesignerOptions;
+void _designerAcceptsNavigation;
+
+// … while the engine-bound ports stay compile-time-rejected on /design.
+const _designerRejectsCodeLink = {
+    propertiesPanel: { parent: document.createElement("div") },
+    // @ts-expect-error — codeLink is engine-bound, absent from DesignerCapabilities.
+    capabilities: { codeLink: {} },
+} satisfies DesignerOptions;
+void _designerRejectsCodeLink;
+
+const _designerRejectsScripting = {
+    propertiesPanel: { parent: document.createElement("div") },
+    // @ts-expect-error — scripting is engine-bound (C7-only), absent from DesignerCapabilities.
+    capabilities: { scripting: {} },
+} satisfies DesignerOptions;
+void _designerRejectsScripting;
+
+// DesignerCapabilities carries exactly the navigation port.
+const _designerCapabilities = { modelNavigation: _asyncNavigation } satisfies DesignerCapabilities;
+void _designerCapabilities;
+
+// The re-exported navigation types are structurally the same from either barrel.
+const _navPortRoot: ModelNavigationPortFromRoot = _asyncNavigation;
+const _navPortDesign: ModelNavigationPortFromDesign = _navPortRoot;
+void (_navPortDesign satisfies ModelNavigationPortFromDesign);
+const _refRoot: ModelReferenceFromRoot = { id: "Process_1", kind: "process" };
+const _refDesign: ModelReferenceFromDesign = _refRoot;
+void _refDesign;
+const _kindRoot: ReferenceKindFromRoot = "process";
+const _kindDesign: ReferenceKindFromDesign = _kindRoot;
+void _kindDesign;
 
 describe("public API conformance", () => {
     it("is a type-only conformance spec; the guarantee is the tsc pass", () => {


### PR DESCRIPTION
## Issue

Closes #1444

## Description

Adds `DesignerOptions.capabilities` with a narrower `DesignerCapabilities` carrying the single engine-neutral `modelNavigation` port, so `/design` consumers get the "Navigate to referenced model" context-pad entry — the engine-bound `codeLink`/`scripting` stay compile-time-rejected. `designer.ts` wires `createModelNavigationModule` directly instead of reusing `capabilityModules()`, keeping code-link/inline-scripting (and the latter's CSS side-effect) out of the CSS-free design entry; the lib was already inlined into the package build, so the purity gate needs no change. `ModelNavigationPort`/`ModelReference`/`ReferenceKind` are now named type exports of both the `/design` and root barrels, with type-level conformance tests in `publicApi.spec.ts` and the design allow-list extended in `architecture.spec.ts`. README documents the new option plus the C8 caveat (zeebe-shaped references need `moddleExtensions`), ADR 0016 is amended, and the demo design page wires a reference-following port as the manual proof. Part of #1438 (roadmap step 6).

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A) — amended 0016
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [ ] Verified in the affected hosts — VS Code / IntelliJ / standalone (N/A — package + demo only)
