### PR TITLE
chore(dmn-modeler): add the npm publishing pipeline and release line

### DIFF
--- a/.github/workflows/publish-npm-modeler.yml
+++ b/.github/workflows/publish-npm-modeler.yml
@@ -1,11 +1,14 @@
 name: Publish npm Modeler
 
-# Builds, smoke-tests and publishes @miragon/bpmn-modeler to the npm registry.
+# Builds, smoke-tests and publishes a modeler package (@miragon/bpmn-modeler or
+# @miragon/dmn-modeler) to the npm registry. The workspace, package directory
+# and any extra smoke-test dependencies are inputs, so one workflow drives both
+# release lines.
 # workflow_dispatch is DRY-RUN ONLY: npm Trusted Publishing validates the
 # top-level caller workflow filename, so a real publish only happens through
 # release-please.yml. A manual dispatch here still runs build + pack + smoke +
 # `npm publish --dry-run` to validate the pipeline; to re-run a failed real
-# publish, re-run the `npm` job on the release-please.yml run instead.
+# publish, re-run the fan-out job on the release-please.yml run instead.
 
 on:
   workflow_dispatch:
@@ -20,6 +23,21 @@ on:
         required: false
         type: boolean
         default: true
+      workspace:
+        description: 'Yarn workspace to publish (e.g. @miragon/bpmn-modeler).'
+        required: false
+        type: string
+        default: '@miragon/bpmn-modeler'
+      package-dir:
+        description: 'Package directory (e.g. packages/bpmn-modeler).'
+        required: false
+        type: string
+        default: packages/bpmn-modeler
+      smoke-extra-deps:
+        description: 'Extra scratch-project deps for the smoke test (space-separated, e.g. jsdom).'
+        required: false
+        type: string
+        default: ''
   workflow_call:
     inputs:
       tag:
@@ -32,6 +50,21 @@ on:
         required: false
         type: boolean
         default: true
+      workspace:
+        description: 'Yarn workspace to publish (e.g. @miragon/bpmn-modeler).'
+        required: false
+        type: string
+        default: '@miragon/bpmn-modeler'
+      package-dir:
+        description: 'Package directory (e.g. packages/bpmn-modeler).'
+        required: false
+        type: string
+        default: packages/bpmn-modeler
+      smoke-extra-deps:
+        description: 'Extra scratch-project deps for the smoke test (space-separated, e.g. jsdom).'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -40,7 +73,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: bpmn-modeler-npm-publish
+  # Per-package group so bpmn and dmn publishes don't serialize against each other.
+  group: npm-publish-${{ inputs.package-dir }}
   cancel-in-progress: false
 
 jobs:
@@ -78,32 +112,40 @@ jobs:
           cache: yarn
           registry-url: 'https://registry.npmjs.org'
 
+      # Slug derived from the workspace (@miragon/bpmn-modeler -> miragon-bpmn-modeler),
+      # used for the tarball filename and the artifact name.
+      - name: Resolve package metadata
+        id: meta
+        run: |
+          SLUG=$(printf '%s' "${{ inputs.workspace }}" | tr -d '@' | tr '/' '-')
+          echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
+
       - name: Install dependencies (focused)
-        run: yarn workspaces focus @miragon/bpmn-modeler
+        run: yarn workspaces focus ${{ inputs.workspace }}
 
       - name: Resolve version
         id: version
         run: |
-          VERSION=$(node -e "console.log(require('./packages/bpmn-modeler/package.json').version)")
+          VERSION=$(node -e "console.log(require('./${{ inputs.package-dir }}/package.json').version)")
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       # Full package build: tsc typecheck + Vite lib + theme CSS + the check-dts,
-      # check-diff-node and dep-alignment (yarn constraints) gates.
+      # externals and dep-alignment (yarn constraints) gates.
       - name: Build
-        run: yarn workspace @miragon/bpmn-modeler build
+        run: yarn workspace ${{ inputs.workspace }} build
 
       - name: Pack tarball
-        run: yarn workspace @miragon/bpmn-modeler pack --out "$RUNNER_TEMP/miragon-bpmn-modeler.tgz"
+        run: yarn workspace ${{ inputs.workspace }} pack --out "$RUNNER_TEMP/${{ steps.meta.outputs.slug }}.tgz"
 
       - name: Scratch-consumer smoke test
         run: |
           SCRATCH="$RUNNER_TEMP/smoke"
           mkdir -p "$SCRATCH"
-          cp packages/bpmn-modeler/scripts/smoke-consumer.mjs "$SCRATCH/smoke-consumer.mjs"
+          cp ${{ inputs.package-dir }}/scripts/smoke-consumer.mjs "$SCRATCH/smoke-consumer.mjs"
           cd "$SCRATCH"
           npm init -y >/dev/null
           npm pkg set type=module
-          npm install "$RUNNER_TEMP/miragon-bpmn-modeler.tgz" --no-audit --no-fund
+          npm install "$RUNNER_TEMP/${{ steps.meta.outputs.slug }}.tgz" ${{ inputs.smoke-extra-deps }} --no-audit --no-fund
           node smoke-consumer.mjs
 
       # Trusted Publishing needs npm >= 11.5.1; Node 22 ships npm 10.
@@ -113,28 +155,28 @@ jobs:
       - name: Skip if version already published
         id: published
         run: |
-          if npm view "@miragon/bpmn-modeler@${{ steps.version.outputs.version }}" version >/dev/null 2>&1; then
+          if npm view "${{ inputs.workspace }}@${{ steps.version.outputs.version }}" version >/dev/null 2>&1; then
             echo "already=true" >> "$GITHUB_OUTPUT"
-            echo "@miragon/bpmn-modeler@${{ steps.version.outputs.version }} is already on npm — nothing to publish."
+            echo "${{ inputs.workspace }}@${{ steps.version.outputs.version }} is already on npm — nothing to publish."
           else
             echo "already=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish (dry-run)
         if: env.EFFECTIVE_DRY_RUN == 'true'
-        run: npm publish "$RUNNER_TEMP/miragon-bpmn-modeler.tgz" --dry-run --access public
+        run: npm publish "$RUNNER_TEMP/${{ steps.meta.outputs.slug }}.tgz" --dry-run --access public
 
       - name: Upload tarball artifact (dry-run)
         if: env.EFFECTIVE_DRY_RUN == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: miragon-bpmn-modeler-v${{ steps.version.outputs.version }}
-          path: ${{ runner.temp }}/miragon-bpmn-modeler.tgz
+          name: ${{ steps.meta.outputs.slug }}-v${{ steps.version.outputs.version }}
+          path: ${{ runner.temp }}/${{ steps.meta.outputs.slug }}.tgz
           retention-days: 7
 
       - name: Publish to npm
         if: env.EFFECTIVE_DRY_RUN == 'false' && steps.published.outputs.already == 'false'
-        run: npm publish "$RUNNER_TEMP/miragon-bpmn-modeler.tgz" --provenance --access public
+        run: npm publish "$RUNNER_TEMP/${{ steps.meta.outputs.slug }}.tgz" --provenance --access public
 
       # Record a deployment so the repo Environments page shows the npm
       # package's last-published version. The environment auto-creates on first use.
@@ -143,13 +185,14 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
+            const workspace = "${{ inputs.workspace }}";
             const version = "${{ steps.version.outputs.version }}";
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.sha,
               environment: "npm-registry",
-              description: `@miragon/bpmn-modeler v${version}`,
+              description: `${workspace} v${version}`,
               required_contexts: [],
               auto_merge: false,
               production_environment: true,
@@ -159,6 +202,6 @@ jobs:
               repo: context.repo.repo,
               deployment_id: deployment.data.id,
               state: "success",
-              environment_url: "https://www.npmjs.com/package/@miragon/bpmn-modeler",
-              description: `@miragon/bpmn-modeler v${version} published`,
+              environment_url: `https://www.npmjs.com/package/${workspace}`,
+              description: `${workspace} v${version} published`,
             });

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,10 @@
 name: Release Please
 
-# Three release lines (see release-please-config.json): "." (the publishable
+# Four release lines (see release-please-config.json): "." (the publishable
 # @miragon/bpmn-modeler npm package — the root component, so it watches the
-# package plus its inlined libs), "apps/vscode-plugin" (vscode) and
-# "apps/intellij-plugin" (intellij), each with its own Release PR, tag and
+# package plus its inlined libs), "apps/vscode-plugin" (vscode),
+# "apps/intellij-plugin" (intellij) and "packages/dmn-modeler" (the publishable
+# @miragon/dmn-modeler npm package), each with its own Release PR, tag and
 # publish jobs. Root outputs are unprefixed; sub-packages are prefixed by path.
 
 on:
@@ -31,6 +32,8 @@ jobs:
       intellij_tag: ${{ steps.release.outputs['apps/intellij-plugin--tag_name'] }}
       npm_released: ${{ steps.release.outputs.release_created }}
       npm_tag: ${{ steps.release.outputs.tag_name }}
+      dmn_released: ${{ steps.release.outputs['packages/dmn-modeler--release_created'] }}
+      dmn_tag: ${{ steps.release.outputs['packages/dmn-modeler--tag_name'] }}
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
@@ -48,12 +51,12 @@ jobs:
   approve-release:
     name: Approve release publish
     needs: release-please
-    if: needs.release-please.outputs.vscode_released == 'true' || needs.release-please.outputs.intellij_released == 'true' || needs.release-please.outputs.npm_released == 'true'
+    if: needs.release-please.outputs.vscode_released == 'true' || needs.release-please.outputs.intellij_released == 'true' || needs.release-please.outputs.npm_released == 'true' || needs.release-please.outputs.dmn_released == 'true'
     runs-on: ubuntu-latest
     environment: release-approval
     steps:
       - name: Record approval
-        run: echo "Release approved — vscode=${{ needs.release-please.outputs.vscode_tag }} intellij=${{ needs.release-please.outputs.intellij_tag }} npm=${{ needs.release-please.outputs.npm_tag }}"
+        run: echo "Release approved — vscode=${{ needs.release-please.outputs.vscode_tag }} intellij=${{ needs.release-please.outputs.intellij_tag }} npm=${{ needs.release-please.outputs.npm_tag }} dmn=${{ needs.release-please.outputs.dmn_tag }}"
 
   vscode:
     needs: [release-please, approve-release]
@@ -103,4 +106,24 @@ jobs:
     with:
       tag: ${{ needs.release-please.outputs.npm_tag }}
       dry-run: false
+    secrets: inherit
+
+  npm-dmn:
+    needs: [release-please, approve-release]
+    if: needs.release-please.outputs.dmn_released == 'true'
+    # id-token: write is required in BOTH this caller job and the called
+    # workflow for npm Trusted Publishing (OIDC) to mint a provenance token.
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
+    uses: ./.github/workflows/publish-npm-modeler.yml
+    with:
+      tag: ${{ needs.release-please.outputs.dmn_tag }}
+      dry-run: false
+      workspace: '@miragon/dmn-modeler'
+      package-dir: packages/dmn-modeler
+      # jsdom for the headless DOM; esbuild to bundle the consumer entry — the
+      # dmn-js stack has no exports maps and only resolves through a bundler.
+      smoke-extra-deps: jsdom esbuild
     secrets: inherit

--- a/.github/workflows/sync-release-markers.yml
+++ b/.github/workflows/sync-release-markers.yml
@@ -3,25 +3,34 @@ name: Sync release markers
 # release-please routes each commit by its changed file paths, and only the root
 # component can watch multiple paths. The root slot belongs to the publishable
 # @miragon/bpmn-modeler package ("." minus exclude-paths — the package plus the
-# 10 libs it inlines). The two hosts are single-path components that *bundle*
-# sources living outside their own path — a coupling no manifest records. This
-# workflow closes that gap: when a feat/fix lands on a bundled path, it commits
-# ONE marker commit (touching the marker file of every host that bundles the
-# change) whose subject mirrors the triggering PR title, so each host's release
-# line and changelog carry the real change:
+# 10 libs it inlines). The two hosts and the DMN package are single-path
+# components that *bundle* sources living outside their own path — a coupling no
+# manifest records. This workflow closes that gap: when a feat/fix lands on a
+# bundled path, it commits ONE marker commit (touching the marker file of every
+# component that bundles the change) whose subject mirrors the triggering PR
+# title, so each component's release line and changelog carry the real change:
 #
 #   - vscode    (apps/vscode-plugin): ships the four webviews, the standalone
 #               app (versioned in lockstep), libs/modeler-core, libs/shared,
-#               libs/standalone-extension and the npm-package sphere.
+#               libs/standalone-extension and the npm-package sphere. Its
+#               BUNDLED_WEBVIEW marker records bundled webviews into a host.
 #   - intellij  (apps/intellij-plugin): ships the bpmn/deployment webviews,
 #               apps/modeler-bridge, libs/modeler-core, libs/shared and the
 #               npm-package sphere. DMN/form webviews are not bundled.
+#               BUNDLED_WEBVIEW marker, as vscode.
+#   - dmn-modeler (packages/dmn-modeler): the publishable @miragon/dmn-modeler
+#               package inlines libs/modeler-types and libs/bpmn-i18n-extras.
+#               Its BUNDLED_LIBS marker records bundled *libs* into a package
+#               (vs BUNDLED_WEBVIEW's webviews into a host). Unlike the host
+#               markers, this one sits under a trigger path, so the trigger
+#               below negates it to stop a marker commit re-triggering the run.
 #
 # Severity: the marker keeps the triggering title's type (feat → minor,
-# fix → patch on the hosts) but strips a breaking `!` — a package-breaking
-# change is not a host-breaking change; a host a change genuinely breaks must
-# touch that host's own path. chore/docs/refactor shared changes are skipped
-# entirely: they ship with the next host release but are not attributed.
+# fix → patch on the components) but strips a breaking `!` — a package-breaking
+# change is not a component-breaking change; a component a change genuinely
+# breaks must touch that component's own path. chore/docs/refactor shared
+# changes are skipped entirely: they ship with the next release but are not
+# attributed.
 #
 # PRs are squash-merged, so the head commit of a push IS the PR title. Rare
 # multi-commit direct pushes are judged by the head commit's title only (the
@@ -30,8 +39,9 @@ name: Sync release markers
 # Commits go through the GitHub API with the App token so the push re-triggers
 # release-please.yml (a plain GITHUB_TOKEN push would not). The multi-file
 # marker commit uses the Git Data API (trees/commits/refs) because the Contents
-# API is single-file. Neither marker file lives under a trigger path below, so
-# a marker push cannot re-trigger this workflow.
+# API is single-file. The two host markers live outside all trigger paths and
+# the DMN BUNDLED_LIBS marker is negated from its own path, so a marker push
+# cannot re-trigger this workflow.
 #
 # workflow_dispatch is a manual seed/escape hatch: it bypasses the type filter
 # and writes a generic `fix: sync bundled sources` marker for every host whose
@@ -49,6 +59,8 @@ on:
       - 'apps/modeler-bridge/**'
       - 'apps/standalone/**'
       - 'packages/bpmn-modeler/**'
+      - 'packages/dmn-modeler/**'
+      - '!packages/dmn-modeler/BUNDLED_LIBS'
       - 'libs/append-menu/**'
       - 'libs/bpmn-clipboard/**'
       - 'libs/bpmn-diff/**'
@@ -99,12 +111,21 @@ jobs:
           # inlines (vite.config.mts INLINED_LIBS). Bundled by both hosts.
           SPHERE='^packages/bpmn-modeler/|^libs/(append-menu|bpmn-clipboard|bpmn-diff|bpmn-i18n-extras|code-link|element-template-chooser|flow-navigation|inline-scripting|model-navigation|modeler-types)/'
 
-          VSC_RELEVANT="^apps/(bpmn-webview|dmn-webview|form-webview|deployment-webview|standalone)/|^libs/(modeler-core|shared|standalone-extension)/|${SPHERE}"
+          VSC_RELEVANT="^apps/(bpmn-webview|dmn-webview|form-webview|deployment-webview|standalone)/|^libs/(modeler-core|shared|standalone-extension)/|^packages/dmn-modeler/|${SPHERE}"
           IJ_RELEVANT="^apps/(bpmn-webview|deployment-webview|modeler-bridge)/|^libs/(modeler-core|shared)/|${SPHERE}"
           VSC_NATIVE='^apps/vscode-plugin/'
           IJ_NATIVE='^apps/intellij-plugin/'
           VSC_MARKER="apps/vscode-plugin/BUNDLED_WEBVIEW"
           IJ_MARKER="apps/intellij-plugin/BUNDLED_WEBVIEW"
+
+          # The DMN package inlines only libs/modeler-types and
+          # libs/bpmn-i18n-extras; a change to either bumps its release line
+          # via BUNDLED_LIBS. IntelliJ ships no DMN editor, so DMN is not in
+          # IJ_RELEVANT; vscode bundles the DMN webview (which inlines the
+          # package), so packages/dmn-modeler IS in VSC_RELEVANT above.
+          DMN_RELEVANT='^libs/(modeler-types|bpmn-i18n-extras)/'
+          DMN_NATIVE='^packages/dmn-modeler/'
+          DMN_MARKER="packages/dmn-modeler/BUNDLED_LIBS"
 
           SUBJECT=$(gh api "repos/${REPO}/commits/${SHA}" --jq '.commit.message' | head -n1)
 
@@ -164,6 +185,13 @@ jobs:
             echo "[intellij] marker queued."
           else
             echo "[intellij] no marker needed."
+          fi
+          if marker_needed "$DMN_RELEVANT" "$DMN_NATIVE" "$DMN_MARKER"; then
+            FILES_JSON=$(jq -c --arg p "$DMN_MARKER" --arg c "$(marker_content dmn-modeler)" \
+              '. + [{path:$p, mode:"100644", type:"blob", content:$c}]' <<<"$FILES_JSON")
+            echo "[dmn-modeler] marker queued."
+          else
+            echo "[dmn-modeler] no marker needed."
           fi
 
           if [ "$(jq 'length' <<<"$FILES_JSON")" -eq 0 ]; then

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   ".": "0.2.0",
   "apps/vscode-plugin": "1.11.0",
-  "apps/intellij-plugin": "1.7.1"
+  "apps/intellij-plugin": "1.7.1",
+  "packages/dmn-modeler": "0.1.0"
 }

--- a/docs/adr/0028-dmn-modeler-as-subpath-release-component.md
+++ b/docs/adr/0028-dmn-modeler-as-subpath-release-component.md
@@ -1,0 +1,110 @@
+# 0028 — `@miragon/dmn-modeler` as a subpath release component
+
+- Status: accepted
+- Date: 2026-09-08 (epic #1467; issue #1466)
+- Category: cross-cutting
+
+## Context
+
+[ADR 0024](0024-extract-publishable-dmn-modeler-package.md) extracted the
+host-free DMN modeler into a second publishable npm package,
+`@miragon/dmn-modeler` at `packages/dmn-modeler` (0.1.0, with a build and a
+`scripts/smoke-consumer.mjs`). It now needs a release line: a way for
+release-please to version it, tag it, and drive its npm publish — the last open
+sub-issue of the extraction epic.
+
+Two facts about the existing pipeline constrain the shape of that line:
+
+- **Only the root component can watch multiple paths**
+  ([ADR 0014](0014-make-bpmn-modeler-the-root-release-component.md)). That root
+  slot already belongs to `@miragon/bpmn-modeler`, the artifact where semver
+  correctness matters most. All other components are single-path.
+- The DMN package **inlines two private libs** — `libs/modeler-types` and
+  `libs/bpmn-i18n-extras` (a subset of the BPMN package's inlined libs) — into
+  its bundle. A change to either alters the published artifact without touching
+  `packages/dmn-modeler`, exactly the coupling ADR 0014 solved for the hosts
+  with sync markers. ADR 0014's marker mechanism was defined only for hosts
+  bundling webviews; a single-path *package* inlining libs is the same gap,
+  unaddressed.
+
+The existing `publish-npm-modeler.yml` already builds, packs, smoke-tests and
+publishes `@miragon/bpmn-modeler` with npm Trusted Publishing
+([ADR 0009](0009-npm-publishing-pipeline.md)).
+
+## Decision
+
+Add `@miragon/dmn-modeler` as a **fourth, subpath release component** rather than
+a second root — and reuse the existing publish machinery instead of cloning it.
+
+- **Subpath component, not a second root.** `packages/dmn-modeler` is a
+  `release-type: node` component with `include-component-in-tag: true`, giving
+  the tag `dmn-modeler-v<version>` — the same shape as the `vscode`/`intellij`
+  host components. The root slot stays `@miragon/bpmn-modeler` (ADR 0014); a
+  package living in its own directory needs no multi-path watching, so no
+  root-component swap is warranted. `packages/dmn-modeler` is already in the
+  root's `exclude-paths` (landed with #1461), so DMN-package commits never feed
+  the npm line.
+- **`BUNDLED_LIBS` marker for the two inlined libs.** `sync-release-markers.yml`
+  learns a third marker, `packages/dmn-modeler/BUNDLED_LIBS`, bumping the DMN
+  line when `libs/modeler-types` or `libs/bpmn-i18n-extras` changes without a
+  native `packages/dmn-modeler` touch. This extends ADR 0014's marker mechanism
+  from *hosts bundling webviews* (`BUNDLED_WEBVIEW`) to *a package inlining
+  libs* — same title-mirroring, same `!`-stripping, same same-sha idempotence.
+  Unlike the host markers, this one sits under its own trigger path, so the
+  trigger negates `packages/dmn-modeler/BUNDLED_LIBS` to keep a marker commit
+  from re-triggering the workflow.
+- **One parameterised reusable publish workflow, not a clone.**
+  `publish-npm-modeler.yml` gains `workspace`, `package-dir` and
+  `smoke-extra-deps` inputs (defaults target `@miragon/bpmn-modeler`; DMN passes
+  `jsdom esbuild`, which the bpmn smoke does not need). `release-please.yml`
+  gains an `npm-dmn` fan-out job mirroring `npm`. Trusted Publishing binds **per
+  package** on npmjs.com but each package points at the same top-level caller
+  (`release-please.yml`) and the shared `npm-registry` environment. As with
+  bpmn's 0.1.0 (ADR 0009), `@miragon/dmn-modeler@0.1.0` requires a one-time
+  manual bootstrap publish before its trusted publisher can be configured.
+- **The DMN smoke bundles its consumer.** Unlike bpmn-js, the dmn-js stack
+  (`dmn-js`, `dmn-js-shared`, `dmn-js-drd`, …) ships no `exports` maps and uses
+  extensionless deep imports, so it only resolves through a bundler — the way
+  every real consumer and the webview host use it, never bare Node ESM. The
+  smoke therefore bundles a tiny consumer entry with esbuild (hence the extra
+  `esbuild` scratch dep) before importing it, rather than importing the tarball
+  directly. A direct import under `node` would fail on dmn-js internals and
+  prove nothing about real usage.
+
+## Consequences
+
+- The DMN package versions and releases on its own line
+  (`dmn-modeler-v<version>`), independent of the BPMN package's cadence — which
+  is the point of a separate package (ADR 0024). A `feat(dmn-modeler): …`
+  commit opens only `chore(main): release dmn-modeler …`.
+- Lib changes to the two inlined libs now correctly bump the DMN line, so the
+  published artifact never changes without a version bump — the same guarantee
+  ADR 0014 gives the hosts and the BPMN package.
+- A `libs/modeler-types` push produces one marker commit touching all three
+  markers: the BPMN (root) line bumps natively, the vscode host via
+  `BUNDLED_WEBVIEW`, and the DMN line via `BUNDLED_LIBS`; the marker commit
+  itself is excluded from the root line and cannot re-trigger the workflow. The
+  vscode host bundles the DMN webview (which inlines the package), so
+  `packages/dmn-modeler` is in the vscode marker's relevant set; IntelliJ ships
+  no DMN editor, so it is not.
+- One publish workflow now serves both packages. A change to the shared publish
+  logic applies to both at once; the cost is that the workflow reads its target
+  from inputs rather than being self-describing.
+
+## Alternatives considered
+
+- **Clone `publish-npm-modeler.yml` into a DMN-specific workflow.** Rejected:
+  two near-identical workflows drift; the only real differences (workspace,
+  directory, one extra smoke dep) are cleanly expressible as inputs.
+- **A second root component.** Impossible — release-please allows only one root;
+  and a package in its own directory does not need multi-path watching anyway.
+- **A dedicated `npm-registry-dmn` environment.** Rejected: the environment
+  gates approval and records deployments; one shared `npm-registry` environment
+  serves both, and the npm-side trusted publisher is already scoped per package.
+- **Swap the root slot to a broader component.** Rejected: the root belongs to
+  the artifact with the hardest semver requirement (ADR 0014); nothing about DMN
+  changes that.
+
+References [ADR 0009](0009-npm-publishing-pipeline.md),
+[ADR 0014](0014-make-bpmn-modeler-the-root-release-component.md),
+[ADR 0024](0024-extract-publishable-dmn-modeler-package.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ contributor-facing record, not user documentation.
 | [0014](0014-make-bpmn-modeler-the-root-release-component.md) | Make the npm package the root release component; hosts release via sync markers | accepted |
 | [0019](0019-webview-panel-chrome-in-shared.md) | Webview panel chrome (resizer/focus/shortcuts) lives in `libs/shared`; publishable `modeler-types` keeps only `isTextEditingSurface` | accepted |
 | [0020](0020-untagged-documents-first-class-in-hosts.md) | Untagged documents are first-class in the hosts (no stamp-on-open); mode is per-editor webview state seeded by `defaultMode`; engine-neutral new-file scaffold | accepted |
+| [0028](0028-dmn-modeler-as-subpath-release-component.md) | `@miragon/dmn-modeler` as a subpath release component (`dmn-modeler-v<version>`); `BUNDLED_LIBS` marker for its two inlined libs; one parameterised publish workflow | accepted |
 
 ### modeler-core
 

--- a/docs/vscode/contributing/release-process.md
+++ b/docs/vscode/contributing/release-process.md
@@ -6,7 +6,7 @@ version history lives on
 
 ## Overview
 
-The repo ships on **three independent release lines**, so a change to one host
+The repo ships on **four independent release lines**, so a change to one host
 no longer forces a release of the others:
 
 | Line | Tag | Covers | Publishes to |
@@ -14,6 +14,7 @@ no longer forces a release of the others:
 | **`npm`** (path `.`, the root component) | `bpmn-modeler-v<version>` | The publishable `@miragon/bpmn-modeler` package + the 10 libs it inlines | npm registry |
 | **`vscode`** (path `apps/vscode-plugin`) | `vscode-v<version>` | VS Code extension + Open VSX + Standalone desktop app | VS Code Marketplace, Open VSX, GitHub Release (DMG/NSIS/Flatpak) + Homebrew |
 | **`intellij`** (path `apps/intellij-plugin`) | `intellij-v<version>` | IntelliJ plugin | JetBrains Marketplace + `updatePlugins.xml` |
+| **`dmn-modeler`** (path `packages/dmn-modeler`) | `dmn-modeler-v<version>` | The publishable `@miragon/dmn-modeler` package + the two libs it inlines | npm registry |
 
 VS Code, Open VSX and Standalone stay on **one** shared version because they are
 all built from the same frontend (`libs/shared`, the webviews). IntelliJ is a
@@ -46,9 +47,10 @@ the sources they bundle from elsewhere
 
 | Line | Natively watched paths | Bundled sources (marker-covered) | Marker file |
 |---|---|---|---|
-| **npm** (root `.`) | `packages/*`, the 10 inlined libs + remaining root files | — | — |
-| **vscode** (`apps/vscode-plugin`) | `apps/vscode-plugin` only | the four webviews, `apps/standalone`, `libs/modeler-core`, `libs/shared`, `libs/standalone-extension`, the npm-package sphere | `apps/vscode-plugin/BUNDLED_WEBVIEW` |
+| **npm** (root `.`) | `packages/bpmn-modeler`, the 10 inlined libs + remaining root files | — | — |
+| **vscode** (`apps/vscode-plugin`) | `apps/vscode-plugin` only | the four webviews, `apps/standalone`, `libs/modeler-core`, `libs/shared`, `libs/standalone-extension`, `packages/dmn-modeler`, the npm-package sphere | `apps/vscode-plugin/BUNDLED_WEBVIEW` |
 | **intellij** (`apps/intellij-plugin`) | `apps/intellij-plugin` only | `apps/bpmn-webview`, `apps/deployment-webview`, `apps/modeler-bridge`, `libs/modeler-core`, `libs/shared`, the npm-package sphere | `apps/intellij-plugin/BUNDLED_WEBVIEW` |
+| **dmn-modeler** (`packages/dmn-modeler`) | `packages/dmn-modeler` only | `libs/modeler-types`, `libs/bpmn-i18n-extras` | `packages/dmn-modeler/BUNDLED_LIBS` |
 
 The 10 inlined libs (with `packages/bpmn-modeler`, the "npm-package sphere" —
 see `INLINED_LIBS` in `packages/bpmn-modeler/vite.config.mts`):
@@ -70,9 +72,13 @@ npm release line.
 ### Sync markers
 
 [`sync-release-markers.yml`](https://github.com/Miragon/bpmn-modeler/blob/main/.github/workflows/sync-release-markers.yml)
-maintains the two host markers. When a `feat`/`fix` lands on a bundled path, it
-commits **one marker commit** — touching the marker file of every host that
-bundles the change — whose subject mirrors the triggering PR title, e.g.
+maintains three markers: the two host `BUNDLED_WEBVIEW` markers and the
+`dmn-modeler` line's `BUNDLED_LIBS` marker (bundled *libs* into a package, vs
+`BUNDLED_WEBVIEW`'s webviews into a host — the DMN package inlines
+`libs/modeler-types` and `libs/bpmn-i18n-extras`). When a `feat`/`fix` lands on
+a bundled path, it commits **one marker commit** — touching the marker file of
+every component that bundles the change — whose subject mirrors the triggering
+PR title, e.g.
 `fix(append-menu): restore flat menu entries … (#1428) [sync d512d6c]`. That
 routes the real change, under its real title, into each host's release line and
 changelog. Key properties:
@@ -90,17 +96,18 @@ changelog. Key properties:
   next host release but get no changelog line. Deliberate noise/value cut.
 - **A host is left out of the marker commit when the push already routes
   natively** (it touched the host's own directory), so no double-bump.
-- Neither marker file sits under a workflow trigger path, so a marker push
-  cannot cascade into more markers.
+- No marker push can cascade into more markers: the two host markers sit
+  outside all trigger paths, and the DMN `BUNDLED_LIBS` marker is negated from
+  its own `packages/dmn-modeler/**` trigger path.
 - **Re-run red `Sync release markers` runs.** The ref update is
   fast-forward-only, so a run that races a concurrent push (or hits an API
   hiccup) fails without writing its marker — that `feat`/`fix` stays
   unattributed until the run is re-run. Re-running is safe: the same-sha guard
   makes it a no-op if the marker already landed.
 - **`workflow_dispatch`** is a manual seed/escape hatch: it bypasses the type
-  filter and writes a generic `fix: sync bundled sources` marker for every host
-  whose marker isn't already at `HEAD` (used once when this routing was
-  adopted).
+  filter and writes a generic `fix: sync bundled sources` marker for every
+  component whose marker isn't already at `HEAD` (used once when this routing
+  was adopted).
 
 ### Signalling severity
 
@@ -129,34 +136,39 @@ flowchart LR
     pr_v{{vscode Release PR}}
     pr_i{{intellij Release PR}}
     pr_n{{npm Release PR}}
+    pr_d{{dmn-modeler Release PR}}
     tag_v[(vscode-v&lt;version&gt; tag<br/>+ Release)]
     tag_i[(intellij-v&lt;version&gt; tag<br/>+ Release)]
     tag_n[(bpmn-modeler-v&lt;version&gt; tag<br/>+ Release)]
+    tag_d[(dmn-modeler-v&lt;version&gt; tag<br/>+ Release)]
 
     commits --> rp
     commits --> sync --> commits
     rp --> pr_v -->|merge| tag_v
     rp --> pr_i -->|merge| tag_i
     rp --> pr_n -->|merge| tag_n
+    rp --> pr_d -->|merge| tag_d
 
     tag_v --> p_vscode[publish-vscode-modeler.yml]
     tag_v --> p_ovsx[publish-open-vsx-modeler.yml]
     tag_v --> p_standalone[release-standalone.yml<br/>→ publish-standalone → homebrew]
     tag_i --> p_intellij[publish-intellij.yml]
-    tag_n --> p_npm[publish-npm-modeler.yml]
+    tag_n --> p_npm[publish-npm-modeler.yml<br/>npm job]
+    tag_d --> p_npm_dmn[publish-npm-modeler.yml<br/>npm-dmn job]
 
     p_vscode --> a_vscode[(VS Code Marketplace)]
     p_ovsx --> a_ovsx[(Open VSX)]
     p_standalone --> a_standalone[(DMG / NSIS / Flatpak + Homebrew)]
     p_intellij --> a_intellij[(updatePlugins.xml + ZIP)]
     p_npm --> a_npm[(npm registry)]
+    p_npm_dmn --> a_npm
 ```
 
 ## Configuration
 
 release-please is driven by two checked-in files:
 
-- **`release-please-config.json`** — three packages, `separate-pull-requests: true`:
+- **`release-please-config.json`** — four packages, `separate-pull-requests: true`:
   - `"."` — `release-type: node`, `component: bpmn-modeler`,
     `include-component-in-tag: true` → tag `bpmn-modeler-v<version>`. The root
     catch-all: `exclude-paths` removes `apps`, `docs`, `.github` and the
@@ -173,11 +185,17 @@ release-please is driven by two checked-in files:
     `include-component-in-tag: true` → tag `intellij-v<version>`. Its `extra-files`
     stamp `gradle.properties` (`pluginVersion`) via the `generic` updater,
     anchored by the `# x-release-please-start-version` markers.
+  - `"packages/dmn-modeler"` — `release-type: node`, `component: dmn-modeler`,
+    `include-component-in-tag: true` → tag `dmn-modeler-v<version>`. It lives in
+    its own directory, so no `changelog-path`/`extra-files` are needed — the
+    default `packages/dmn-modeler/{package.json,CHANGELOG.md}` handling applies.
+    (`packages/dmn-modeler` is already in the root's `exclude-paths`, so a
+    DMN-package change never feeds the npm line.)
   - `changelog-sections` map commit **types** (`feat`/`fix`/`refactor`/`docs`/
     `chore`) to changelog headings.
 - **`.release-please-manifest.json`** — `{ ".": "…", "apps/vscode-plugin": "…",
-  "apps/intellij-plugin": "…" }`, the current version of each line.
-  release-please updates these on each release.
+  "apps/intellij-plugin": "…", "packages/dmn-modeler": "…" }`, the current
+  version of each line. release-please updates these on each release.
 
 ## Releasing
 
@@ -200,20 +218,26 @@ Merging a Release PR fans out via `release-please.yml`:
 |---|---|---|
 | `vscode` | `publish-vscode-modeler.yml`, `publish-open-vsx-modeler.yml`, `release-standalone.yml` | Marketplace + Open VSX + DMG/NSIS/Flatpak + Homebrew. |
 | `intellij` | `publish-intellij.yml` | Multi-platform ZIP → JetBrains Marketplace, refreshes `docs/public/updatePlugins.xml`. |
-| `npm` | `publish-npm-modeler.yml` | Builds + packs + smoke-tests, then `npm publish --provenance` to the npm registry via Trusted Publishing (OIDC). |
+| `npm` | `publish-npm-modeler.yml` (`npm` job) | Builds + packs + smoke-tests, then `npm publish --provenance` to the npm registry via Trusted Publishing (OIDC). |
+| `dmn-modeler` | `publish-npm-modeler.yml` (`npm-dmn` job) | Same workflow, parameterised for `@miragon/dmn-modeler` (`workspace`/`package-dir`/`smoke-extra-deps: jsdom esbuild` inputs); publishes to npm via Trusted Publishing. |
 
 Each `publish-*` workflow is also runnable on its own via `workflow_dispatch`
 (pass the line's tag, e.g. `tag: vscode-v1.4.0` / `tag: intellij-v1.4.0`) with a
 `dry-run` option for reruns.
 
-> **`publish-npm-modeler.yml` dispatch is dry-run-only.** npm Trusted Publishing
-> validates the **top-level caller** workflow filename, and the trusted publisher
-> is configured for `release-please.yml`. A manual `workflow_dispatch` of the npm
-> workflow therefore always runs as a dry-run (build + pack + smoke +
-> `npm publish --dry-run`), even if you set `dry-run: false`. To re-run a failed
-> **real** publish, re-run the `npm` job on the triggering `release-please.yml`
-> run — not the standalone workflow. The publish step is idempotent: it skips if
-> the version is already on npm.
+> **`publish-npm-modeler.yml` dispatch is dry-run-only.** The one workflow
+> serves both npm packages — dispatch it with the `workspace` /`package-dir` /
+> `smoke-extra-deps` inputs (defaults target `@miragon/bpmn-modeler`; pass
+> `@miragon/dmn-modeler` + `packages/dmn-modeler` + `jsdom esbuild` for the DMN
+> package — the DMN smoke bundles its consumer, since the dmn-js stack only
+> resolves through a bundler). npm Trusted Publishing validates the **top-level caller** workflow
+> filename, and the trusted publisher is configured for `release-please.yml`. A
+> manual `workflow_dispatch` of the npm workflow therefore always runs as a
+> dry-run (build + pack + smoke + `npm publish --dry-run`), even if you set
+> `dry-run: false`. To re-run a failed **real** publish, re-run the `npm` (or
+> `npm-dmn`) job on the triggering `release-please.yml` run — not the standalone
+> workflow. The publish step is idempotent: it skips if the version is already
+> on npm.
 
 > The `@miragon/create-append-c7` polyfill that the BPMN webview depends on
 > lives in its [own repository](https://github.com/Miragon/create-append-c7)
@@ -230,7 +254,8 @@ environment:
 | VS Code | `vscode-marketplace` |
 | IntelliJ | `jetbrains-marketplace` |
 | Standalone | `standalone` |
-| npm package | `npm-registry` |
+| npm package (`@miragon/bpmn-modeler`) | `npm-registry` |
+| DMN npm package (`@miragon/dmn-modeler`) | `npm-registry` (shared) |
 
 The repo
 [Environments / Deployments page](https://github.com/Miragon/bpmn-modeler/deployments)
@@ -256,26 +281,31 @@ then shows the last-published version per host.
   manual, so the bundle is not mirrored to `standalone-latest`. The docs download
   page resolves the most recent release that carries an arm64 DMG, independent
   of the tag scheme.
-- **npm package** → the [`@miragon/bpmn-modeler`](https://www.npmjs.com/package/@miragon/bpmn-modeler)
-  npm registry entry, published with provenance. Each release publishes the
+- **npm packages** → the [`@miragon/bpmn-modeler`](https://www.npmjs.com/package/@miragon/bpmn-modeler)
+  and [`@miragon/dmn-modeler`](https://www.npmjs.com/package/@miragon/dmn-modeler)
+  npm registry entries, published with provenance. Each release publishes the
   yarn-packed tarball with the npm CLI (`npm publish <tarball> --provenance`);
   yarn `pack` rewrites the `workspace:*` ranges to real versions first.
 
 ## npm Trusted Publishing (one-time setup)
 
-The npm line uses **Trusted Publishing (OIDC)** — no long-lived npm token lives
+Both npm lines use **Trusted Publishing (OIDC)** — no long-lived npm token lives
 in CI. npm only lets you configure a trusted publisher *after* the package
-exists, so the first `0.1.0` release was a one-time manual bootstrap publish
-(build → `yarn workspace @miragon/bpmn-modeler pack` → `npm publish <tarball>
---access public` with a short-lived granular token, then the token was revoked).
-Every release since publishes over OIDC.
+exists, so each package's first `0.1.0` release is a one-time manual bootstrap
+publish (build → `yarn workspace <workspace> pack` → `npm publish <tarball>
+--access public` with a short-lived granular token, then the token is revoked).
+`@miragon/dmn-modeler@0.1.0` needs the same bootstrap before its trusted
+publisher can be configured. Every release since publishes over OIDC.
 
-Two constraints follow from how npm scopes the trusted publisher:
+The trusted publisher is configured **per package** on npmjs.com, but each one
+points at the **same** caller workflow (`release-please.yml`) and the shared
+`npm-registry` GitHub environment. Two constraints follow from how npm scopes it:
 
 - The trusted publisher is bound to the **top-level caller workflow**
   (`release-please.yml`) and the `npm-registry` GitHub environment, so
   `publish-npm-modeler.yml` must stay called from `release-please.yml` to
-  publish for real (see the dispatch-is-dry-run-only note above).
-- `id-token: write` is required in **both** the `npm` caller job in
+  publish for real (see the dispatch-is-dry-run-only note above). This holds for
+  both the `npm` and `npm-dmn` fan-out jobs.
+- `id-token: write` is required in **both** the caller job (`npm` / `npm-dmn`) in
   `release-please.yml` and `publish-npm-modeler.yml` itself, and npm ≥ 11.5.1
   (the workflow upgrades npm, since Node 22 ships npm 10).

--- a/packages/dmn-modeler/scripts/smoke-consumer.mjs
+++ b/packages/dmn-modeler/scripts/smoke-consumer.mjs
@@ -2,17 +2,26 @@
 // like a real dependency, not just that it builds in-repo.
 //
 // Runs from a throwaway project (`npm init -y`, `type: module`,
-// `npm install <tarball> jsdom`) where `@miragon/dmn-modeler` resolves through
-// node_modules — the same path an out-of-repo consumer takes. It asserts:
+// `npm install <tarball> jsdom esbuild`) where `@miragon/dmn-modeler` resolves
+// through node_modules — the same path an out-of-repo consumer takes. It asserts:
 //   1. no `workspace:*` range survived the pack (yarn rewrites them to real
 //      versions; a survivor would `npm install`-fail for a real consumer);
 //   2. every `exports` subpath resolves to a file that exists;
-//   3. the package imports under jsdom and `createModeler` + `loadDiagram` of a
-//      minimal DMN succeeds. If dmn-js cannot run under jsdom in the scratch app
-//      this degrades to import-only and says so.
+//   3. the package + its externalised dmn-js stack **bundle** and import, and
+//      `createModeler` + `loadDiagram` of a minimal DMN succeeds.
+//
+// Step 3 goes through esbuild on purpose. The dmn-js stack (dmn-js,
+// dmn-js-shared, dmn-js-drd, …) ships no `exports` maps and uses extensionless
+// deep imports, so it does not resolve under Node's native ESM resolver — only
+// through a bundler, which is how every real consumer (Vite/webpack/esbuild)
+// and the webview host use it. We therefore bundle a tiny consumer entry the
+// same way, then run it. A direct `import("@miragon/dmn-modeler")` under bare
+// `node` would fail on dmn-js internals and prove nothing about real usage.
+// If dmn-js cannot render under jsdom in the scratch app this degrades to
+// import-only and says so.
 import { createRequire } from "node:module";
 import { existsSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const PKG = "@miragon/dmn-modeler";
 const require = createRequire(import.meta.url);
@@ -52,8 +61,11 @@ for (const subpath of SUBPATHS) {
     }
 }
 
-// 3. Import under jsdom and stand up a modeler. A minimal DRD with one decision
-//    table, mirroring the sample the webview host uses for standalone runs.
+// 3. Bundle a consumer entry with esbuild (resolving the dmn-js stack a real
+//    bundler would), then import the bundle and stand up a modeler. CSS/font
+//    assets the stack imports are dropped — the smoke exercises behaviour, not
+//    styling. A minimal DRD with one decision table, mirroring the sample the
+//    webview host uses for standalone runs.
 const MINIMAL_DMN = `<?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="smoke" name="Smoke" namespace="http://camunda.org/schema/1.0/dmn">
   <decision id="decision_1" name="Decision 1">
@@ -69,17 +81,72 @@ const MINIMAL_DMN = `<?xml version="1.0" encoding="UTF-8"?>
   </dmndi:DMNDI>
 </definitions>`;
 
+const { build } = await import("esbuild");
+const bundlePath = fileURLToPath(
+    new URL("./dmn-modeler.smoke-bundle.mjs", pathToFileURL(`${process.cwd()}/`)),
+);
+try {
+    await build({
+        stdin: {
+            contents: `export { createModeler } from "${PKG}";`,
+            resolveDir: process.cwd(),
+            loader: "js",
+        },
+        bundle: true,
+        format: "esm",
+        platform: "node",
+        loader: {
+            ".css": "empty",
+            ".svg": "empty",
+            ".eot": "empty",
+            ".woff": "empty",
+            ".woff2": "empty",
+            ".ttf": "empty",
+        },
+        outfile: bundlePath,
+        logLevel: "silent",
+    });
+} catch (error) {
+    fail(`bundling a consumer of "${PKG}" failed: ${error.message}`);
+}
+
 const { JSDOM } = await import("jsdom");
 const dom = new JSDOM(`<!doctype html><html><body></body></html>`, { pretendToBeVisual: true });
+// jsdom implements none of these; a real browser (every actual consumer's
+// environment) does. Stub them so the theme code, diagram-js layout and the
+// properties panel's rAF-scheduled render run headless.
+dom.window.matchMedia ??= (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+        return false;
+    },
+});
+dom.window.requestAnimationFrame ??= (cb) => setTimeout(() => cb(Date.now()), 0);
+dom.window.cancelAnimationFrame ??= (id) => clearTimeout(id);
+dom.window.SVGElement.prototype.getBBox ??= () => ({ x: 0, y: 0, width: 0, height: 0 });
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame;
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame;
+// defineProperty, not assignment: Node >=21 ships `navigator` as a getter-only
+// global, so `globalThis.navigator = …` throws.
 for (const key of ["window", "document", "navigator", "HTMLElement", "Node", "SVGElement"]) {
-    globalThis[key] = dom.window[key];
+    Object.defineProperty(globalThis, key, {
+        value: dom.window[key],
+        configurable: true,
+        writable: true,
+    });
 }
 
 let mod;
 try {
-    mod = await import(PKG);
+    mod = await import(pathToFileURL(bundlePath));
 } catch (error) {
-    fail(`import("${PKG}") threw: ${error.message}`);
+    fail(`import of the bundled "${PKG}" threw: ${error.message}`);
 }
 if (typeof mod.createModeler !== "function") {
     fail(`${PKG} does not export createModeler`);
@@ -95,12 +162,16 @@ try {
     if (!xml.includes("decision_1")) fail("exportDiagram did not round-trip the decision");
     modeler.destroy();
     console.log(
-        `smoke-consumer: installed ${PKG}@${installedManifest.version} resolves every subpath ` +
-            `and createModeler + loadDiagram round-trips a DMN under jsdom.`,
+        `smoke-consumer: bundled consumer of ${PKG}@${installedManifest.version} resolves ` +
+            `every subpath and createModeler + loadDiagram round-trips a DMN under jsdom.`,
     );
 } catch (error) {
     console.log(
-        `smoke-consumer: installed ${PKG}@${installedManifest.version} resolves every subpath ` +
-            `and imports under jsdom; dmn-js could not run headless (import-only smoke): ${error.message}`,
+        `smoke-consumer: bundled consumer of ${PKG}@${installedManifest.version} resolves ` +
+            `every subpath and imports; dmn-js could not render headless (import-only smoke): ${error.message}`,
     );
 }
+
+// The headless modeler leaves rAF/timer-scheduled render work pending; exit
+// explicitly so a late headless-only throw can't fail an otherwise-passed smoke.
+process.exit(0);

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -84,6 +84,11 @@
       "component": "intellij",
       "include-component-in-tag": true,
       "extra-files": [{ "type": "generic", "path": "gradle.properties" }]
+    },
+    "packages/dmn-modeler": {
+      "release-type": "node",
+      "component": "dmn-modeler",
+      "include-component-in-tag": true
     }
   }
 }


### PR DESCRIPTION
## Issue

Closes #1466 (part of #1467)

## Description

`packages/dmn-modeler` becomes a fourth release-please line (component `dmn-modeler`, tag `dmn-modeler-v<version>`), with a manifest entry at `0.1.0`. `publish-npm-modeler.yml` is parameterised with `workspace` / `package-dir` / `smoke-extra-deps` inputs so one reusable workflow drives both npm packages, and `release-please.yml` gains `dmn_released`/`dmn_tag` outputs plus an `npm-dmn` fan-out job wired into the `approve-release` gate. `sync-release-markers.yml` writes a `packages/dmn-modeler/BUNDLED_LIBS` marker when `libs/modeler-types` or `libs/bpmn-i18n-extras` change (the ADR 0014 single-path gap), adds `packages/dmn-modeler` to `VSC_RELEVANT`, and negates the marker from its own trigger path to prevent re-triggering. The DMN smoke test now bundles its consumer with esbuild before running it under jsdom, because the dmn-js stack ships no exports maps and only resolves through a bundler. Documented in [ADR 0028](docs/adr/0028-dmn-modeler-as-subpath-release-component.md) and the release-process guide; the one-time `0.1.0` bootstrap publish + Trusted-Publisher setup + `dmn-modeler-v0.1.0` tag remain manual post-merge steps (see #1466).

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [ ] Tests added or updated (N/A — CI/release configuration; validated via workflow dry-runs)
- [x] Docs (release-process guide updated)
- [x] ADR added under `docs/adr/` (0028)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [ ] Verified in the affected hosts — N/A (no host code changed)