### PR TITLE
feat(bpmn-modeler): add capabilities.modelNavigation on /viewer

### DIFF
--- a/apps/demo-webapp/bpmn/viewer.ts
+++ b/apps/demo-webapp/bpmn/viewer.ts
@@ -1,6 +1,6 @@
 import { createViewer } from "@miragon/bpmn-modeler/viewer";
 import type { ThemeMode } from "@miragon/bpmn-modeler/viewer";
-import { mountDemoHeader } from "../src";
+import { mountDemoHeader, modelHref, resolveReference } from "../src";
 import { MODELS } from "../src/registry";
 
 // The viewer ships its own lean stylesheet (`@miragon/bpmn-modeler/viewer.css`),
@@ -9,7 +9,8 @@ import { MODELS } from "../src/registry";
 // source escapes the dev-server root and 404s. This is the epic's regression
 // check: the viewer page must render, select, hover, zoom/pan, switch themes,
 // and show a readonly properties panel (every entry disabled) with no editing
-// affordance (no palette, context pad, or keyboard delete).
+// affordance (no palette, no keyboard delete). The one context-pad entry is
+// navigate, opted into via `capabilities.modelNavigation` below.
 import "../../../packages/bpmn-modeler/src/styles/viewer.css";
 
 /**
@@ -41,6 +42,24 @@ async function main(): Promise<void> {
     const viewer = await createViewer(canvas, {
         theme: themeMode as ThemeMode,
         propertiesPanel: { parent: properties },
+        // The one engine-neutral host capability on /viewer (#1445): a Call
+        // Activity / Business Rule Task / linked form gets a "Navigate to
+        // referenced model" context-pad entry — the single interaction a readonly
+        // surface still offers. Omitting `capabilities` renders no entry. C8-shaped
+        // references need `moddleExtensions: { zeebe }` to parse.
+        capabilities: {
+            modelNavigation: {
+                openReference: ({ id, kind }) => {
+                    if (kind === "form") {
+                        return;
+                    }
+                    const target = resolveReference(id, kind);
+                    if (target) {
+                        window.location.href = modelHref(target);
+                    }
+                },
+            },
+        },
     });
     viewerRef.current = viewer;
     await viewer.loadDiagram(model.xml);

--- a/docs/adr/0014-readonly-viewer-subpath.md
+++ b/docs/adr/0014-readonly-viewer-subpath.md
@@ -171,3 +171,48 @@ byte-identical to before.
 - **`locale` / `TranslateModule` remain omitted** — diagram-js's identity
   `translate` satisfies the renderer (English labels); hosts can add the
   translate module via `additionalModules`.
+
+## Amendment (#1445, 2026-09-04)
+
+`ViewerOptions` gains an **optional `capabilities: ViewerCapabilities`** —
+navigation-only, exactly like `/design`'s `DesignerCapabilities` (#1444, ADR
+0016). Model navigation is the one interaction a readonly surface should still
+offer, and it reads the model without mutating it, so it belongs on the viewer
+too. Present ⇒ the viewer registers `diagram-js/lib/features/context-pad` +
+`createModelNavigationModule(port)`; absent ⇒ the graph is byte-identical to
+before and `getService("contextPad")` throws (step 9, #1447, the bpmn-webview
+View mode, depends on this).
+
+- **diagram-js's context pad, never bpmn-js's.** `NavigatedViewer` registers no
+  `contextPad`, so one must be composed in. We register the plain diagram-js
+  module (`ContextPad.$inject = [canvas, elementRegistry, eventBus, scheduler]`,
+  `__depends__` interaction-events/scheduler/overlays — all already in the viewer
+  graph), **not** `bpmn-js/lib/features/context-pad`, whose provider drags
+  connect / create / direct-editing / popup-menu and injects `modeling`. The
+  readonly-by-construction proof is therefore unchanged with the capability on:
+  `modeling` / `commandStack` stay unregistered and throw (asserted in
+  `createViewer.spec.ts`).
+- **Own `ViewerCapabilities` interface**, not a reuse of `DesignerCapabilities`:
+  `/viewer` must not import from `src/design/*`. Structural identity between the
+  two (mutual assignability) is asserted in `publicApi.spec.ts`, and the
+  navigation types re-export from the `/viewer` barrel as they do from `/design`.
+- **The line-17 "context pad" remark** (Context, "hiding the palette leaves
+  editing live — keyboard, context pad") refers to **bpmn-js's** editing pad,
+  which the viewer still never registers. The opt-in diagram-js pad here carries
+  only the navigate entry and no editing affordance, so that argument stands.
+- **Empty pad on an unreferenced element renders nothing.** The provider returns
+  `{}` for an element with no resolvable reference; diagram-js renders an empty,
+  invisible `.djs-context-pad` (same as bpmn-js does for labels). No handling.
+- **No build / CSS / config change.** `@miragon/bpmn-model-navigation` is already
+  inlined into the package build (INLINED_LIBS, api-extractor `bundledPackages`);
+  its only bare runtime import is `bpmn-js/lib/util/ModelUtil`; the identity
+  `translate` the pad provider injects already exists in the viewer graph; and
+  `.djs-context-pad` CSS already ships via `viewer.css`. As on `/design`, the one
+  conditional is inlined rather than reusing `src/capabilityModules.ts` (which
+  value-imports code-link + inline-scripting, the latter dragging a CSS side
+  effect into the CSS-free viewer entry).
+- **The two stale acceptance criteria in #1445 are consciously not applied.**
+  The issue asked to update `scripts/check-viewer-pure-entry.mjs` and the viewer
+  lean-set rule in `architecture.spec.ts` — both retired in #1439/#1449 (the two
+  amendments above). There is no viewer allow-list left to update; re-adding one
+  would contradict the surface-accretion trajectory those amendments set.

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -85,7 +85,7 @@ The three optional capability ports (`ModelerCapabilities`) are:
 
 | Capability | Port | Wires up |
 | --- | --- | --- |
-| `modelNavigation` | `ModelNavigationPort` | jump-to-element / model navigation (engine-neutral — **also available on `/design`** via its narrower `DesignerCapabilities`) |
+| `modelNavigation` | `ModelNavigationPort` | jump-to-element / model navigation (engine-neutral — **also available on `/design` and `/viewer`** via their narrower `DesignerCapabilities` / `ViewerCapabilities`) |
 | `codeLink` | `CodeLinkPort` | code ↔ diagram linking |
 | `scripting` | `InlineScriptingPort` | inline script editing (**C7 only** — the C8 modeler leaves it unregistered even if the port is supplied) |
 
@@ -431,7 +431,9 @@ surface and on the [viewer](#viewer)'s opt-in readonly panel.
 `@miragon/bpmn-modeler/viewer` is a **readonly** surface for view-only
 permissions and embedded previews. It wraps bpmn-js's `NavigatedViewer` (mouse +
 keyboard pan/zoom) plus the selection outline, an opt-in **readonly**
-engine-neutral properties panel (#1443), and the browser-only
+engine-neutral properties panel (#1443), an opt-in **model-navigation**
+context-pad entry (#1445 — the one interaction a readonly surface still offers),
+and the browser-only
 [diff rendering primitives](#diff) (`DiffViewer`, `DiffLegend`, `DiffNavigator`,
 `DiffPaneCoordinator`). The Camunda editor stack (camunda-bpmn-js, CodeMirror,
 token simulation, lint) stays out of its module graph, so it survives
@@ -457,6 +459,7 @@ viewer.selection.onSelectionChanged((ids) => console.log("selected", ids));
 | --- | --- | --- | --- |
 | `theme` | `"light" \| "dark" \| "automatic"` | `"automatic"` | Colour theme; toggles a per-instance `data-bpmn-theme` attribute (same mechanism as the modeler). |
 | `propertiesPanel` | `{ parent: HTMLElement }` | — | Opt-in **readonly** properties panel: the engine-neutral panel renders into `parent` with every entry disabled (the viewer registers no `modeling` service). Omitted ⇒ no panel modules load, no DOM added. |
+| `capabilities` | `ViewerCapabilities` | — | Engine-neutral host ports. Navigation-only: `{ modelNavigation }` — the one interaction a readonly surface still offers. Present ⇒ a diagram-js context pad with only the navigate entry is registered; omitted ⇒ no `contextPad` service. Same [C8 caveat](#designeroptions) as `/design`. |
 | `moddleExtensions` | `Record<string, object>` | — | Extra moddle extensions for a host's own BPMN namespace. |
 | `additionalModules` | `unknown[]` | — | Escape hatch: extra render-only bpmn-js DI modules. |
 
@@ -469,15 +472,20 @@ handle narrows to a viewer handle with no adapter (a compile-time acceptance
 criterion). `captureViewState` / `applyViewState` (see
 [View state](#view-state-capture--restore)) make the viewer a valid target for a
 mode switch — capture on the editor, apply on the viewer. There is no
-`newDiagram`, `setElementTemplates`, `setSettings`, linting, clipboard,
-capabilities, or events.
+`newDiagram`, `setElementTemplates`, `setSettings`, linting, clipboard, or
+events; the only host capability is the opt-in `modelNavigation` (see
+[`ViewerOptions`](#vieweroptions)).
 
 `getService` is typed against `CoreViewerServices` — the readonly `Pick` of the
 [core services](#core-services--escape-hatch): `canvas`, `elementRegistry`,
 `eventBus`, `overlays`, `selection`. The editing services (`modeling`,
 `commandStack`) are **not registered** on a viewer — even with the properties
-panel registered — so resolving one throws: the surface is readonly by
-construction, not by convention.
+panel or model-navigation capability registered — so resolving one throws: the
+surface is readonly by construction, not by convention. `contextPad` is
+registered **only** with `capabilities.modelNavigation`, and even then it is
+diagram-js's plain pad (not bpmn-js's, whose provider injects `modeling`)
+carrying only the navigate entry; without the capability, resolving `contextPad`
+throws too.
 
 ### Kept out of the module graph
 

--- a/packages/bpmn-modeler/src/publicApi.spec.ts
+++ b/packages/bpmn-modeler/src/publicApi.spec.ts
@@ -18,7 +18,12 @@ import type {
     ThemeMode,
 } from "./publicApi";
 import type { ViewState } from "./viewState";
-import type { BpmnViewerHandle, CoreViewerServices, ViewerOptions } from "./viewer/publicApi";
+import type {
+    BpmnViewerHandle,
+    CoreViewerServices,
+    ViewerCapabilities,
+    ViewerOptions,
+} from "./viewer/publicApi";
 import type {
     BpmnDesignerHandle,
     CoreDesignerServices,
@@ -37,6 +42,12 @@ import type {
     ModelReference as ModelReferenceFromDesign,
     ReferenceKind as ReferenceKindFromDesign,
 } from "./design/index";
+// …and from the /viewer barrel — the same public proof for a /viewer consumer.
+import type {
+    ModelNavigationPort as ModelNavigationPortFromViewer,
+    ModelReference as ModelReferenceFromViewer,
+    ReferenceKind as ReferenceKindFromViewer,
+} from "./viewer/index";
 
 // A minimal stub of the injected `@miragon/bpmn-modeler/lint` namespace. The
 // on-tiers below all require a `module`, so migration failures are compile-time.
@@ -461,6 +472,44 @@ void _refDesign;
 const _kindRoot: ReferenceKindFromRoot = "process";
 const _kindDesign: ReferenceKindFromDesign = _kindRoot;
 void _kindDesign;
+
+// The /viewer surface accepts the same one engine-neutral capability, …
+const _viewerAcceptsNavigation = {
+    capabilities: { modelNavigation: _asyncNavigation },
+} satisfies ViewerOptions;
+void _viewerAcceptsNavigation;
+
+// … while the engine-bound ports stay compile-time-rejected on /viewer too.
+const _viewerRejectsCodeLink = {
+    // @ts-expect-error — codeLink is engine-bound, absent from ViewerCapabilities.
+    capabilities: { codeLink: {} },
+} satisfies ViewerOptions;
+void _viewerRejectsCodeLink;
+
+const _viewerRejectsScripting = {
+    // @ts-expect-error — scripting is engine-bound (C7-only), absent from ViewerCapabilities.
+    capabilities: { scripting: {} },
+} satisfies ViewerOptions;
+void _viewerRejectsScripting;
+
+// ViewerCapabilities carries exactly the navigation port, …
+const _viewerCapabilities = { modelNavigation: _asyncNavigation } satisfies ViewerCapabilities;
+void _viewerCapabilities;
+
+// … and is structurally identical to DesignerCapabilities (mutually assignable),
+// the own-interface guarantee: the viewer must not import from src/design/*.
+const _viewerCapsAsDesigner: DesignerCapabilities = _viewerCapabilities;
+void _viewerCapsAsDesigner;
+const _designerCapsAsViewer: ViewerCapabilities = { modelNavigation: _asyncNavigation };
+void (_designerCapsAsViewer satisfies DesignerCapabilities);
+
+// The re-exported navigation types are the same from the /viewer barrel too.
+const _navPortViewer: ModelNavigationPortFromViewer = _navPortRoot;
+void (_navPortViewer satisfies ModelNavigationPortFromDesign);
+const _refViewer: ModelReferenceFromViewer = _refRoot;
+void _refViewer;
+const _kindViewer: ReferenceKindFromViewer = _kindRoot;
+void _kindViewer;
 
 describe("public API conformance", () => {
     it("is a type-only conformance spec; the guarantee is the tsc pass", () => {

--- a/packages/bpmn-modeler/src/viewer/createViewer.spec.ts
+++ b/packages/bpmn-modeler/src/viewer/createViewer.spec.ts
@@ -1,4 +1,4 @@
-import { beforeAll, afterEach, describe, expect, it } from "vitest";
+import { beforeAll, afterEach, describe, expect, it, vi } from "vitest";
 import { NoModelerError } from "@miragon/bpmn-modeler-types";
 import { createViewer } from "./createViewer";
 import type { BpmnViewer } from "./viewer";
@@ -140,6 +140,8 @@ describe("createViewer (runtime, jsdom)", () => {
             // drag any editing service into the DI graph.
             expect(() => viewer!.getService("modeling")).toThrow();
             expect(() => viewer!.getService("commandStack")).toThrow();
+            // The panel is orthogonal to navigation: no context pad without it.
+            expect(() => viewer!.getService("contextPad")).toThrow();
         });
 
         it("exposes the host custom-group slot", async () => {
@@ -178,6 +180,85 @@ describe("createViewer (runtime, jsdom)", () => {
 
             expect(document.querySelector(".bio-properties-panel-container")).toBeNull();
             expect(() => viewer!.getService("propertiesPanel")).toThrow();
+        });
+    });
+
+    describe("model navigation capability (opt-in, #1445)", () => {
+        const port = { openReference: vi.fn() };
+
+        afterEach(() => {
+            port.openReference.mockReset();
+        });
+
+        it("registers the diagram-js pad + navigation provider, no editing services", async () => {
+            container = mount();
+            viewer = await createViewer(container, {
+                capabilities: { modelNavigation: port },
+            });
+
+            expect(viewer.getService("contextPad")).toBeDefined();
+            expect(viewer.getService("navigateContextPadProvider")).toBeDefined();
+            expect(viewer.getService("formReferenceStatusClient")).toBeDefined();
+            expect(viewer.getService("modelNavigationPort")).toBe(port);
+
+            // The pad is diagram-js's, not bpmn-js's, so it drags in no editing.
+            expect(() => viewer!.getService("modeling")).toThrow();
+            expect(() => viewer!.getService("commandStack")).toThrow();
+        });
+
+        it("contributes exactly the navigate entry on a referencing element", async () => {
+            container = mount();
+            viewer = await createViewer(container, {
+                capabilities: { modelNavigation: port },
+            });
+
+            // Build the business object directly — no importXML (jsdom SVG wall).
+            const moddle = viewer.getService<{ create(type: string, attrs: object): unknown }>(
+                "moddle",
+            );
+            const businessObject = moddle.create("bpmn:CallActivity", {
+                calledElement: "handleRejection",
+            });
+            const element = { type: "bpmn:CallActivity", businessObject };
+
+            const contextPad = viewer.getService<{
+                getEntries(
+                    target: unknown,
+                ): Record<string, { action: { click: (event: Event, element: unknown) => void } }>;
+            }>("contextPad");
+            const entries = contextPad.getEntries(element);
+            expect(Object.keys(entries)).toEqual(["navigate-to-referenced-model"]);
+
+            entries["navigate-to-referenced-model"].action.click(new Event("click"), element);
+            expect(port.openReference).toHaveBeenCalledWith({
+                id: "handleRejection",
+                kind: "process",
+            });
+        });
+
+        it("contributes nothing on an element with no reference", async () => {
+            container = mount();
+            viewer = await createViewer(container, {
+                capabilities: { modelNavigation: port },
+            });
+
+            const moddle = viewer.getService<{ create(type: string, attrs: object): unknown }>(
+                "moddle",
+            );
+            const businessObject = moddle.create("bpmn:Task", {});
+            const contextPad = viewer.getService<{
+                getEntries(target: unknown): Record<string, unknown>;
+            }>("contextPad");
+
+            expect(contextPad.getEntries({ type: "bpmn:Task", businessObject })).toEqual({});
+        });
+
+        it("registers no context pad when the capability is omitted", async () => {
+            container = mount();
+            viewer = await createViewer(container);
+
+            expect(() => viewer!.getService("contextPad")).toThrow();
+            expect(() => viewer!.getService("navigateContextPadProvider")).toThrow();
         });
     });
 

--- a/packages/bpmn-modeler/src/viewer/index.ts
+++ b/packages/bpmn-modeler/src/viewer/index.ts
@@ -6,8 +6,11 @@
  * simulation, lint) into the module graph. It does carry the browser-only diff
  * rendering primitives, the shared i18n translator via `DiffLegend` (#1439),
  * and — when a consumer opts in via `propertiesPanel` — the engine-neutral
- * readonly panel (preact via `@bpmn-io/properties-panel`, #1443). See ADR 0014
- * and its amendments.
+ * readonly panel (preact via `@bpmn-io/properties-panel`, #1443). When a consumer
+ * opts into `capabilities.modelNavigation` (#1445), it also registers a
+ * diagram-js context pad carrying only the "Navigate to referenced model" entry —
+ * the one interaction a readonly surface still offers. See ADR 0014 and its
+ * amendments.
  *
  * Deliberately imports **no CSS**: `cssCodeSplit: false` on the lib build would
  * fold any stylesheet reachable from here into the shared `dist/bpmn-modeler.css`
@@ -20,11 +23,19 @@
 export { createViewer } from "./createViewer";
 export type {
     ViewerOptions,
+    ViewerCapabilities,
     BpmnViewerHandle,
     CoreViewerServices,
     CreateViewer,
 } from "./publicApi";
 export type { ThemeMode } from "../publicApi";
+
+// ── Model-navigation capability — the one engine-neutral host port on /viewer ─
+export type {
+    ModelNavigationPort,
+    ModelReference,
+    ReferenceKind,
+} from "@miragon/bpmn-model-navigation";
 
 // ── Viewport / selection — public, referenced by the viewer handle ───────────
 export { ViewportManager } from "../viewport";

--- a/packages/bpmn-modeler/src/viewer/publicApi.ts
+++ b/packages/bpmn-modeler/src/viewer/publicApi.ts
@@ -1,4 +1,5 @@
 import type { ImportXMLResult } from "bpmn-js/lib/BaseViewer";
+import type { ModelNavigationPort } from "@miragon/bpmn-model-navigation";
 import type { CoreModelerServices, ThemeMode } from "../publicApi";
 import type { ViewportManager } from "../viewport";
 import type { SelectionManager } from "../selection";
@@ -19,8 +20,10 @@ import type { ViewState } from "../viewState";
  * Every handle member below is signature-identical to its {@link
  * BpmnModelerHandle} counterpart (subset compatibility is asserted in
  * `publicApi.spec.ts`), so a host can narrow a modeler handle to a viewer handle
- * without adapters. There is no `engine`, `linting`, `clipboard`,
- * `capabilities`, events, or `locale`.
+ * without adapters. There is no `engine`, `linting`, `clipboard`, events, or
+ * `locale`; the one host capability it accepts is the engine-neutral
+ * `modelNavigation` — the single interaction a readonly surface still offers
+ * (see {@link ViewerCapabilities}).
  */
 
 /**
@@ -35,9 +38,28 @@ export type CoreViewerServices = Pick<
 >;
 
 /**
+ * The host capabilities a viewer can opt into — navigation-only. Navigation is
+ * the one interaction a readonly surface still offers: `modelNavigation`
+ * ("Navigate to referenced model" on Call Activities / Business Rule Tasks /
+ * linked forms) reads the model without mutating it, so it belongs on the viewer
+ * too. Present ⇒ a diagram-js context pad carrying only the navigate entry is
+ * registered; absent ⇒ no `contextPad` service is registered and no entry
+ * renders. The engine-bound ports (`codeLink`, `scripting`) are absent by
+ * construction — the viewer has no editing surface to bind them to.
+ *
+ * Its own interface rather than a reuse of {@link DesignerCapabilities}: the
+ * viewer must not import from `src/design/*`. Structural identity with
+ * `DesignerCapabilities` is asserted in `publicApi.spec.ts`.
+ */
+export interface ViewerCapabilities {
+    modelNavigation?: ModelNavigationPort;
+}
+
+/**
  * Per-instance configuration for {@link createViewer}. Deliberately minimal: a
- * viewer has no engine (bpmn-js's base viewer reads any BPMN), no host
- * capabilities, and only an opt-in readonly properties panel.
+ * viewer has no engine (bpmn-js's base viewer reads any BPMN), an opt-in
+ * readonly properties panel, and — as its only host capability — the
+ * engine-neutral `modelNavigation` (see {@link ViewerCapabilities}).
  */
 export interface ViewerOptions {
     /**
@@ -48,6 +70,14 @@ export interface ViewerOptions {
      * the panel modules enter the DI graph and no DOM is added.
      */
     propertiesPanel?: { parent: HTMLElement };
+
+    /**
+     * Engine-neutral host capabilities to opt into — currently only
+     * `modelNavigation`. Omit it and no `contextPad` service enters the DI
+     * graph, so no context-pad entry ever renders. See
+     * {@link ViewerCapabilities}.
+     */
+    capabilities?: ViewerCapabilities;
 
     /**
      * Colour theme — defaults to `"automatic"`. Theming always engages: the

--- a/packages/bpmn-modeler/src/viewer/viewer.ts
+++ b/packages/bpmn-modeler/src/viewer/viewer.ts
@@ -1,6 +1,8 @@
 import NavigatedViewer from "bpmn-js/lib/NavigatedViewer";
 import OutlineModule from "bpmn-js/lib/features/outline";
+import ContextPadModule from "diagram-js/lib/features/context-pad";
 import { ImportXMLError, ImportXMLResult, SaveXMLResult } from "bpmn-js/lib/BaseViewer";
+import { createModelNavigationModule } from "@miragon/bpmn-model-navigation";
 // Deep imports on purpose: the lib barrel side-effect-imports its CSS, and the
 // viewer entry must stay CSS-free (`cssCodeSplit: false` would fold any
 // reachable sheet into the shared `dist/bpmn-modeler.css`). Gated by
@@ -36,6 +38,11 @@ import type { CoreViewerServices, ViewerOptions } from "./publicApi";
  * (`@miragon/bpmn-modeler-properties-panel`) mounts readonly: the renderer
  * derives readonly from the absent `modeling` service and disables every entry.
  * Without the option, none of the panel modules enter the DI graph.
+ *
+ * With `options.capabilities.modelNavigation` set, a diagram-js context pad
+ * carrying only the "Navigate to referenced model" entry is registered — the one
+ * interaction a readonly surface still offers. Without it, no `contextPad`
+ * service enters the graph.
  *
  * Per-instance by construction: bound to its own `container`, so several viewers
  * (or a viewer beside a modeler) can coexist on a page. Use {@link createViewer}
@@ -126,6 +133,18 @@ export class BpmnViewer {
      */
     async init(): Promise<void> {
         const panel = this.options.propertiesPanel;
+
+        // diagram-js's plain context pad, never bpmn-js's — the latter's provider
+        // drags connect/create/direct-editing/popup-menu and injects `modeling`,
+        // which a readonly viewer never registers. Registered only with the
+        // capability, so an omitted port leaves the graph byte-identical (no
+        // `contextPad` service). ContextPad's deps (interaction-events, scheduler,
+        // overlays) are already in the viewer graph.
+        const navigationPort = this.options.capabilities?.modelNavigation;
+        const capModules = navigationPort
+            ? [ContextPadModule, createModelNavigationModule(navigationPort)]
+            : [];
+
         this.viewer = new NavigatedViewer({
             container: this.container,
             moddleExtensions: this.options.moddleExtensions,
@@ -154,6 +173,7 @@ export class BpmnViewer {
                           CustomGroupsModule,
                       ]
                     : []),
+                ...capModules,
                 ...((this.options.additionalModules as any[]) ?? []),
             ],
         });


### PR DESCRIPTION
## Issue

Closes #1445

## Description

Adds `ViewerOptions.capabilities` with a navigation-only `ViewerCapabilities` so `/viewer` consumers get the "Navigate to referenced model" context-pad entry, the one interaction a readonly surface still offers. `NavigatedViewer` registers no `contextPad`, so with the port given `viewer.ts` composes `diagram-js/lib/features/context-pad` (not bpmn-js's, whose provider injects `modeling`) plus `createModelNavigationModule`; omitted, the DI graph is byte-identical and `getService("contextPad")` throws. `ViewerCapabilities` is its own interface so `/viewer` never imports from `/design`, with mutual assignability to `DesignerCapabilities` and cross-barrel type identity asserted in `publicApi.spec.ts`, and `createViewer.spec.ts` proves the pad carries exactly the navigate entry while `modeling`/`commandStack` stay unregistered. README documents the option, ADR 0014 is amended (including why the issue's retired-gate acceptance criteria are consciously not applied), and the demo viewer page wires a reference-following port. Part of #1438 (roadmap step 7).

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A) — amended 0014
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [ ] Verified in the affected hosts — VS Code / IntelliJ / standalone (N/A — package + demo only)
