### PR TITLE
refactor(dmn-webview): rewire as a thin host adapter over @miragon/dmn-modeler

### DIFF
--- a/apps/dmn-webview/README.md
+++ b/apps/dmn-webview/README.md
@@ -13,6 +13,11 @@ The host-free modeler facade now lives in the publishable
 [`packages/dmn-modeler`](../../packages/dmn-modeler/README.md); this app is the
 thin host adapter that consumes it.
 
+The adapter is a flat `src/` layout mirroring
+[`apps/bpmn-webview`](../bpmn-webview/README.md): `bootstrap.ts` runs the
+protocol dispatch and handshake, `host.ts` selects the `HostApi`, and
+`state.ts` + `webviewState.ts` hold the persisted properties-panel UI state.
+
 ## Local development
 
 From the repo root:

--- a/apps/dmn-webview/src/app/index.ts
+++ b/apps/dmn-webview/src/app/index.ts
@@ -1,4 +1,0 @@
-export { createModeler } from "@miragon/dmn-modeler";
-export type { DmnModelerHandle } from "@miragon/dmn-modeler";
-export * from "./state";
-export * from "./host";

--- a/apps/dmn-webview/src/bootstrap.spec.ts
+++ b/apps/dmn-webview/src/bootstrap.spec.ts
@@ -28,19 +28,26 @@ const mocks = vi.hoisted(() => {
         ),
         initResizer: vi.fn(() => panelHandle),
         installPanelShortcuts: vi.fn(),
+        stateManagerCtor: vi.fn(),
         stateManager: {
             restorePanelVisibility: vi.fn(),
             persistPanelVisibility: vi.fn(),
             restorePanelUiState: vi.fn(),
             startPersisting: vi.fn(),
         },
+        setLanguage: vi.fn(),
+        getLocale: vi.fn(() => "en"),
     };
 });
 
-vi.mock("./app", () => ({
-    createModeler: mocks.createModeler,
+vi.mock("@miragon/dmn-modeler", () => ({ createModeler: mocks.createModeler }));
+
+vi.mock("./state", () => ({
     readSavedPanelVisibility: vi.fn(() => undefined),
     WebviewStateManager: class {
+        constructor(...args: unknown[]) {
+            mocks.stateManagerCtor(...args);
+        }
         restorePanelVisibility = mocks.stateManager.restorePanelVisibility;
         persistPanelVisibility = mocks.stateManager.persistPanelVisibility;
         restorePanelUiState = mocks.stateManager.restorePanelUiState;
@@ -52,6 +59,8 @@ vi.mock("@miragon/bpmn-modeler-i18n", () => ({
     i18n: {
         translate: (text: string) => text,
         onChange: vi.fn(),
+        setLanguage: mocks.setLanguage,
+        getLocale: mocks.getLocale,
     },
 }));
 
@@ -123,6 +132,8 @@ describe("DMN bootstrap", () => {
             canvas,
             expect.objectContaining({ propertiesPanel: { parent: panel }, theme: "light" }),
         );
+        // The state manager is scoped to the properties-panel element, not `document`.
+        expect(mocks.stateManagerCtor).toHaveBeenCalledWith(host, panel);
         // The host adapter scoped the page on `<html>` off the (light) VS Code signal.
         expect(document.documentElement.getAttribute("data-dmn-theme")).toBe("light");
         expect(mocks.createModeler.mock.invocationCallOrder[0]).toBeLessThan(
@@ -195,5 +206,33 @@ describe("DMN bootstrap", () => {
         function dispatch(data: Record<string, unknown>): void {
             window.dispatchEvent(new MessageEvent("message", { data }));
         }
+    });
+
+    it("seeds a forced theme and locale from bootstrap opts", async () => {
+        vi.resetModules();
+        mocks.handle.setTheme.mockClear();
+        mocks.setLanguage.mockClear();
+
+        document.body.className = "";
+        document.body.innerHTML = `
+            <main id="js-canvas"></main>
+            <aside id="js-properties-panel"></aside>
+        `;
+        Object.defineProperty(document, "readyState", { value: "complete", configurable: true });
+
+        const host = {
+            postMessage: vi.fn(),
+            getState: () => undefined,
+            setState: vi.fn(),
+            updateState: vi.fn(),
+        };
+
+        const { bootstrap } = await import("./bootstrap");
+        bootstrap(host as never, { theme: "dark", locale: "de" });
+
+        // The forced dark mode reaches the instance before any settings reply,
+        // and the locale is seeded before the modeler renders.
+        await vi.waitFor(() => expect(mocks.handle.setTheme).toHaveBeenCalledWith("dark"));
+        expect(mocks.setLanguage).toHaveBeenCalledWith("de");
     });
 });

--- a/apps/dmn-webview/src/bootstrap.ts
+++ b/apps/dmn-webview/src/bootstrap.ts
@@ -16,6 +16,7 @@ import {
     GetDmnModelerSettingCommand,
     GetPropertiesPanelStateCommand,
     type HostThemeAdapter,
+    type HostThemeMode,
     initResizer,
     installPanelShortcuts,
     LogErrorCommand,
@@ -28,15 +29,17 @@ import {
     SyncDocumentCommand,
 } from "@miragon/bpmn-modeler-shared";
 import { asyncDebounce, NoModelerError, serializeAsync } from "@miragon/bpmn-modeler-types";
-import { i18n } from "@miragon/bpmn-modeler-i18n";
+import { i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
+import { createModeler, type DmnModelerHandle } from "@miragon/dmn-modeler";
 
-import { createModeler, readSavedPanelVisibility, WebviewStateManager } from "./app";
-import type { DmnModelerHandle } from "./app";
+import { readSavedPanelVisibility, WebviewStateManager } from "./state";
 import type { HostApi } from "@miragon/bpmn-modeler-shared";
-import type { WebviewState } from "./app/host";
+import type { WebviewState } from "./webviewState";
 
-// Injected by bootstrap(); the app/demo entry chooses the concrete host.
+// Injected by bootstrap(); the app/demo entry chooses the concrete host and,
+// optionally, seeds the initial theme mode / locale.
 let host: HostApi<WebviewState, Command | Query>;
+let bootstrapOpts: { theme?: HostThemeMode; locale?: SupportedLocale } = {};
 let modeler: DmnModelerHandle | undefined;
 let themeAdapter: HostThemeAdapter | undefined;
 
@@ -165,29 +168,41 @@ const RESOLVER_TIMEOUT_MS = 5000;
  * 2. User switched to another tab and now switched back
  */
 async function run(): Promise<void> {
-    const stateManager = new WebviewStateManager(host);
+    const canvas = requireElement("#js-canvas");
+    const propertiesPanel = requireElement("#js-properties-panel");
+    const stateManager = new WebviewStateManager(host, propertiesPanel);
     window.addEventListener("message", onReceiveMessage);
 
     // Theme is host policy: drive the page-level scope (host chrome, keyed off
     // `:root[data-dmn-theme="dark"]`) and the modeler instance's own theme off
     // the VS Code `<body>`-class signal. The instance is also born correct via
-    // `theme: resolveHostThemeKind()` below, so this mainly covers the page
-    // chrome and later live theme switches. The host's `colorTheme` preference
-    // (which may force light) is applied once the setting query arrives below.
+    // `theme: resolveHostThemeKind()` below; the adapter covers the page chrome,
+    // a forced `opts.theme` seam, and later live theme switches. The host's
+    // `colorTheme` preference (which may force light) is applied once the setting
+    // query arrives below.
     themeAdapter = createHostThemeAdapter((kind) => {
         applyPageThemeScope("data-dmn-theme", kind);
         modeler?.setTheme(kind);
     });
-    themeAdapter.setMode("automatic");
 
-    const canvas = requireElement("#js-canvas");
-    const propertiesPanel = requireElement("#js-properties-panel");
+    // Seed the locale before the modeler renders so the resizer labels (and,
+    // once DMN language wiring lands, the dmn-js UI) come up translated.
+    if (bootstrapOpts.locale) {
+        i18n.setLanguage(bootstrapOpts.locale);
+    }
+
     modeler = await createModeler(canvas, {
         propertiesPanel: { parent: propertiesPanel },
         theme: resolveHostThemeKind(),
         onContentChanged: () => void debouncedSendChanges(),
         onWarning: (message) => host.postMessage(new LogWarningCommand(message)),
     });
+
+    // Drive the mode only after the instance exists so a forced `opts.theme`
+    // (the demo, which never gets a settings reply) actually reaches
+    // `modeler.setTheme`; "automatic" reproduces today's follow-the-IDE
+    // behaviour and installs the live `<body>`-class observer.
+    themeAdapter.setMode(bootstrapOpts.theme ?? "automatic");
 
     // Labels reuse the BPMN i18n keys; DMN has no language wiring yet, so they
     // render the English fallback until that lands.
@@ -351,10 +366,15 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>) {
 
 /**
  * Starts the DMN webview against the given host. The entry (real or demo)
- * chooses the host.
+ * chooses the host and, optionally, the initial theme mode / locale — the demo
+ * seeds them directly since it has no host settings reply to wait on.
  */
-export function bootstrap(injectedHost: HostApi<WebviewState, Command | Query>): void {
+export function bootstrap(
+    injectedHost: HostApi<WebviewState, Command | Query>,
+    opts: { theme?: HostThemeMode; locale?: SupportedLocale } = {},
+): void {
     host = injectedHost;
+    bootstrapOpts = opts;
     registerGlobalErrorHandlers();
     if (document.readyState === "complete") {
         void run();

--- a/apps/dmn-webview/src/host.ts
+++ b/apps/dmn-webview/src/host.ts
@@ -1,3 +1,8 @@
+/**
+ * Host-adapter surface — the VS Code protocol adapter (Query/Command wiring,
+ * `bootstrap`'s host handshake). Lives in the app, outside the publishable
+ * `@miragon/dmn-modeler` boundary.
+ */
 import {
     Command,
     DmnFileQuery,
@@ -12,28 +17,9 @@ import {
     HostApiImpl,
     MockHostApi,
 } from "@miragon/bpmn-modeler-shared";
+import type { WebviewState } from "./webviewState";
 
 declare const process: { env: { NODE_ENV: string } };
-
-/**
- * Shape of the data persisted via `host.setState` / `host.getState`.
- */
-export interface WebviewState {
-    // Scroll position of `.bio-properties-panel-scroll-container`.
-    panelScroll?: number;
-    /**
-     * Indexes (in render order) of `.bio-properties-panel-group` elements
-     * that are currently expanded.  Keyed by position so it survives a
-     * language switch — group labels are localised, indexes are not.
-     */
-    expandedGroupIndexes?: number[];
-    /**
-     * Per-editor properties-panel visibility. Absent until the user first
-     * toggles the panel in this editor; while absent the editor follows the
-     * host's global default (`dmnPropertiesPanelVisible`). Present entry wins.
-     */
-    panelVisible?: boolean;
-}
 
 type StateType = WebviewState;
 

--- a/apps/dmn-webview/src/index.ts
+++ b/apps/dmn-webview/src/index.ts
@@ -1,2 +1,2 @@
 export { bootstrap } from "./bootstrap";
-export type { WebviewState } from "./app/host";
+export type { WebviewState } from "./webviewState";

--- a/apps/dmn-webview/src/main.ts
+++ b/apps/dmn-webview/src/main.ts
@@ -1,4 +1,4 @@
-import { getHostApi } from "./app";
+import { getHostApi } from "./host";
 import { bootstrap } from "./bootstrap";
 
 bootstrap(getHostApi());

--- a/apps/dmn-webview/src/state.spec.ts
+++ b/apps/dmn-webview/src/state.spec.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Command, MockHostApi, Query } from "@miragon/bpmn-modeler-shared";
+
+import { readSavedPanelVisibility, WebviewStateManager } from "./state";
+import type { WebviewState } from "./webviewState";
+
+type MessageType = Command | Query;
+
+/**
+ * In-memory host mirroring the production `MockHost.updateState` merge, so the
+ * manager exercises the real persist path (`updateState` → `setState` fallback).
+ */
+class TestHost extends MockHostApi<WebviewState, MessageType> {
+    override updateState(state: Partial<WebviewState>): void {
+        try {
+            this.setState({ ...this.getState(), ...state });
+        } catch {
+            this.setState(state as WebviewState);
+        }
+    }
+
+    override postMessage(): void {
+        // No host to forward to in unit tests.
+    }
+}
+
+describe("readSavedPanelVisibility", () => {
+    it("returns the saved visibility (true)", () => {
+        const host = new TestHost();
+        host.setState({ panelVisible: true });
+        expect(readSavedPanelVisibility(host)).toBe(true);
+    });
+
+    it("returns the saved visibility (false)", () => {
+        const host = new TestHost();
+        host.setState({ panelVisible: false });
+        expect(readSavedPanelVisibility(host)).toBe(false);
+    });
+
+    it("returns undefined when no entry is saved", () => {
+        const host = new TestHost();
+        host.setState({});
+        expect(readSavedPanelVisibility(host)).toBeUndefined();
+    });
+
+    it("returns undefined when getState throws", () => {
+        const host = new TestHost();
+        expect(readSavedPanelVisibility(host)).toBeUndefined();
+    });
+});
+
+describe("WebviewStateManager.restorePanelVisibility", () => {
+    function panelHandle() {
+        const setVisible = vi.fn();
+        return { handle: { setVisible } as never, setVisible };
+    }
+
+    it("applies the saved entry over the fallback", () => {
+        const host = new TestHost();
+        host.setState({ panelVisible: false });
+        const manager = new WebviewStateManager(host, document.createElement("div"));
+        const { handle, setVisible } = panelHandle();
+
+        manager.restorePanelVisibility(handle, true);
+
+        expect(setVisible).toHaveBeenCalledWith(false);
+    });
+
+    it("falls back to the host default when no entry is saved", () => {
+        const host = new TestHost();
+        const manager = new WebviewStateManager(host, document.createElement("div"));
+        const { handle, setVisible } = panelHandle();
+
+        manager.restorePanelVisibility(handle, true);
+
+        expect(setVisible).toHaveBeenCalledWith(true);
+    });
+});
+
+describe("WebviewStateManager.persistPanelVisibility", () => {
+    it("merges the visibility into existing state", () => {
+        const host = new TestHost();
+        host.setState({ panelScroll: 42 });
+        const manager = new WebviewStateManager(host, document.createElement("div"));
+
+        manager.persistPanelVisibility(true);
+
+        expect(host.getState()).toEqual({ panelScroll: 42, panelVisible: true });
+    });
+
+    it("writes a first entry when no state exists yet", () => {
+        const host = new TestHost();
+        const setState = vi.spyOn(host, "setState");
+        const manager = new WebviewStateManager(host, document.createElement("div"));
+
+        manager.persistPanelVisibility(false);
+
+        expect(setState).toHaveBeenCalledWith({ panelVisible: false });
+        expect(host.getState()).toEqual({ panelVisible: false });
+    });
+});
+
+describe("WebviewStateManager.restorePanelUiState", () => {
+    let rafQueue: FrameRequestCallback[] = [];
+
+    beforeEach(() => {
+        rafQueue = [];
+        vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+            rafQueue.push(cb);
+            return rafQueue.length;
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        document.body.innerHTML = "";
+    });
+
+    function flushFrame(): void {
+        const callbacks = rafQueue;
+        rafQueue = [];
+        callbacks.forEach((cb) => cb(0));
+    }
+
+    /** A scroll container with `count` collapsed groups whose headers toggle `open`. */
+    function panelWithGroups(count: number) {
+        const panelRoot = document.createElement("div");
+        const container = document.createElement("div");
+        container.className = "bio-properties-panel-scroll-container";
+        let scrollTop = 0;
+        Object.defineProperty(container, "scrollTop", {
+            configurable: true,
+            get: () => scrollTop,
+            set: (value: number) => {
+                scrollTop = value;
+            },
+        });
+        const headers: HTMLElement[] = [];
+        for (let index = 0; index < count; index++) {
+            const group = document.createElement("div");
+            group.className = "bio-properties-panel-group";
+            const header = document.createElement("div");
+            header.className = "bio-properties-panel-group-header";
+            header.addEventListener("click", () => header.classList.toggle("open"));
+            group.appendChild(header);
+            container.appendChild(group);
+            headers.push(header);
+        }
+        panelRoot.appendChild(container);
+        document.body.appendChild(panelRoot);
+        return { panelRoot, container, headers };
+    }
+
+    it("toggles the saved groups open and applies scroll on the second frame", () => {
+        const host = new TestHost();
+        host.setState({ expandedGroupIndexes: [1], panelScroll: 200 });
+        const { panelRoot, container, headers } = panelWithGroups(3);
+        const manager = new WebviewStateManager(host, panelRoot);
+
+        manager.restorePanelUiState();
+
+        flushFrame(); // toggles group headers, schedules the scroll frame
+        expect(headers[1].classList.contains("open")).toBe(true);
+        expect(headers[0].classList.contains("open")).toBe(false);
+        expect(container.scrollTop).toBe(0);
+
+        flushFrame(); // applies scroll once Preact has flushed re-renders
+        expect(container.scrollTop).toBe(200);
+    });
+
+    it("does nothing when no panel UI state is saved", () => {
+        const host = new TestHost();
+        host.setState({ panelVisible: true });
+        const { panelRoot } = panelWithGroups(2);
+        const manager = new WebviewStateManager(host, panelRoot);
+
+        manager.restorePanelUiState();
+
+        expect(rafQueue).toHaveLength(0);
+    });
+});
+
+describe("WebviewStateManager panel scoping", () => {
+    /** A panel host with a scroll container, plus a decoy panel elsewhere. */
+    function panels() {
+        const panelRoot = document.createElement("div");
+        const scroll = document.createElement("div");
+        scroll.className = "bio-properties-panel-scroll-container";
+        panelRoot.appendChild(scroll);
+        document.body.appendChild(panelRoot);
+
+        const otherPanel = document.createElement("div");
+        const otherScroll = document.createElement("div");
+        otherScroll.className = "bio-properties-panel-scroll-container";
+        otherPanel.appendChild(otherScroll);
+        document.body.appendChild(otherPanel);
+
+        return { panelRoot, scroll, otherScroll };
+    }
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("persists scroll only for the container within the passed panelRoot", () => {
+        vi.useFakeTimers();
+        const { panelRoot, scroll, otherScroll } = panels();
+        const host = new TestHost();
+        const updateState = vi.spyOn(host, "updateState");
+        const manager = new WebviewStateManager(host, panelRoot);
+
+        manager.startPersisting();
+
+        Object.defineProperty(scroll, "scrollTop", { value: 42, configurable: true });
+        scroll.dispatchEvent(new Event("scroll"));
+        vi.advanceTimersByTime(100);
+        expect(updateState).toHaveBeenCalledWith({ panelScroll: 42 });
+
+        // A scroll in a foreign panel must not be persisted as ours.
+        updateState.mockClear();
+        Object.defineProperty(otherScroll, "scrollTop", { value: 99, configurable: true });
+        otherScroll.dispatchEvent(new Event("scroll"));
+        vi.advanceTimersByTime(100);
+        expect(updateState).not.toHaveBeenCalled();
+
+        vi.useRealTimers();
+    });
+
+    it("persists expanded group indexes when a group toggles open", async () => {
+        const { panelRoot, scroll } = panels();
+        const group = document.createElement("div");
+        group.className = "bio-properties-panel-group";
+        const header = document.createElement("div");
+        header.className = "bio-properties-panel-group-header";
+        group.appendChild(header);
+        scroll.appendChild(group);
+
+        const host = new TestHost();
+        const updateState = vi.spyOn(host, "updateState");
+        const manager = new WebviewStateManager(host, panelRoot);
+
+        manager.startPersisting();
+
+        header.classList.add("open");
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(updateState).toHaveBeenCalledWith({ expandedGroupIndexes: [0] });
+    });
+});

--- a/apps/dmn-webview/src/state.ts
+++ b/apps/dmn-webview/src/state.ts
@@ -1,5 +1,10 @@
+/**
+ * Host-adapter surface — `WebviewStateManager` speaks the private Query/Command
+ * protocol and persists panel UI state. Lives in the app, outside the
+ * publishable `@miragon/dmn-modeler` boundary.
+ */
 import { Command, Query, HostApi, PropertiesPanelHandle } from "@miragon/bpmn-modeler-shared";
-import { WebviewState } from "./host";
+import { WebviewState } from "./webviewState";
 
 /**
  * Reads the per-editor properties-panel visibility from persisted state.
@@ -46,7 +51,13 @@ function isGroupOpen(group: HTMLElement): boolean {
  * 2. {@link startPersisting}       — installs the change listeners
  */
 export class WebviewStateManager {
-    constructor(private readonly host: HostApi<WebviewState, Command | Query>) {}
+    constructor(
+        private readonly host: HostApi<WebviewState, Command | Query>,
+        // The properties-panel host element. The scroll container is looked up
+        // within it rather than via `document` so a second modeler's panel on
+        // the same page is never mistaken for this one's.
+        private readonly panelRoot: HTMLElement,
+    ) {}
 
     /**
      * Restores the properties-panel UI state (expanded groups + scroll) in a
@@ -66,7 +77,7 @@ export class WebviewStateManager {
             return;
         }
         requestAnimationFrame(() => {
-            const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
+            const container = this.panelRoot.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
             if (!container) {
                 return;
             }
@@ -133,7 +144,7 @@ export class WebviewStateManager {
      * Wires a debounced scroll listener on the properties panel.
      */
     private subscribePanelScroll(): void {
-        const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
+        const container = this.panelRoot.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
         if (!container) {
             return;
         }
@@ -157,7 +168,7 @@ export class WebviewStateManager {
      * changes elsewhere in the panel subtree (input focus, hover, etc.).
      */
     private subscribeGroupExpansion(): void {
-        const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
+        const container = this.panelRoot.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
         if (!container) {
             return;
         }

--- a/apps/dmn-webview/src/webviewState.ts
+++ b/apps/dmn-webview/src/webviewState.ts
@@ -1,0 +1,24 @@
+/**
+ * @internal Host-adapter surface — persisted webview UI state shapes consumed by
+ * `WebviewStateManager`. Not part of the public modeler API.
+ */
+
+/**
+ * Shape of the data persisted via `host.setState` / `host.getState`.
+ */
+export interface WebviewState {
+    // Scroll position of `.bio-properties-panel-scroll-container`.
+    panelScroll?: number;
+    /**
+     * Indexes (in render order) of `.bio-properties-panel-group` elements
+     * that are currently expanded.  Keyed by position so it survives a
+     * language switch — group labels are localised, indexes are not.
+     */
+    expandedGroupIndexes?: number[];
+    /**
+     * Per-editor properties-panel visibility. Absent until the user first
+     * toggles the panel in this editor; while absent the editor follows the
+     * host's global default (`dmnPropertiesPanelVisible`). Present entry wins.
+     */
+    panelVisible?: boolean;
+}

--- a/docs/adr/0024-extract-publishable-dmn-modeler-package.md
+++ b/docs/adr/0024-extract-publishable-dmn-modeler-package.md
@@ -64,6 +64,8 @@ Two decisions specific to this step:
   that BPMN uses) → issue #1462.
 - **The thin-adapter rewire** of `apps/dmn-webview/src/app/` (host.ts / state.ts
   still speak the protocol under a temporary eslint exemption) → issue #1463.
+  → landed with #1463: `src/app/` is flattened to `src/`, the eslint exemption
+  is gone, and the adapter root mirrors `apps/bpmn-webview/src`.
 - **The subpath release line and parameterised publish workflow** (the DMN
   release component, its own ADR) → issue #1466 / ADR 0025.
 

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -159,18 +159,19 @@ module.exports = [
         },
     },
     // Protocol-boundary guardrail (BND-PROTOCOL-PRIVATE): the publishable
-    // libraries and the remaining webview `app/` feature layer (dmn, #1293 /
-    // #1371) may import the public `@miragon/bpmn-modeler-types` package, but
+    // libraries may import the public `@miragon/bpmn-modeler-types` package, but
     // never the private `@miragon/bpmn-modeler-shared` protocol package
     // (Query/Command bases, `HostApi`, document-flush plumbing). The types
     // package itself is included so it can never depend on the protocol side,
     // keeping the split acyclic.
     //
-    // The bpmn-webview adapter root (`apps/bpmn-webview/src/**`) is deliberately
-    // absent: #1377 made it a thin host layer that speaks the protocol by
-    // design. AC3 (protocol types reach only the adapter + hosts) is carried by
-    // the rule's libs/packages coverage plus `packages/bpmn-modeler/src/
-    // architecture.spec.ts`, which forbids the package from naming the protocol.
+    // The webview adapter roots (`apps/bpmn-webview/src/**`, #1377;
+    // `apps/dmn-webview/src/**`, #1463) are deliberately absent: they are thin
+    // host layers that speak the protocol by design. AC3 (protocol types reach
+    // only the adapter + hosts) is carried by the rule's libs/packages coverage
+    // plus `packages/bpmn-modeler/src/architecture.spec.ts` and
+    // `packages/dmn-modeler/src/architecture.spec.ts`, which forbid each package
+    // from naming the protocol.
     {
         files: [
             "libs/modeler-types/**",
@@ -184,11 +185,7 @@ module.exports = [
             "libs/flow-navigation/**",
             "packages/bpmn-modeler/**",
             "packages/dmn-modeler/**",
-            "apps/dmn-webview/src/app/**",
         ],
-        // Host-adapter layer inside dmn `app/` still speaks the protocol; it is
-        // relocated out of the publishable boundary in a follow-up. Exempt until then.
-        ignores: ["apps/dmn-webview/src/app/host.ts", "apps/dmn-webview/src/app/state.ts"],
         rules: {
             // This block wins `no-restricted-imports` for its files (ESLint flat
             // config replaces, not merges, a rule's options on the last match), so

--- a/libs/shared/src/lib/documentFlush.ts
+++ b/libs/shared/src/lib/documentFlush.ts
@@ -8,9 +8,7 @@ import {
  * The webview-side capabilities the flush responder drives, named in domain
  * terms so every modeler webview can supply them without the
  * responder importing either modeler. Kept as a tiny port so the responder is
- * unit-testable from the `shared` vitest project — the DMN webview has no
- * vitest project of its own, so covering the shared responder is how the DMN
- * flush path gets tested at all.
+ * unit-testable from the `shared` vitest project independently of either webview.
  */
 export interface FlushSource {
     /** Whether the modeler has finished bootstrapping (`modelerIsInitialized`). */


### PR DESCRIPTION
## Issue

Closes #1463 (epic #1467).

## Description

Flattens `apps/dmn-webview/src/app/{host,state}.ts` into `src/`, moves `WebviewState` to `src/webviewState.ts`, deletes the `src/app` barrel, and imports `createModeler` straight from `@miragon/dmn-modeler`, so the adapter root mirrors `apps/bpmn-webview` and the `BND-PROTOCOL-PRIVATE` eslint block drops the dmn `app/**` entry and its per-file exemptions. `bootstrap(host, opts?)` gains a `theme?` / `locale?` seam so a host without a settings reply (the demo) can seed the initial mode and language, and `WebviewStateManager` now scopes panel lookups to the properties-panel element instead of `document`, matching the bpmn manager. Adds `state.spec.ts` against `MockHostApi`, extends `bootstrap.spec.ts` for the new seam and panel scoping, corrects the stale `documentFlush.ts` note about the DMN webview lacking a vitest project, and marks the thin-adapter follow-up as landed in ADR 0024.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A) — `apps/dmn-webview/src/state.spec.ts` (new), `bootstrap.spec.ts` extended
- [x] Docs (or N/A) — `apps/dmn-webview/README.md`, ADR 0024 follow-up note
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A) — executes ADR 0024, no new decision
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A) — staged bundle contract unchanged (`index.js`/`index.css`); F5 open/edit/save/flush-on-close not yet re-verified manually
