### PR TITLE
refactor(bpmn-modeler): trim redundant internal comments

### DIFF
--- a/packages/bpmn-modeler/scripts/check-design-pure-entry.mjs
+++ b/packages/bpmn-modeler/scripts/check-design-pure-entry.mjs
@@ -1,22 +1,4 @@
-// Acceptance criterion for issue #1196, mechanised: the engine-neutral design
-// subpath (`@miragon/bpmn-modeler/design`) must stay free of the Camunda editor
-// stack at the *module-graph* level — in every bundling mode. Single-file hosts
-// (vite-plugin-singlefile) inline everything reachable, so a bare import that
-// survives here would land in the consumer's one bundle.
-//
-// Unlike `/viewer`, the design surface DOES ship the engine-neutral properties
-// panel — so `bpmn-js-properties-panel`, `@bpmn-io/properties-panel`, `preact`,
-// CodeMirror, and `bpmn-js-create-append-anything` are all *allowed*. What must
-// never appear is the Camunda engine stack (camunda-bpmn-js, the C7/C8 moddles
-// and behaviours, transaction boundaries, element templates) and the lint stack.
-// Token simulation is engine-neutral canvas chrome shared by every surface
-// (ADR 0022), so it is allowed.
-//
-// The heavy stacks are Vite `external`s — they survive as *bare import
-// specifiers* in dist/design.js and its relative chunks. So we start at
-// dist/design.js, follow only relative specifiers (the emitted chunks), and fail
-// if any bare specifier names a forbidden package. A content-grep for `bpmnlint`
-// catches an inlined-lib leak too.
+// Single-file bundlers include reachable imports, so the design graph must exclude engine and lint stacks.
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve, relative } from "node:path";
@@ -24,9 +6,6 @@ import { dirname, resolve, relative } from "node:path";
 const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../dist");
 const ROOT_ENTRY = resolve(distDir, "design.js");
 
-// Forbidden bare specifiers — the Camunda engine + lint stacks the design
-// surface must never reach. Matched as a whole package name: `pkg` exactly or
-// `pkg/<subpath>`.
 const FORBIDDEN_PREFIXES = [
     "camunda-bpmn-js",
     "camunda-bpmn-moddle",
@@ -41,18 +20,14 @@ const FORBIDDEN_PREFIXES = [
     "@miragon/bpmnlint-plugin-rules",
 ];
 
-// A last-line content grep (mirrors check-lint-free-entry.mjs): catches the lint
-// stack even if it were inlined into a chunk rather than left external.
+// Catch lint code that was inlined instead of left as an external import.
 const FORBIDDEN_CONTENT = /bpmnlint/;
 
 function isForbidden(spec) {
     return FORBIDDEN_PREFIXES.some((prefix) => spec === prefix || spec.startsWith(`${prefix}/`));
 }
 
-// Static specifiers only: `import … from "x"`, bare `import "x"`, and
-// `export … from "x"`. `import(` (dynamic) is deliberately excluded — a reachable
-// dynamic import is a separate chunk a single-file bundler inlines anyway, so we
-// follow the static closure that decides the critical path.
+// This scan covers static imports and re-exports only; dynamic imports are excluded.
 const STATIC_SPECIFIER_PATTERNS = [
     /\bimport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
     /\bexport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
@@ -90,7 +65,6 @@ while (queue.length > 0) {
 
     for (const spec of staticSpecifiers(code)) {
         if (spec.startsWith(".")) {
-            // Follow our own emitted chunks.
             const resolved = resolve(dirname(file), spec);
             if (existsSync(resolved)) queue.push(resolved);
             continue;

--- a/packages/bpmn-modeler/scripts/check-diff-node.mjs
+++ b/packages/bpmn-modeler/scripts/check-diff-node.mjs
@@ -1,10 +1,4 @@
-// Node smoke test for the `./diff` data-layer entry (#1378).
-//
-// Imports the built `dist/diff.js` under plain Node — no jsdom, no DOM globals —
-// and runs `computeDiff` on two inline XML strings. This mechanises the
-// "browser + Node" acceptance criterion and catches DOM/CSS leakage into the
-// shared Rollup chunks the diff entry pulls in: any such import would throw at
-// module-eval time here, where `window`/`document` do not exist.
+// Plain Node exposes accidental DOM or CSS dependencies in the published diff entry.
 import { computeDiff, sideView } from "../dist/diff.js";
 
 const BEFORE = `<?xml version="1.0" encoding="UTF-8"?>

--- a/packages/bpmn-modeler/scripts/check-lint-free-entry.mjs
+++ b/packages/bpmn-modeler/scripts/check-lint-free-entry.mjs
@@ -1,13 +1,4 @@
-// Acceptance criterion for issue #1407, mechanised: a `linting: false` consumer
-// must have no lint import in its module graph, in every bundling mode. The lint
-// stack now lives behind the `@miragon/bpmn-modeler/lint` subpath and is injected
-// by the host, so nothing the root entry *statically* reaches may name bpmnlint.
-//
-// We start at `dist/index.js` and follow only static import/export specifiers
-// (never `import(...)` — a dynamic import is a separate chunk a single-file
-// bundler inlines, which is the whole failure mode this replaces), collecting the
-// transitive closure of chunks the root entry pulls in unconditionally. If any of
-// them mentions `bpmnlint`, the lint stack leaked back into the critical path.
+// Linting is injected by consumers; the root entry must not statically pull in its stack.
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve, relative } from "node:path";
@@ -16,8 +7,7 @@ const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../dist");
 const ROOT_ENTRY = resolve(distDir, "index.js");
 const FORBIDDEN = /bpmnlint/;
 
-// Static specifiers only: `import … from "x"`, bare `import "x"`, and
-// `export … from "x"`. `import(` (dynamic) is deliberately excluded.
+// This scan covers static imports and re-exports only; dynamic imports are excluded.
 const STATIC_SPECIFIER_PATTERNS = [
     /\bimport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
     /\bexport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,

--- a/packages/bpmn-modeler/scripts/check-mode-pure-entry.mjs
+++ b/packages/bpmn-modeler/scripts/check-mode-pure-entry.mjs
@@ -1,15 +1,4 @@
-// Acceptance criterion for the `@miragon/bpmn-modeler/mode` subpath (#1447),
-// mechanised: the mode-session entry orchestrates the surfaces the *consumer*
-// injects, so it must value-import none of the bpmn-js / Camunda / lint stack —
-// in every bundling mode. A single-file host (vite-plugin-singlefile) inlines
-// everything reachable, so a bare import that survives here would land in a
-// mode-only consumer's one bundle even though they never asked for the editor.
-//
-// The heavy stacks are Vite `external`s — they survive as *bare import
-// specifiers* in dist/mode.js and its relative chunks. So we start at
-// dist/mode.js, follow only relative specifiers (the emitted chunks), and fail
-// if any bare specifier names a forbidden package. A content-grep for `bpmnlint`
-// catches an inlined-lib leak too.
+// Keep injected surface dependencies out of the mode entry, including its emitted chunks.
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve, relative } from "node:path";
@@ -17,10 +6,6 @@ import { dirname, resolve, relative } from "node:path";
 const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../dist");
 const ROOT_ENTRY = resolve(distDir, "mode.js");
 
-// Forbidden bare specifiers — bpmn-js / diagram-js, the Camunda engine stack,
-// the lint stack, the bpmn-io panel primitives, and the engine-bound properties
-// panel. The consumer supplies these through the injected surface factories, so
-// none may reach the mode entry's module graph.
 function isForbidden(spec) {
     return (
         spec === "bpmn-js" ||
@@ -39,14 +24,10 @@ function isForbidden(spec) {
     );
 }
 
-// A last-line content grep (mirrors check-design-pure-entry.mjs): catches the
-// lint stack even if it were inlined into a chunk rather than left external.
+// Catch lint code that was inlined instead of left as an external import.
 const FORBIDDEN_CONTENT = /bpmnlint/;
 
-// Static specifiers only: `import … from "x"`, bare `import "x"`, and
-// `export … from "x"`. `import(` (dynamic) is deliberately excluded — a reachable
-// dynamic import is a separate chunk a single-file bundler inlines anyway, so we
-// follow the static closure that decides the critical path.
+// This scan covers static imports and re-exports only; dynamic imports are excluded.
 const STATIC_SPECIFIER_PATTERNS = [
     /\bimport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
     /\bexport\s+[^;'"]*?\bfrom\s*["']([^"']+)["']/g,
@@ -84,7 +65,6 @@ while (queue.length > 0) {
 
     for (const spec of staticSpecifiers(code)) {
         if (spec.startsWith(".")) {
-            // Follow our own emitted chunks.
             const resolved = resolve(dirname(file), spec);
             if (existsSync(resolved)) queue.push(resolved);
             continue;

--- a/packages/bpmn-modeler/scripts/smoke-consumer.mjs
+++ b/packages/bpmn-modeler/scripts/smoke-consumer.mjs
@@ -1,15 +1,4 @@
-// Scratch-consumer smoke test (issue #1379): proves the *packed* tarball works
-// once installed like a real dependency, not just that it builds in-repo.
-//
-// Runs from a throwaway project (`npm init -y`, `type: module`,
-// `npm install <tarball>`) where `@miragon/bpmn-modeler` resolves through
-// node_modules — the same path an out-of-repo consumer takes. It asserts:
-//   1. no `workspace:*` range survived the pack (yarn rewrites them to real
-//      versions; a survivor would `npm install`-fail for a real consumer);
-//   2. every `exports` subpath resolves to a file that exists (the root entry
-//      is resolved, never executed — it touches the DOM);
-//   3. representative browser consumers bundle without aliases or externals;
-//   4. the Node-safe `./diff` subpath actually runs end to end.
+// Test the installed tarball so workspace aliases cannot hide packaging failures.
 import { createRequire } from "node:module";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -23,7 +12,6 @@ function fail(message) {
     process.exit(1);
 }
 
-// 1. No workspace: range survived the pack.
 const installedManifest = require(`${PKG}/package.json`);
 for (const field of [
     "dependencies",
@@ -38,8 +26,7 @@ for (const field of [
     }
 }
 
-// 2. Every exports subpath resolves to a real file. The root entry is
-//    DOM-touching, so we resolve it (proves the mapping + file) but never import it.
+// Resolve browser entries without importing them: they require the DOM.
 const SUBPATHS = [
     ".",
     "./diff",
@@ -67,9 +54,7 @@ for (const subpath of SUBPATHS) {
     }
 }
 
-// 3. Bundle browser consumers without running their DOM-touching code in Node.
-// Factory calls are intentionally retained: each fixture exercises the actual
-// dependency closure for that public surface and option shape.
+// Retain factory calls so bundling exercises each surface's actual dependency graph.
 if (esbuildVersion !== "0.28.2") {
     fail(`expected esbuild 0.28.2, found ${esbuildVersion}`);
 }
@@ -134,7 +119,6 @@ for (const [name, contents] of Object.entries(BROWSER_FIXTURES)) {
     }
 }
 
-// 4. The Node-safe ./diff subpath runs. Fixtures mirror scripts/check-diff-node.mjs.
 const { computeDiff, sideView } = await import(`${PKG}/diff`);
 
 const BEFORE = `<?xml version="1.0" encoding="UTF-8"?>

--- a/packages/bpmn-modeler/src/bpmnlint/LintConfigService.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/LintConfigService.ts
@@ -9,12 +9,7 @@ import { BrowserLinter } from "./browserLinter";
 import { type LintConfigOption, resolveLintConfig } from "./lintConfigResolution";
 import type { ModelerMode } from "../mode";
 
-/**
- * The subset of `bpmn-js-bpmnlint`'s `linting` module this service drives. The
- * package ships no types, so we declare only the members we touch: `lint` is
- * overridden per tier, and `update`/`isActive`/`toggle` repaint or clear the
- * overlays.
- */
+// bpmn-js-bpmnlint ships no types for this service.
 interface Linting {
     lint: () => Promise<LintResults>;
     update(): void;
@@ -22,22 +17,14 @@ interface Linting {
     toggle(active: boolean): void;
 }
 
-/**
- * The slice of diagram-js's `Canvas` this service needs. The state classes and
- * the vendor pill are scoped to this container (`.djs-container`) rather than
- * `document.body`, so two modelers on one page never toggle each other's lint
- * chrome.
- */
 interface Canvas {
     getContainer(): HTMLElement;
 }
 
-/** The bpmn-js viewer, injected as `bpmnjs`; only its definitions root is read. */
 interface Bpmnjs {
     getDefinitions(): unknown;
 }
 
-/** diagram-js's event bus, injected as `eventBus`; only import completion is observed. */
 interface EventBus {
     on(event: string, callback: (event: unknown) => void): void;
 }
@@ -76,32 +63,12 @@ export interface LintCallbacks {
     onLintingToggled?: (enabled: boolean) => void;
 }
 
-/**
- * The live tier of one modeler instance.
- *
- *  - `external` — results arrive via {@link LintConfigService.applyLintResults};
- *    the webview only paints them (the host runs the linter).
- *  - `in-page` — the webview lints itself via {@link BrowserLinter} on every
- *    relint the vendor schedules.
- *  - `in-page-disabled` — the user turned in-page linting off from the canvas;
- *    overlays are cleared and a re-enable chip is shown, but the tier is
- *    remembered so a re-import does not silently reactivate it.
- *
- * Precedence: any external push wins — it switches an in-page instance to
- * `external` and suspends the in-page run.
- */
+// Remember user-disabled state so re-import cannot silently reactivate linting.
 type LintTierState = "external" | "in-page" | "in-page-disabled";
 
-// A slashed circle, painted in `currentColor` so it inherits the chip's text
-// colour like the vendor lint icon does.
 const OFF_ICON = `<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="6"/><line x1="4" y1="4" x2="12" y2="12"/></svg>`;
 
-/**
- * Vendor `_formatIssues` mutates each report object in place (it writes
- * `report.rule`, `report.isChildIssue`, …). So the object we hand the vendor must
- * not be the one we emitted through `onLintResults`: copy every report first so
- * the emitted {@link LintRunEvent} stays the pristine rule-keyed output.
- */
+// The vendor mutates reports when formatting overlays; clone them to preserve emitted results.
 function shallowCopyResults(results: LintResults): LintResults {
     const copy: LintResults = {};
     for (const [rule, reports] of Object.entries(results)) {
@@ -110,25 +77,7 @@ function shallowCopyResults(results: LintResults): LintResults {
     return copy;
 }
 
-/**
- * bpmn-js DI service (registered by {@link createLintModule}) that owns one
- * modeler's bpmnlint tier and its in-canvas chrome.
- *
- * It drives `bpmn-js-bpmnlint`'s `linting` module by overriding its `lint()` —
- * the module's own `update()` (fired on import, element changes, toggles) then
- * diffs and draws the overlays, so no overlay/rendering code changes across
- * tiers. The override's body depends on the tier: `external` returns the host's
- * last-pushed results; `in-page` runs {@link BrowserLinter} against the live
- * tree and emits the raw result through `onLintResults`; `in-page-disabled`
- * returns nothing so the linter, which the vendor keeps running even while
- * inactive, does no real work.
- *
- * It also owns the in-canvas disable affordance: an "off" button beside the
- * lint summary pill, and a muted "Linting off" chip with an "Enable" action in
- * its place once disabled. In the in-page tier the toggle is applied
- * optimistically (the webview owns the linter); in the external tier it is
- * reported through `onLintingToggled` and the overlays wait for the host's push.
- */
+// Override vendor lint() so every tier reuses its overlay rendering and update lifecycle.
 export class LintConfigService {
     static $inject = [
         "linting",
@@ -142,33 +91,17 @@ export class LintConfigService {
 
     private state: LintTierState;
 
-    // Present once the in-page tier is live; undefined for a purely external
-    // instance. Mutable because the host can hand linting back to the webview
-    // after construction via {@link startInPageLinting}, which lazily builds it —
-    // the constructor only builds it for an up-front in-page tier.
     private browserLinter?: BrowserLinter;
 
-    // Kept from `tierInit` so a later {@link startInPageLinting} or
-    // {@link setMode} can re-resolve the config with the same engine and explicit
-    // option. `engine` is undefined on the engine-neutral Design surface.
     private readonly engine?: Engine;
 
     private readonly explicitConfig?: LintConfigOption;
 
-    // The active design/implement mode. Mutated by {@link setMode}; feeds
-    // `resolveLintConfig` so a per-mode `config` (and the mode default) follows a
-    // live toggle.
     private mode: ModelerMode;
 
-    // The last config a host handed in via {@link startInPageLinting}. A
-    // workspace `.bpmnlintrc` is mode-invariant, so once set it wins over the
-    // resolver on both modes and a {@link setMode} only stores the new mode.
+    // Workspace configuration must remain authoritative across mode changes.
     private hostConfig?: BpmnlintConfig;
 
-    // The config-version token of the last in-page instruction. Used to dedup a
-    // repeat covered instruction, but only while actually `"in-page"`: any
-    // disabled/external push in between leaves this stale, and the state guard
-    // below stops that stale token from dropping a genuine re-enable.
     private lastConfigToken?: string;
 
     private results: LintResults = {};
@@ -196,14 +129,9 @@ export class LintConfigService {
             this.browserLinter = this.buildLinter();
         }
 
-        // One `lint` override for every tier; {@link runLint} branches on state.
-        // The vendor calls it from `update()` on import.done / elements.changed.
         this.linting.lint = () => this.runLint();
 
-        // Registered unconditionally so a post-handback re-import re-activates the
-        // in-page tier too (an external instance can later become in-page via
-        // {@link startInPageLinting}). Guarded on the current state so it never
-        // activates an external instance and never resurrects a user-disabled one.
+        // External instances can later switch to in-page linting, so register this listener in both tiers.
         eventBus.on("import.done", () => {
             if (this.state === "in-page") {
                 this.activateInPage();
@@ -214,24 +142,7 @@ export class LintConfigService {
         }
     }
 
-    /**
-     * Starts (or restarts) the in-page linter on host instruction — the handback
-     * when the host finds no workspace `.bpmnlintrc`. Lazily builds the
-     * {@link BrowserLinter} (the constructor only builds it for an up-front
-     * in-page tier) and activates it if a diagram is already imported;
-     * otherwise the unconditional `import.done` listener activates it.
-     *
-     * No-ops when the user has disabled linting from the canvas — a host
-     * instruction must never silently re-enable a user-disabled linter; the
-     * chip's own click handler owns re-enable. Also no-ops when already in-page
-     * with a duplicate instruction (no new config, or the same `configToken` as
-     * the live run — the host re-sends on panel re-activation and rebuilding the
-     * {@link BrowserLinter} would churn the lint chrome for nothing). The dedup
-     * is gated on `state === "in-page"` so a token left stale by an intervening
-     * disabled/external push can never drop a genuine re-enable. Precedence is
-     * unchanged: {@link applyLintResults}/{@link applyLintingDisabled} still
-     * hard-set `"external"`, so any host push still wins over this.
-     */
+    // Deduplicate only while in-page: an intervening external push makes the previous token stale.
     startInPageLinting(config?: BpmnlintConfig, configToken?: string): void {
         if (this.state === "in-page-disabled") {
             return;
@@ -255,15 +166,6 @@ export class LintConfigService {
         }
     }
 
-    /**
-     * Switches the design/implement mode of the in-page linter. Same-mode calls
-     * are a no-op. A host-handed workspace config is mode-invariant, so when one
-     * is present (or the tier is not currently a live in-page run) only the mode
-     * is stored — a later re-enable/handback resolves with it. Otherwise the
-     * linter is rebuilt against the new mode's resolved config and re-activated,
-     * so its next relint (and `onLintResults`) reflects the new mode — a host's
-     * Problems panel follows the toggle without a separate message.
-     */
     setMode(mode: ModelerMode): void {
         if (mode === this.mode) {
             return;
@@ -277,43 +179,22 @@ export class LintConfigService {
         }
     }
 
-    /**
-     * Builds the {@link BrowserLinter} for the current mode. A host-handed
-     * workspace config (mode-invariant) wins; otherwise the resolver picks the
-     * explicit config, its per-mode entry, or the mode default.
-     */
     private buildLinter(): BrowserLinter {
         return new BrowserLinter(
             this.hostConfig ?? resolveLintConfig(this.mode, this.engine, this.explicitConfig),
         );
     }
 
-    /**
-     * Applies host-pushed results (external tier). Any push wins: an in-page
-     * instance switches to `external` and its in-page run is suspended. `null`
-     * deactivates linting — the no-config experience.
-     */
     applyLintResults(results: LintResults | null): void {
         this.state = "external";
         this.render(results);
     }
 
-    /**
-     * Applies the host's **user-disabled** push (external tier): clears the
-     * overlays and shows the re-enable chip. Switches an in-page instance to
-     * `external` as any push does.
-     */
     applyLintingDisabled(): void {
         this.state = "external";
         this.renderDisabled();
     }
 
-    /**
-     * The tier-dependent body behind the vendor's `lint()`. Only the in-page tier
-     * emits `onLintResults`, and only it returns freshly copied reports (the
-     * vendor mutates them); the external tier replays the host's last results and
-     * the disabled tier returns nothing so no overlays are drawn.
-     */
     private async runLint(): Promise<LintResults> {
         if (this.state === "in-page" && this.browserLinter) {
             const event = await this.browserLinter.run(this.bpmnjs.getDefinitions());
@@ -326,11 +207,6 @@ export class LintConfigService {
         return this.results;
     }
 
-    /**
-     * Switches the in-page linter on: marks the container, activates the vendor
-     * module (which triggers the first relint through our override), and shows the
-     * off button. Idempotent — a relint reuses the existing chrome.
-     */
     private activateInPage(): void {
         this.hideDisabledChip();
         this.canvas.getContainer().classList.add("bpmnlint-active");
@@ -342,16 +218,12 @@ export class LintConfigService {
         this.showOffButton();
     }
 
-    /**
-     * Renders `results`, or deactivates linting when `results` is `null` (no
-     * `.bpmnlintrc`, or a host read/lint failure).
-     */
     private render(results: LintResults | null): void {
         this.hideDisabledChip();
         if (!results) {
             this.results = {};
             if (this.linting.isActive()) {
-                // Fires `linting.toggle`, which clears the overlays via `update()`.
+                // toggle already triggers update to clear overlays.
                 this.linting.toggle(false);
             }
             this.canvas.getContainer().classList.remove("bpmnlint-active");
@@ -364,18 +236,13 @@ export class LintConfigService {
         if (this.linting.isActive()) {
             this.linting.update();
         } else {
-            // Activating fires `linting.toggle`, which triggers the first `update()`.
+            // Activation triggers update; an explicit second update would duplicate the first run.
             this.linting.toggle(true);
         }
         this.showOffButton();
     }
 
-    /**
-     * Renders the **user-disabled** state (distinct from the inactive `null`
-     * above): clears the overlays like an inactive linter, but shows a muted
-     * chip so the user can turn linting back on from inside the canvas — the
-     * summary pill they would otherwise click is gone.
-     */
+    // Disabling hides the vendor pill, so provide a separate way to re-enable linting.
     private renderDisabled(): void {
         this.results = {};
         if (this.linting.isActive()) {
@@ -386,12 +253,6 @@ export class LintConfigService {
         this.showDisabledChip();
     }
 
-    /**
-     * Handles the off button. Reports the toggle to the host in every tier; in the
-     * in-page tier it also flips the state and clears the overlays optimistically
-     * (the webview owns the linter). In the external tier the render waits for the
-     * host's disabled push.
-     */
     private handleOffClick(): void {
         this.callbacks.onLintingToggled?.(false);
         if (this.state === "in-page") {
@@ -400,12 +261,7 @@ export class LintConfigService {
         }
     }
 
-    /**
-     * Handles the re-enable chip. Reports the toggle in every tier; in the in-page
-     * tier it also flips back, rebuilds the linter (so a {@link setMode} that
-     * arrived while disabled takes effect on re-enable), and re-runs the in-page
-     * lint. In the external tier the overlays wait for the host's push.
-     */
+    // Rebuild on re-enable so a mode change made while disabled takes effect.
     private handleEnableClick(): void {
         this.callbacks.onLintingToggled?.(true);
         if (this.state === "in-page-disabled") {
@@ -415,20 +271,11 @@ export class LintConfigService {
         }
     }
 
-    /**
-     * The vendor summary pill (created on module init, so it is present from the
-     * first render even while hidden). Scoped to this modeler's canvas container
-     * so a sibling modeler's pill is never picked up.
-     */
     private pill(): HTMLElement | null {
         return this.canvas.getContainer().querySelector<HTMLElement>(".bjsl-button");
     }
 
-    /**
-     * Wraps the vendor pill in a flex row so an "off" button can sit beside it.
-     * Idempotent: the vendor only rewrites the pill's `innerHTML`/classes on
-     * relint, never re-parents it, so the wrapper and our button survive.
-     */
+    // The vendor only rewrites the pill's contents, so this wrapper survives relints.
     private ensureToolbar(): HTMLElement | null {
         const pill = this.pill();
         if (!pill || !pill.parentElement) {

--- a/packages/bpmn-modeler/src/bpmnlint/index.ts
+++ b/packages/bpmn-modeler/src/bpmnlint/index.ts
@@ -1,18 +1,6 @@
 /**
- * Public `@miragon/bpmn-modeler/lint` subpath entry.
- *
- * This module — and only this module — statically imports the lint stack
- * (`bpmn-js-bpmnlint`, `bpmnlint`'s `Linter`, `@miragon/bpmnlint-plugin-rules`,
- * and the CSS). The package never imports it: a host that wants linting imports
- * this subpath itself and hands the namespace in as `linting.module` (see
- * {@link LintModule}). That injection is what keeps the whole stack out of a
- * `linting: false` consumer's module graph — even under single-file bundlers,
- * where a reachable internal dynamic import can no longer be tree-shaken.
- *
- * bpmn-js modules are fixed at construction, so the host resolves this import
- * *before* `createModeler`; the facade then calls {@link createLintModule} with
- * the per-instance tier + config + callbacks and drops the returned module into
- * `additionalModules`.
+ * Import this subpath before creating a modeler and pass it as `linting.module`.
+ * Linting is injected so consumers that omit it do not bundle the lint stack.
  */
 import bpmnLintingModule from "bpmn-js-bpmnlint";
 import "bpmn-js-bpmnlint/dist/assets/css/bpmn-js-bpmnlint.css";
@@ -20,16 +8,11 @@ import "./bpmnlint.css";
 
 import { LintCallbacks, LintConfigService, LintTierInit } from "./LintConfigService";
 
-/**
- * Builds the bpmn-js DI module for one modeler instance: the vendor overlay
- * module plus {@link LintConfigService} and the two per-instance value providers
- * it injects (`lintTier`, `lintCallbacks`). `bpmnLintConfig` is eagerly
- * initialised (`__init__`) so the in-page tier can subscribe to `import.done`
- * and start linting without the host ever calling `getService`.
- */
+/** Builds the per-instance lint module for the consumer's `linting.module`. */
 export function createLintModule(tier: LintTierInit, callbacks: LintCallbacks): unknown {
     return {
         __depends__: [bpmnLintingModule],
+        // Initialize eagerly so import.done starts linting without a getService call.
         __init__: ["bpmnLintConfig"],
         bpmnLintConfig: ["type", LintConfigService],
         lintTier: ["value", tier],

--- a/packages/bpmn-modeler/src/createModeler.ts
+++ b/packages/bpmn-modeler/src/createModeler.ts
@@ -3,38 +3,22 @@ import { extras as i18nExtras } from "@miragon/bpmn-modeler-i18n-extras";
 import type { ModelerOptions } from "./publicApi";
 import { BpmnModeler } from "./modeler";
 
-/**
- * Runtime options accepted by {@link createModeler}: the public
- * {@link ModelerOptions} plus one internal knob (`handleGlobalEscape`), which
- * stays `@internal` and out of `publicApi.ts`.
- */
 export interface CreateModelerOptions extends ModelerOptions {
     /**
-     * When `true`, an Escape with nothing focused (`<body>`) re-homes this
-     * canvas. Default off; the single-instance bootstrap passes `true` for
-     * page-wide behaviour, while a multi-instance consumer leaves it off so each
-     * modeler only reacts to Escapes inside its own subtrees.
-     *
-     * @internal Not part of the public API.
+     * @internal Opt in only for single-instance hosts; body-targeted Escape has no instance scope.
      */
     handleGlobalEscape?: boolean;
 }
 
 /**
- * Stands up one independent modeler bound to `container` and its own
- * `propertiesPanel.parent`, then applies the initial data-carrying options
- * (element templates, settings, theme, locale) in the order the host expects.
- *
- * Async because {@link BpmnModeler.init} awaits the lazy bpmnlint chunk before
- * constructing bpmn-js.
+ * Creates an independent modeler in `container` with its own properties panel.
+ * Applies the supplied templates, settings, theme, and locale before returning.
  */
 export async function createModeler(
     container: HTMLElement,
     options: CreateModelerOptions,
 ): Promise<BpmnModeler> {
-    // Merge the modeler's Camunda-7 / dmn-js / internal strings onto the shared
-    // library's dictionaries before anything translates. Idempotent, so a second
-    // instance (or the bootstrap's own call) re-invoking it is harmless.
+    // Register missing translations before construction can render labels.
     i18n.extend(i18nExtras);
 
     const modeler = new BpmnModeler(container, options);
@@ -46,13 +30,9 @@ export async function createModeler(
     if (options.settings) {
         modeler.setSettings(options.settings);
     }
-    // Always engage theming so the per-instance `data-bpmn-theme` attribute is
-    // set from the first frame; `"automatic"` then follows `prefers-color-scheme`.
+    // Apply the default on the first frame, even when the caller omitted a theme.
     modeler.setTheme(options.theme ?? "automatic");
-    // The i18n instance is a page-global singleton, so a locale set here is
-    // page-wide; only touch it when the caller is explicit, or a default call
-    // would stomp a language the host already set. Per-instance locales are a
-    // documented 0.1.0 limitation.
+    // Locale is page-global; an omitted option must preserve the host's existing language.
     if (options.locale) {
         i18n.setLanguage(options.locale as SupportedLocale);
     }

--- a/packages/bpmn-modeler/src/design/designer.ts
+++ b/packages/bpmn-modeler/src/design/designer.ts
@@ -41,26 +41,8 @@ import type { ThemeMode } from "../publicApi";
 import type { CoreDesignerServices, DesignerOptions } from "./publicApi";
 
 /**
- * Encapsulates one engine-neutral, editable bpmn-js modeler instance — the
- * Design-mode analogue of {@link BpmnModeler} and {@link BpmnViewer}.
- *
- * Wraps the base `bpmn-js/lib/Modeler` (palette, context pad, modelling,
- * keyboard, copy-paste, snapping, searchPad, outline) plus the engine-neutral
- * properties panel (`@miragon/bpmn-modeler-properties-panel` — the full
- * standard-BPMN group set, no Camunda groups) and our neutral UX modules
- * (translate, append menu, flow navigation) and the mode-invariant canvas
- * chrome every surface shares (minimap, token simulation, keyboard focus —
- * ADR 0022). It loads none of the Camunda editing stack (camunda-bpmn-js,
- * element templates, transaction boundaries), so it never carries an execution
- * platform — the absence of `modeler:executionPlatform` on the model is exactly
- * the mode marker a host routes on. Linting is injection-only (ADR 0023): the
- * lint stack loads only when the host hands in a `module`, and resolves the
- * engine-neutral Design config.
- *
- * Per-instance by construction: bound to its own `container` and
- * `propertiesPanel.parent`, so several surfaces can coexist on a page. Use
- * {@link createDesigner} as the factory. Every accessor throws
- * {@link NoModelerError} before {@link init} or after {@link destroy}.
+ * An independent, editable BPMN surface without an execution platform.
+ * Create it with {@link createDesigner}; accessors require a live instance.
  */
 export class BpmnDesigner {
     private modeler: Modeler | undefined = undefined;
@@ -69,21 +51,15 @@ export class BpmnDesigner {
 
     private _selection: SelectionManager | undefined;
 
-    // Drill-down plane tracking, composed into captureViewState/applyViewState
-    // and exposed via the public `rootElement` getter for host-driven restore.
     private _rootElement: RootElementManager | undefined;
 
-    // Per-instance theme controller, created lazily on the first setTheme.
     private themeController?: ThemeController;
 
-    // Disposes the canvas-size observer installed by loadDiagram.
     private stopObservingSize?: () => void;
 
-    // Teardown for the container-scoped focus features installed in init().
     private focusDisposers: Array<() => void> = [];
 
-    // The debounced content-saved emitter, live only when `onContentSaved` was
-    // supplied. Held so {@link destroy} can cancel a pending trailing export.
+    // Retain the debouncer so destroy can cancel a pending export.
     private contentSaved?: AsyncDebounced<() => Promise<void>>;
 
     /**
@@ -137,12 +113,7 @@ export class BpmnDesigner {
         applyViewStateComposition(this.viewStateManagers(), state);
     }
 
-    /**
-     * The three managers backing view-state capture/apply. Reading `viewport`
-     * throws {@link NoModelerError} before {@link init}; the root manager is
-     * created and cleared in lockstep with it, so the assertion never fires
-     * after that guard passes.
-     */
+    // Accessing viewport guards initialization; all three managers share its lifecycle.
     private viewStateManagers() {
         return {
             viewport: this.viewport,
@@ -151,31 +122,17 @@ export class BpmnDesigner {
         };
     }
 
-    /**
-     * Creates and mounts the engine-neutral bpmn-js modeler, then wires the
-     * viewport/selection managers, focus features, and the debounced
-     * content-saved subscription.
-     *
-     * @internal Construction step invoked by {@link createDesigner}; not part of
-     *   the public handle.
-     */
+    /** @internal */
     async init(): Promise<void> {
         this.disposeFocusFeatures();
 
-        // The designer registers NativeCopyPasteModule itself (system/browser
-        // clipboard, parity with camunda-bpmn-js's base Modeler and the same
-        // `bpmn-js-clip----` wire format). A sandboxed host that can't reach the
-        // system clipboard supplies a bridge, whose module overrides
-        // NativeCopyPaste — hence NativeCopyPaste must be registered for the
-        // bridge to disable it.
+        // Register NativeCopyPaste even with a bridge: the bridge module expects to disable it.
         const clip = this.options.clipboard;
         const clipModules = clip
             ? createClipboardModules({ element: clip.bridge, text: clip.text })
             : [];
         if (clip) {
-            // The label overlay lives outside the bpmn-js DI context, so the DI
-            // clipboard modules don't reach it; this document-level polyfill
-            // bridges its Cmd/Ctrl+C/V through the text bridge. Idempotent.
+            // The FEEL editor sits outside bpmn-js DI and needs the document-level text bridge.
             const textBridge = clip.text ?? clip.bridge;
             installContentEditableClipboardPolyfill(
                 () => textBridge.requestClipboard(),
@@ -184,11 +141,7 @@ export class BpmnDesigner {
         }
         const extra = (this.options.additionalModules as any[]) ?? [];
 
-        // Inline the one navigation capability rather than reusing
-        // src/capabilityModules.ts — that value-imports code-link and
-        // inline-scripting (the latter even side-effect-imports CSS, which would
-        // pollute the CSS-free design entry) and takes an Engine. An absent
-        // capability registers no provider, so no context-pad entry renders.
+        // capabilityModules imports engine features and CSS, which must stay out of the design entry.
         const navigationPort = this.options.capabilities?.modelNavigation;
         const capModules = navigationPort ? [createModelNavigationModule(navigationPort)] : [];
 
@@ -196,38 +149,23 @@ export class BpmnDesigner {
             container: this.container,
             propertiesPanel: {
                 parent: this.options.propertiesPanel.parent,
-                // Mount the FEEL/documentation popups inside the instance
-                // container (they default to document.body, outside this
-                // instance's theme scope). Safe because the popup is fixed.
+                // Keep popups within this instance's theme scope instead of document.body.
                 feelPopupContainer: this.container,
             },
-            // Ship the minimap collapsed; the toggle lives in the canvas corner.
             minimap: { open: false },
             moddleExtensions: this.options.moddleExtensions,
             additionalModules: [
                 TranslateModule,
-                // Engine-neutral panel (our fork of bpmn-js-properties-panel): the
-                // renderer + neutral provider + a design-mode filter (identity here,
-                // there is no engine provider to filter) + the host custom-group slot.
                 PropertiesPanelModule,
                 NeutralPropertiesProviderModule,
                 ModeFilterModule,
                 CustomGroupsModule,
-                // The base create/append overlay our AppendMenuModule decorates.
-                // Engine-neutral: with no `elementTemplates` service registered it
-                // shows just the standard-BPMN panel, and powers favourites.
                 CreateAppendAnythingModule,
                 AppendMenuModule,
                 FlowNavigationModule,
                 MinimapModule,
-                // Engine-neutral: simulates plain BPMN control flow, no Camunda
-                // stack behind it (ADR 0022).
                 TokenSimulationModule,
-                // Injection-only lint tier (ADR 0023): empty unless the host hands
-                // in a `module` from `@miragon/bpmn-modeler/lint`. `mode: "design"`
-                // + `engine: undefined` resolves the engine-neutral Design config.
-                // `nudgeWhenOmitted: false` — the designer never linted implicitly,
-                // so an omitted option has nothing to migrate.
+                // Design never enabled linting implicitly, so omission needs no migration notice.
                 ...buildLintModules(
                     this.options.linting,
                     { engine: undefined, mode: "design" },
@@ -256,9 +194,6 @@ export class BpmnDesigner {
             appendMenuOverride?.setFavourites(this.options.favouriteBpmnElements);
         }
 
-        // The package-owned debounced content event: one full export per burst of
-        // model changes (300ms / 1000ms maxWait). destroy() cancels a pending
-        // trailing export.
         const onContentSaved = this.options.onContentSaved;
         if (onContentSaved) {
             this.contentSaved = asyncDebounce(
@@ -272,12 +207,6 @@ export class BpmnDesigner {
         }
     }
 
-    /**
-     * Composes the container-scopable focus features onto the fresh modeler: the
-     * "Escape → focus canvas" guard and the canvas focus reticle. Both are scoped
-     * to this instance's canvas container and panel parent so several surfaces on
-     * one page never cross-fire.
-     */
     private installFocusFeatures(): void {
         const canvas = this.getModeler().get<{
             getContainer(): HTMLElement;
@@ -419,11 +348,6 @@ export class BpmnDesigner {
         this.lintHandle().startInPageLinting(config, configToken);
     }
 
-    /**
-     * The shared lint handle methods over this instance's defensively-resolved
-     * {@link LintConfigService} (absent unless a lint module was injected). The
-     * same helper the root modeler composes, so the two surfaces stay in lockstep.
-     */
     private lintHandle(): LintHandleMethods {
         return createLintHandleMethods(
             () => this.getModeler().get<LintConfigService>("bpmnLintConfig", false) ?? undefined,

--- a/packages/bpmn-modeler/src/design/index.ts
+++ b/packages/bpmn-modeler/src/design/index.ts
@@ -1,31 +1,9 @@
 /**
- * `@miragon/bpmn-modeler/design` — the host-free, engine-neutral BPMN design
- * surface.
- *
- * A fully editable but engine-neutral surface for documentation / conceptual
- * modelling: the base bpmn-js Modeler plus a plain-BPMN properties panel
- * (general / documentation groups), neutral UX (translate, append menu, flow
- * navigation), and the mode-invariant canvas chrome (minimap, token simulation,
- * keyboard focus — ADR 0022). It drags none of the Camunda editing stack
- * (camunda-bpmn-js, element templates, transaction boundaries, lint) into the
- * module graph. That leanness is enforced at the graph level
- * (`scripts/check-design-pure-entry.mjs` + `architecture.spec.ts`) so it holds
- * under single-file bundlers. See ADR 0016.
- *
- * The mode marker is the absence of `modeler:executionPlatform` on
- * `bpmn:Definitions` — route with `detectEngine(xml)` (`undefined` ⇒ Design).
- *
- * Deliberately imports **no CSS**: `cssCodeSplit: false` on the lib build would
- * fold any stylesheet reachable from here into the shared `dist/bpmn-modeler.css`
- * (the modeler's `styles.css`), pulling the editor chrome's CSS back in. The
- * design surface's own sheet ships separately as
- * `@miragon/bpmn-modeler/design.css` (built by `vite.viewer-css.config.mts`),
- * which a consumer loads instead. Note that the properties panel does pull preact
- * and CodeMirror (its FEEL/JSON editors) into the graph — legitimately, unlike
- * the readonly `/viewer`.
+ * Editable, engine-neutral BPMN modeling with a properties panel.
+ * Use `detectEngine(xml)` to route untagged models here (`undefined` means Design).
+ * Load `@miragon/bpmn-modeler/design.css` separately.
  */
 
-// ── Public factory + API surface ─────────────────────────────────────────────
 export { createDesigner } from "./createDesigner";
 export type {
     DesignerOptions,
@@ -36,24 +14,20 @@ export type {
 } from "./publicApi";
 export type { ThemeMode, ClipboardOptions, ContentSavedEvent } from "../publicApi";
 
-// ── Model-navigation capability — the one engine-neutral host port on /design ─
 export type {
     ModelNavigationPort,
     ModelReference,
     ReferenceKind,
 } from "@miragon/bpmn-model-navigation";
 
-// ── Mode routing — re-exported for hosts that decide Design vs Implement ──────
 export { detectEngine } from "../detectEngine";
 export type { DetectedEngine } from "../detectEngine";
 
-// ── Viewport / selection — public, referenced by the designer handle ─────────
 export { ViewportManager } from "../viewport";
 export type { ViewportData } from "../viewport";
 export { SelectionManager } from "../selection";
 export type { RootElementManager } from "../rootElement";
 export type { ViewState } from "../viewState";
 
-// ── Re-exports so the rolled-up `.d.ts` stays self-contained ─────────────────
 export { NoModelerError } from "@miragon/bpmn-modeler-types";
 export type { ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";

--- a/packages/bpmn-modeler/src/diff/index.ts
+++ b/packages/bpmn-modeler/src/diff/index.ts
@@ -1,20 +1,9 @@
 /**
- * `@miragon/bpmn-modeler/diff` — the Node- and browser-safe diff data layer.
- *
- * Surfaces the pure computation and its serializable result types from the
- * inlined `@miragon/bpmn-modeler-diff` lib. This entry pulls in no CSS, no
- * bpmn-js, no i18n, and no preact, so it runs under plain Node (mechanised by
- * scripts/check-diff-node.mjs). The rendering primitives (DiffViewer,
- * DiffLegend, DiffNavigator, DiffPaneCoordinator) live on the `/viewer` entry.
- *
- * `computeDiff` / `sideView` are re-published as thin local wrappers rather than
- * bare `export … from`: api-extractor resolves a bundled lib via its
- * `types: ./src/index.ts` source, so a direct function re-export would inline
- * the implementation *body* into the rolled-up `dist/diff.d.ts` (invalid ambient
- * output). A local wrapper is emitted from the package's own source, so the dts
- * plugin produces a clean declaration; the return/parameter types still inline
- * cleanly because they carry no body.
+ * BPMN diff computation and serializable results for Node and browsers.
+ * Browser rendering primitives are available from `@miragon/bpmn-modeler/viewer`.
  */
+
+// Local wrappers prevent API Extractor from emitting bundled function bodies into declarations.
 import {
     computeDiff as computeDiffData,
     sideView as sideViewData,

--- a/packages/bpmn-modeler/src/index.ts
+++ b/packages/bpmn-modeler/src/index.ts
@@ -5,17 +5,12 @@
  * exports below exist only for the in-repo `apps/bpmn-webview` adapter.
  */
 
-// Side-effect styles the modeler's own DOM depends on. `themes.css` (imported
-// last) folds in the upstream light base + the `[data-bpmn-theme="dark"]`-scoped
-// dark overrides, so loading `styles.css` is all a consumer needs for
-// per-instance theming. The legacy split `light-theme.css` / `dark-theme.css`
-// exports remain for the `#theme-link` fallback.
+// Load theme overrides last so they take precedence over the base styles.
 import "./styles/default.css";
 import "./styles/diff.css";
 import "./styles/canvasFocusIndicator.css";
 import "./styles/themes.css";
 
-// ── Public factory + API surface ─────────────────────────────────────────────
 export { createModeler } from "./createModeler";
 export type {
     ThemeMode,
@@ -40,7 +35,6 @@ export type {
 } from "@miragon/bpmn-model-navigation";
 export { UnsupportedEngineError } from "./modeler";
 
-// ── Re-exports so the rolled-up `.d.ts` stays self-contained ─────────────────
 export type {
     Engine,
     BpmnModelerSetting,
@@ -53,18 +47,13 @@ export { detectEngine } from "./detectEngine";
 export type { DetectedEngine } from "./detectEngine";
 export type { ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
 
-// ── Viewport / selection — public, referenced by the designed handle ─────────
 export { ViewportManager } from "./viewport";
 export type { ViewportData } from "./viewport";
 export { SelectionManager } from "./selection";
 export type { RootElementManager } from "./rootElement";
 export type { ViewState } from "./viewState";
 
-// ── Diff view — moved to `@miragon/bpmn-modeler/viewer` (#1439) ───────────────
-// Local value+type aliases rather than `export … from`: api-extractor attaches a
-// JSDoc `@deprecated` tag to a declaration this file owns, but drops it from a
-// bare re-export statement — so only this form surfaces the deprecation in the
-// rolled-up `dist/index.d.ts`. The live surface is `@miragon/bpmn-modeler/viewer`.
+// Local aliases preserve @deprecated in the declaration rollup; API Extractor drops it on bare re-exports.
 import { DiffViewer as DiffViewerImpl } from "./viewer/diff/DiffViewer";
 import type { DiffMarkerClass as DiffMarkerClassImpl } from "./viewer/diff/DiffViewer";
 import { DiffLegend as DiffLegendImpl } from "./viewer/diff/DiffLegend";
@@ -98,10 +87,6 @@ export const DiffPaneCoordinator = DiffPaneCoordinatorImpl;
 /** @deprecated Import from `@miragon/bpmn-modeler/viewer` instead; removed in a future major. */
 export type DiffPaneCoordinator = DiffPaneCoordinatorImpl;
 
-// ── @internal — host-only surface the thin bpmn-webview adapter still needs ───
-// The adapter reaches the raw {@link BpmnModeler} class (host-only methods:
-// onCommandStackChanged, applyImplementationStatus, drill-down restore, …) and
-// its `CreateModelerOptions`.
 /** @internal */
 export { BpmnModeler } from "./modeler";
 /** @internal */

--- a/packages/bpmn-modeler/src/keyboardFocus.ts
+++ b/packages/bpmn-modeler/src/keyboardFocus.ts
@@ -1,115 +1,41 @@
-/**
- * @internal Package-internal wiring — the canvas-focus keyboard guard the
- * factory installs per instance. Not part of the public API.
- */
+/** @internal */
 
-/**
- * Injected dependencies for the webview-level "Escape → focus canvas" guard.
- *
- * Closures rather than a service handle so this stays testable without a live
- * bpmn-js modeler and so the real services can be resolved lazily (they don't
- * exist until the modeler is created).
- */
+// Resolve services lazily because the guard can be wired before the modeler exists.
 export interface KeyboardFocusDeps {
-    /**
-     * The DOM subtrees this instance owns — the canvas container and its
-     * properties-panel parent. An Escape is only handled when it originates
-     * inside one of these, so multiple modelers on one page never cross-fire:
-     * an Escape in panel A re-homes canvas A, not canvas B. Escape must be
-     * caught in the properties panel (a *sibling* of the canvas, not a
-     * descendant), which is why this is a document listener scoped by roots
-     * rather than a container listener.
-     */
+    // Include the sibling properties panel so its Escape events reach this canvas.
     roots: HTMLElement[];
-    /** Moves DOM focus onto the canvas SVG (`canvas.focus()`). */
     focusCanvas: () => void;
-    /** Whether the canvas SVG currently holds DOM focus (`canvas.isFocused()`). */
     isCanvasFocused: () => boolean;
-    /** Whether any element is currently selected (`selection.get().length > 0`). */
     hasSelection: () => boolean;
-    /** Clears the current selection (`selection.select(null)`). */
     clearSelection: () => void;
-    /** Whether the diagram-js SearchPad is currently open. */
     isSearchPadOpen: () => boolean;
-    /** Closes the SearchPad (restores the cached selection). */
     closeSearchPad: () => void;
-    /**
-     * When `true`, an Escape fired with focus on `<body>` (nothing focused) is
-     * also handled — the single-instance host wants a stray Escape anywhere on
-     * the page to re-home the canvas. Defaults to `false` so a library consumer
-     * hosting several modelers only reacts to Escapes inside its own roots.
-     */
+    // Opt in only for single-instance hosts; body events cannot identify a modeler.
     handleGlobalEscape?: boolean;
 }
 
-/**
- * Installs a document-level Escape handler that pulls focus back onto the
- * canvas — the Vim-style "return to normal mode".
- *
- * bpmn-js's Keyboard service only listens on the canvas SVG (diagram-js ≥ 15,
- * `tabindex=0`), so while focus sits in the properties panel, a FEEL editor,
- * or a search field, keystrokes like `A`/`N`/arrows never reach the modeler.
- * Escape re-homes focus so the next keystroke drives the diagram again.
- *
- * Escape is staged, one layer per press (mirroring the append-menu's
- * template-then-close staging): while focus is elsewhere it only re-homes
- * focus and *keeps* the selection — selection anchors the keyboard-modelling
- * flow (`A`/`R`/arrows) and drives the properties panel, so clearing it here
- * would blank the panel the user just escaped from. Only a further Escape on
- * the already-focused canvas clears the selection, reaching the neutral state
- * the focus reticle marks. bpmn-js has no deselect-on-Escape of its own.
- *
- * The listener runs in the **bubble** phase and stays deliberately passive
- * (no preventDefault/stopPropagation) so host Escape behaviour is untouched.
- *
- * @param deps Injected roots + focus/selection/search-pad closures (see {@link KeyboardFocusDeps}).
- * @returns A disposer that removes the document listener, so a destroyed
- *   modeler instance stops reacting to Escapes.
- */
+// bpmn-js only receives shortcuts on the canvas SVG, so Escape must restore its focus.
 export function installKeyboardFocus(deps: KeyboardFocusDeps): () => void {
-    const handler = (e: KeyboardEvent): void => {
-        if (e.key !== "Escape") return;
+    const handler = (event: KeyboardEvent): void => {
+        if (event.key !== "Escape") return;
 
-        // Scope to this instance's own subtrees: an Escape targeting another
-        // modeler (or unrelated page chrome) must not re-home our canvas. The
-        // single-instance host opts into also handling body-targeted Escapes so
-        // a keystroke with nothing focused still returns to the canvas.
-        const target = e.target;
-        const inRoots = target instanceof Node && deps.roots.some((root) => root.contains(target));
+        const target = event.target;
+        const isWithinInstance =
+            target instanceof Node && deps.roots.some((root) => root.contains(target));
         const isGlobalBody = deps.handleGlobalEscape === true && target === document.body;
-        if (!inRoots && !isGlobalBody) return;
+        if (!isWithinInstance && !isGlobalBody) return;
 
-        // Something already handled this Escape. Covers CodeMirror 6 (FEEL
-        // editor), whose Escape binding preventDefault-s only while its
-        // autocomplete popup is open — so the first Escape closes the popup
-        // and the second reaches us — plus any Escape bpmn-js itself consumes.
-        if (e.defaultPrevented) return;
+        // Let an editor consume Escape to close autocomplete before moving focus.
+        if (event.defaultPrevented) return;
 
-        // The append-menu and template-chooser overlays need no guard here:
-        // both register Escape as a document *capture* listener with
-        // stopPropagation, so this bubble listener never fires while they are
-        // open. First Escape closes the overlay; a second one lands here and
-        // focuses the canvas.
-
-        // SearchPad closes on keyup, not keydown (SearchPad.js). If we pulled
-        // focus to the canvas on this keydown, the matching keyup would miss
-        // the search field and the pad would stay open forever. So close it
-        // explicitly here: one Escape both closes the search and focuses the
-        // canvas.
+        // SearchPad closes on keyup; moving focus first would prevent it from receiving that event.
         if (deps.isSearchPadOpen()) {
             deps.closeSearchPad();
             deps.focusCanvas();
             return;
         }
 
-        // Label direct-editing needs no guard: its keydown handler stops
-        // propagation for every key, so we never see its Escape. Drag cancel
-        // and the popup menu preventDefault theirs, caught above — so reaching
-        // this point means there is no more transient UI layer to peel.
-
-        // Final layer: Escape on the already-focused canvas drops the
-        // selection (Figma/vim-visual convention), reaching the bare
-        // canvas-focus state the reticle lights up for.
+        // Keep selection on the first Escape so returning from the panel preserves keyboard modeling.
         if (deps.isCanvasFocused() && deps.hasSelection()) {
             deps.clearSelection();
             return;
@@ -117,6 +43,7 @@ export function installKeyboardFocus(deps: KeyboardFocusDeps): () => void {
 
         deps.focusCanvas();
     };
+    // Bubble after overlays and label editors have had a chance to stop propagation.
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
 }

--- a/packages/bpmn-modeler/src/mode.ts
+++ b/packages/bpmn-modeler/src/mode.ts
@@ -1,79 +1,23 @@
-/**
- * Runtime **design / implement** mode for a live `createModeler` instance
- * (issue #1442, epic #1438 "one document, three modes").
- *
- * Unlike the `/design` subpath — a *separate* engine-neutral factory for
- * untagged models — this is a runtime toggle on the same Camunda-tagged
- * `createModeler` instance: same bpmn-js modeler, same moddle, same behaviours,
- * same command stack. Nothing in the DI module graph is added or removed on a
- * toggle, so `zeebe:*` / `camunda:*` extensions are never at risk (a re-created
- * engine-neutral instance would drop them through `ModdleCopy` on replace /
- * copy-paste). What changes is presentational plus the lint scope: the
- * properties panel is filtered to its engine-neutral surface, the engine chrome
- * (element-template chooser) is hidden, and the in-page linter re-resolves its
- * config for the mode (dropping the Camunda engine layer in design — ADR 0023).
- * The canvas chrome (minimap, token simulation, focus reticle) is mode-invariant
- * (ADR 0022).
- *
- * The single source of truth for the mode is the properties panel's
- * `propertiesPanelModeFilter` service — it already holds the mode and fires
- * `propertiesPanel.providersChanged` from its own `setMode`. This helper is a
- * pure orchestration layer over a small {@link ModePorts} seam (the
- * `viewState.ts` pattern), so it needs no live modeler to unit-test.
- */
+// Keep the engine modeler alive across mode changes so replace/copy-paste preserves engine extensions.
 
 export type ModelerMode = "design" | "implement";
 
-/**
- * The attribute stamped on the container + panel parent so CSS can hide engine
- * chrome in design mode. Mirrors `data-bpmn-theme` (see `theme.ts`).
- */
 export const MODE_ATTRIBUTE = "data-bpmn-mode";
 
-/**
- * Resolves the caller's optional `mode` to a concrete one. The default is
- * `"implement"` — an engine-tagged model shows its full Camunda surface unless
- * a host opts into design. This must be applied at the `createModeler` seam:
- * the panel's `ModeFilterProvider` defaults to `"design"` when its config key is
- * absent, so omitting the key would silently flip every consumer to design.
- */
+// The panel defaults to design when its config is absent; the modeler must explicitly default to implement.
 export function normalizeMode(mode: ModelerMode | undefined): ModelerMode {
     return mode ?? "implement";
 }
 
-/**
- * The DI-service seam {@link applyMode} drives, so the orchestration stays pure
- * and unit-testable. Consumers reach this through the composed
- * {@link BpmnModeler.setMode} handle method, never the services directly.
- */
 export interface ModePorts {
-    /** The panel filter's current mode — `propertiesPanelModeFilter.getMode()`. */
     getFilterMode(): ModelerMode;
-    /**
-     * Switches the panel filter's mode. The filter fires
-     * `propertiesPanel.providersChanged` itself, so a live panel re-derives
-     * immediately — no separate refresh here.
-     */
+    // The filter emits providersChanged itself, so no separate panel refresh is needed.
     setFilterMode(mode: ModelerMode): void;
-    /** Stamps {@link MODE_ATTRIBUTE} on the container + panel parent, in both modes. */
     setModeAttribute(mode: ModelerMode): void;
-    /**
-     * Re-resolves the in-page lint config for `mode` — a per-mode `config` or the
-     * mode default (which drops the Camunda engine layer in design). A no-op when
-     * the instance carries no lint module, or when a mode-invariant workspace
-     * config is active.
-     */
     setLintMode(mode: ModelerMode): void;
-    /** Optional outbound notification, fired once per actual change (the epic's `modeChanged`). */
     onModeChanged?: (mode: ModelerMode) => void;
 }
 
-/**
- * Applies `mode` to a live instance through {@link ModePorts}. A no-op when the
- * filter already holds `mode`, so the attribute stamp, the lint re-resolve, and
- * the `onModeChanged` callback never re-fire on a redundant call. Otherwise:
- * flip the filter → stamp the attribute → re-resolve the lint config → notify.
- */
 export function applyMode(ports: ModePorts, mode: ModelerMode): void {
     if (ports.getFilterMode() === mode) {
         return;

--- a/packages/bpmn-modeler/src/modeModules.ts
+++ b/packages/bpmn-modeler/src/modeModules.ts
@@ -1,52 +1,17 @@
-/**
- * The design-mode chrome filter for the create/replace/append popup menus
- * (issue #1442, epic #1438).
- *
- * The properties-panel `propertiesPanelModeFilter` filters the *panel*; this DI
- * module filters the *popup menus* so design mode also hides the element-template
- * affordances there. It reads the mode lazily off `propertiesPanelModeFilter`
- * (the single source of truth), so nothing here holds a second mode field that
- * could drift, and a toggle takes effect on the next popup open (menus are
- * transient, rebuilt per open — no refresh needed).
- *
- * Two hooks:
- *  - a low-priority popup-menu provider on `bpmn-replace` / `bpmn-append` /
- *    `bpmn-create` that, in design mode, strips the template entries from the
- *    accumulated menu (see {@link stripTemplateEntries});
- *  - a high-priority `elementTemplates.select` guard that stops the event in
- *    design mode, since the template chooser subscribes at default priority in
- *    its constructor with no off switch.
- */
 import type { ModelerMode } from "./mode";
 
-/**
- * Below diagram-js's `DEFAULT_PRIORITY` (1000). diagram-js applies
- * function-returning popup-menu providers as middleware over the accumulated
- * entries in provider order, and a **lower** priority is pushed later and so
- * runs **last** (`diagram-js/lib/features/popup-menu/PopupMenu.js`). Running last
- * is what lets us strip the template entries the engine providers (e.g. C8's
- * `ElementTemplatesReplaceProvider`, keyed `replace.template-*` with
- * `group.id === "templates"`) added at default priority.
- */
+// Run after the default-priority (1000) providers so their template entries can be removed.
 const POPUP_MODE_FILTER_PRIORITY = 100;
 
-/** The popup menus whose template entries design mode strips. */
 const FILTERED_MENUS = ["bpmn-replace", "bpmn-append", "bpmn-create"] as const;
 
 /** Runs before the template chooser (default 1000) so its handler never fires. */
 const TEMPLATE_SELECT_GUARD_PRIORITY = 10000;
 
-/** Element-template entries are keyed `template-*` or `<prefix>.template-*`. */
 const TEMPLATE_ENTRY_KEY = /(^|\.)template-/;
 
-/**
- * Drops the element-template entries from a popup-menu entry map — those keyed
- * `template-*` / `*.template-*`, plus any entry whose `group.id` is `"templates"`
- * (belt-and-braces for a differently-keyed provider). Pure; the identity on a
- * template-free menu.
- */
 export function stripTemplateEntries(entries: Record<string, any>): Record<string, any> {
-    const kept: Record<string, any> = {};
+    const nonTemplateEntries: Record<string, any> = {};
     for (const [key, entry] of Object.entries(entries)) {
         if (TEMPLATE_ENTRY_KEY.test(key)) {
             continue;
@@ -54,9 +19,9 @@ export function stripTemplateEntries(entries: Record<string, any>): Record<strin
         if (entry?.group?.id === "templates") {
             continue;
         }
-        kept[key] = entry;
+        nonTemplateEntries[key] = entry;
     }
-    return kept;
+    return nonTemplateEntries;
 }
 
 export class PopupMenuModeFilter {
@@ -82,11 +47,7 @@ export class PopupMenuModeFilter {
             this.mode() === "design" ? stripTemplateEntries(entries) : entries;
     }
 
-    /**
-     * Reads the mode off the panel filter (the single source of truth). Resolved
-     * defensively — a surface without the panel filter registered is treated as
-     * `implement` (identity), so the module is safe to register unconditionally.
-     */
+    // Read the panel filter each time so popup menus cannot retain a stale mode.
     private mode(): ModelerMode {
         return this.injector.get("propertiesPanelModeFilter", false)?.getMode() ?? "implement";
     }

--- a/packages/bpmn-modeler/src/modeSession/index.ts
+++ b/packages/bpmn-modeler/src/modeSession/index.ts
@@ -1,18 +1,6 @@
 /**
- * `@miragon/bpmn-modeler/mode` — the View ↔ Design ↔ Implement session and its
- * opt-in segmented-control strip.
- *
- * {@link createModeSession} owns the single live surface for a BPMN page and
- * switches it between modes (live `setMode` toggle where possible, otherwise
- * export → destroy → recreate → restore). The consumer injects the per-mode
- * surface factories, so this entry value-imports **no** bpmn-js / Camunda code —
- * a consumer that bundles only `/viewer` never drags the editor stack in. The
- * strip ({@link mountModeStrip}) is a separate export that renders a group only
- * when two or more modes are available. See ADR 0021.
- *
- * Deliberately imports **no CSS**: the strip's sheet ships separately as
- * `@miragon/bpmn-modeler/mode.css` (built by `vite.viewer-css.config.mts`), so a
- * `cssCodeSplit: false` lib build cannot fold it into `dist/bpmn-modeler.css`.
+ * View / Design / Implement sessions with consumer-supplied surface factories.
+ * The optional mode strip needs `@miragon/bpmn-modeler/mode.css`.
  */
 
 export { createModeSession } from "./modeSession";
@@ -28,12 +16,7 @@ export type {
     SurfaceHandle,
 } from "./publicApi";
 
-// ── Mode model — re-exported so a consumer needs only this one subpath ────────
-// The functions are wrapped in local declarations rather than bare re-exported:
-// api-extractor inlines the bundled `@miragon/bpmn-modeler-types` source, and a
-// bare `export … from` of a *function* would roll its body into the emitted
-// `.d.ts` as an illegal `declare function … {`. A local wrapper emits a clean
-// signature (the same shape check-dts's design/viewer entries rely on).
+// Local wrappers prevent API Extractor from emitting bundled function bodies into declarations.
 import {
     SURFACE_MODES,
     defaultMode as defaultModeImpl,

--- a/packages/bpmn-modeler/src/modeSession/modeSession.ts
+++ b/packages/bpmn-modeler/src/modeSession/modeSession.ts
@@ -16,8 +16,7 @@ import type {
     SurfaceHandle,
 } from "./publicApi";
 
-/** The live handle carries the design/implement toggle only when it is a modeler. */
-function canToggle(handle: SurfaceHandle): handle is SurfaceHandle & {
+function canToggleMode(handle: SurfaceHandle): handle is SurfaceHandle & {
     setMode(mode: ModelerMode): void;
     getMode(): ModelerMode;
 } {
@@ -50,20 +49,18 @@ export async function createModeSession(options: ModeSessionOptions): Promise<Mo
 
     let busy = false;
 
-    /** Stands up the surface for `mode`, routing Design to the modeler on a tagged model. */
     function buildSurface(mode: SurfaceMode): Promise<SurfaceHandle> {
         const base: SurfaceContext = { container, engine, theme };
         if (mode === "view") {
             return surfaces.view!(base);
         }
         if (mode === "implement") {
-            const ctx: ModelerSurfaceContext = { ...base, mode: "implement" };
-            return surfaces.implement!(ctx);
+            const context: ModelerSurfaceContext = { ...base, mode: "implement" };
+            return surfaces.implement!(context);
         }
-        // Design: the full modeler serves it on a tagged model, else the designer.
         if (engine !== undefined && surfaces.implement) {
-            const ctx: ModelerSurfaceContext = { ...base, mode: "design" };
-            return surfaces.implement(ctx);
+            const context: ModelerSurfaceContext = { ...base, mode: "design" };
+            return surfaces.implement(context);
         }
         return surfaces.design!(base);
     }
@@ -80,7 +77,7 @@ export async function createModeSession(options: ModeSessionOptions): Promise<Mo
         if (kind === "none") {
             return;
         }
-        if (kind === "toggle" && canToggle(handle)) {
+        if (kind === "toggle" && canToggleMode(handle)) {
             handle.setMode(target as ModelerMode);
             // The handle is the single source of truth for the applied mode.
             currentMode = handle.getMode();
@@ -94,14 +91,11 @@ export async function createModeSession(options: ModeSessionOptions): Promise<Mo
         busy = true;
         options.onSwitchStateChanged?.(true);
 
-        // Captured before the destroy so the view state survives the swap; kept
-        // in scope so the fallback path can re-import the same diagram.
         const snapshot = handle.captureViewState();
         let xml: string;
         try {
             xml = await handle.exportDiagram();
         } catch (error) {
-            // Nothing destroyed yet — keep the instance and surface the error.
             busy = false;
             options.onSwitchStateChanged?.(false);
             options.onError?.(error);
@@ -118,7 +112,7 @@ export async function createModeSession(options: ModeSessionOptions): Promise<Mo
             handle.applyViewState(snapshot);
             options.onModeChanged?.(target, "recreate");
         } catch (error) {
-            // Past the destroy — the page must never be handle-less.
+            // Recover a usable surface if switching fails after the old instance was destroyed.
             options.onError?.(error);
             const fallback = defaultMode(engine, available);
             handle = await buildSurface(fallback);
@@ -146,12 +140,6 @@ export async function createModeSession(options: ModeSessionOptions): Promise<Mo
     };
 }
 
-/**
- * The modes the injected factories offer for this engine, in canonical order. A
- * mode is available when its routed factory exists and the engine rule permits
- * it: View needs `view`; Design needs the modeler (tagged model) or the designer;
- * Implement needs the modeler *and* a tagged model.
- */
 function computeAvailableModes(
     surfaces: SurfaceFactories,
     engine: SurfaceContext["engine"],
@@ -166,7 +154,6 @@ function computeAvailableModes(
         if (mode === "implement") {
             return surfaces.implement !== undefined;
         }
-        // Design routes to the modeler on a tagged model, else the designer.
         return (
             (engine !== undefined && surfaces.implement !== undefined) ||
             surfaces.design !== undefined

--- a/packages/bpmn-modeler/src/modeler.ts
+++ b/packages/bpmn-modeler/src/modeler.ts
@@ -4,9 +4,7 @@ import BpmnModeler8 from "camunda-bpmn-js/lib/camunda-cloud/Modeler";
 import { ImportXMLError, ImportXMLResult, SaveXMLResult } from "bpmn-js/lib/BaseViewer";
 import TokenSimulationModule from "bpmn-js-token-simulation";
 import { ElementTemplateChooserModule } from "@miragon/bpmn-modeler-element-template-chooser";
-// Deep ESM import: the package's CJS entry (`index.js` requiring an ESM `lib/`)
-// yields `{ default: <module> }` under Vite 8's require-of-ESM interop, so the
-// DI module never registers and every `get("transactionBoundaries")` throws.
+// The CJS entry wraps the ESM module in a default export, preventing DI registration under Vite.
 import TransactionBoundariesModule from "camunda-transaction-boundaries/lib/index.js";
 import { CreateAppendElementTemplatesModule } from "bpmn-js-create-append-anything";
 import { AppendMenuModule } from "@miragon/bpmn-modeler-append-menu";
@@ -14,13 +12,8 @@ import type { CodeLinkMapClient } from "@miragon/bpmn-modeler-code-link";
 import { FlowNavigationModule } from "@miragon/bpmn-modeler-flow-navigation";
 import { CreateAppendC7ElementTemplatesModule } from "@miragon/create-append-c7";
 import { createClipboardModules } from "@miragon/bpmn-modeler-clipboard";
-// Only the mode filter + custom-group slot: the lib's PropertiesPanelModule /
-// NeutralPropertiesProviderModule collide with camunda-bpmn-js's own
-// `propertiesPanel` DI name. The engine surface owns the renderer + providers;
-// these two ride alongside to filter it in design mode. Deep imports on
-// purpose: the lib index re-exports its TSX renderer, whose
-// `@bpmn-io/properties-panel/preact` JSX pragma cannot resolve the
-// jsx-dev-runtime Vite dev servers emit — the engine graph must stay TSX-free.
+// The full panel conflicts with Camunda's propertiesPanel service. Deep imports also avoid
+// its TSX renderer, whose JSX runtime does not resolve in Vite development builds.
 import { ModeFilterModule } from "@miragon/bpmn-modeler-properties-panel/modeFilter/ModeFilterProvider";
 import { CustomGroupsModule } from "@miragon/bpmn-modeler-properties-panel/customGroups/CustomGroupsRegistry";
 import { TranslateModule } from "@miragon/bpmn-modeler-i18n";
@@ -62,8 +55,6 @@ import { ModeUiModule } from "./modeModules";
 import { installKeyboardFocus } from "./keyboardFocus";
 import type { CreateModelerOptions } from "./createModeler";
 import type { CoreModelerServices, ThemeMode } from "./publicApi";
-// Type-only: erased at build so it never pulls the lint stack into the main
-// bundle. The runtime lint module is injected by the host (see LintingOptions).
 import type { LintConfigService } from "./bpmnlint/LintConfigService";
 
 const DEFAULT_SETTINGS: BpmnModelerSetting = {
@@ -72,8 +63,6 @@ const DEFAULT_SETTINGS: BpmnModelerSetting = {
     colorTheme: "automatic",
 };
 
-// Align-to-origin plugin config; the container / panel parent are per-instance
-// HTMLElements resolved from the constructor options in {@link BpmnModeler.init}.
 const ALIGN_TO_ORIGIN_OPTIONS = {
     alignOnSave: false,
     offset: 150,
@@ -81,24 +70,14 @@ const ALIGN_TO_ORIGIN_OPTIONS = {
 };
 
 /**
- * Encapsulates one bpmn-js modeler instance and all operations on it.
- *
- * Per-instance by construction: it is bound to its own `container` and
- * `propertiesPanel.parent` (see {@link CreateModelerOptions}), so several
- * modelers can coexist on a page. Use {@link createModeler} as the factory. All
- * methods throw {@link NoModelerError} if called before {@link init}, and
- * {@link destroy} tears the instance down.
- *
- * Viewport and selection concerns are delegated to {@link ViewportManager}
- * and {@link SelectionManager}, accessible via the corresponding getters
- * after {@link init} has been called.
+ * An independent Camunda BPMN modeler with its own canvas and properties panel.
+ * Create it with {@link createModeler}; accessors require a live instance.
  */
 export class BpmnModeler {
     private modeler: Modeler | undefined = undefined;
 
     private settings: BpmnModelerSetting = { ...DEFAULT_SETTINGS };
 
-    // Tracks the active engine so transaction-boundary calls are gated to C7 only.
     private engine: Engine | undefined = undefined;
 
     private _viewport: ViewportManager | undefined;
@@ -107,21 +86,13 @@ export class BpmnModeler {
 
     private _rootElement: RootElementManager | undefined;
 
-    // Optional host sink for non-fatal warnings (element-not-found, missing
-    // inline script). Kept as an injected callback rather than a host import so
-    // the modeler stays constructible in tests and the standalone dev browser.
     private onWarningSink?: (message: string) => void;
 
-    // Teardown for the container-scoped focus features installed in init();
-    // run on re-create (to avoid stacking) and on destroy().
     private focusDisposers: Array<() => void> = [];
 
-    // The debounced content-saved emitter, live only when `onContentSaved` was
-    // supplied. Held so {@link destroy} can cancel a pending trailing export.
+    // Retain the debouncer so destroy can cancel a pending export.
     private contentSaved?: AsyncDebounced<() => Promise<void>>;
 
-    // Per-instance theme controller, created lazily on the first setTheme. Scopes
-    // `data-bpmn-theme` to this instance's container + panel parent.
     private themeController?: ThemeController;
 
     /**
@@ -155,12 +126,7 @@ export class BpmnModeler {
         return this._selection;
     }
 
-    /**
-     * Access the root element manager after {@link init}.
-     *
-     * @internal Host-adapter surface (drill-down state restore); not part of the
-     *   public handle.
-     */
+    /** @internal */
     get rootElement(): RootElementManager {
         if (!this._rootElement) {
             throw new NoModelerError();
@@ -198,32 +164,17 @@ export class BpmnModeler {
     }
 
     /**
-     * Creates and mounts the bpmn-js modeler for the engine in `options.engine`,
-     * then wires the per-instance subscriptions (element-template errors,
-     * debounced content-saved). The DI extras, capabilities, and page-level
-     * side-effect callbacks all come from the constructor options.
-     *
-     * Async for API stability (a host that learns the engine late calls this
-     * late); the lint modules are now built synchronously from the host-injected
-     * lint module. Re-`init()` disposes the prior instance's focus installs
-     * first.
-     *
-     * @internal Construction step invoked by {@link createModeler}; not part of
-     *   the public handle.
+     * @internal Async signature retained for compatibility.
      * @throws {UnsupportedEngineError} If the engine string is not recognised.
      */
     async init(): Promise<void> {
         const engine = this.options.engine;
         this.disposeFocusFeatures();
 
-        // Per-instance panel host, so id-coupled DI services (scriptEditorButtons)
-        // observe this modeler's own panel instead of the first `#js-properties-panel`.
+        // Inject the panel root so script controls cannot target a sibling modeler's panel.
         const propertiesPanelRootModule = {
             propertiesPanelRoot: ["value", this.options.propertiesPanel.parent],
         };
-        // TranslateModule is an opinionated built-in registered on every instance
-        // (the host-set locale is page-global), so the demo modeler gains
-        // translations too — intended.
         const commonModules = [
             TranslateModule,
             TokenSimulationModule,
@@ -239,31 +190,18 @@ export class BpmnModeler {
             AppendMenuModule,
             FlowNavigationModule,
             propertiesPanelRootModule,
-            // Design/implement mode (#1442): the panel mode filter + host
-            // custom-group slot, and the popup-menu chrome filter. Mode-invariant
-            // — nothing here registers/unregisters on a toggle, so engine data is
-            // never at risk on replace/copy-paste.
             ModeFilterModule,
             CustomGroupsModule,
             ModeUiModule,
         ];
         const capModules = capabilityModules(engine, this.options.capabilities);
-        // Clipboard is a [B] built-in: omitting `clipboard` registers nothing, so
-        // bpmn-js's native (browser) clipboard stays in charge; a host that
-        // can't reach the system clipboard from its webview supplies a bridge.
-        // A distinct `text` bridge routes label + contenteditable/FEEL surfaces
-        // through the host's text channel; it defaults to the element bridge.
         const clip = this.options.clipboard;
         const clipModules = clip
             ? createClipboardModules({ element: clip.bridge, text: clip.text })
             : [];
         if (clip) {
-            // The FEEL editor (CodeMirror 6) and diagram-js label overlay live
-            // outside the bpmn-js DI context, so the DI clipboard modules above
-            // don't reach them; this document-level polyfill bridges their
-            // Cmd/Ctrl+C/V (and guards Ctrl+A) through the text bridge. Arrow-
-            // wrapped so the bridge keeps its own `this`. Idempotent by its own
-            // install guard, so a re-init() never stacks handlers.
+            // FEEL editors sit outside bpmn-js DI and need the document-level text bridge.
+            // Wrap callbacks to preserve the bridge's this binding.
             const textBridge = clip.text ?? clip.bridge;
             installContentEditableClipboardPolyfill(
                 () => textBridge.requestClipboard(),
@@ -276,15 +214,12 @@ export class BpmnModeler {
             container: this.container,
             propertiesPanel: {
                 parent: this.options.propertiesPanel.parent,
-                // Mount the FEEL expression popup inside the instance container
-                // (it defaults to document.body, outside this instance's theme
-                // scope). Safe because the popup is `position: fixed`.
+                // Keep popups within this instance's theme scope instead of document.body.
                 feelPopupContainer: this.container,
             },
             alignToOrigin: ALIGN_TO_ORIGIN_OPTIONS,
             moddleExtensions: this.options.moddleExtensions,
-            // Mandatory: ModeFilterProvider defaults to "design" when this config
-            // key is absent, which would silently blank the engine surface.
+            // The panel defaults to design if this config is absent.
             propertiesPanelMode: normalizeMode(this.options.mode),
         };
 
@@ -332,8 +267,7 @@ export class BpmnModeler {
             }
         }
 
-        // Subscribe *before* the factory pushes the initial templates so the
-        // errors fired while the loader validates them are observed.
+        // Subscribe before initial templates are supplied so their validation errors are observed.
         const onElementTemplatesErrors = this.options.onElementTemplatesErrors;
         if (onElementTemplatesErrors) {
             this.getModeler().on("elementTemplates.errors", (event: any) => {
@@ -341,9 +275,6 @@ export class BpmnModeler {
             });
         }
 
-        // The package-owned debounced content event: one full export per burst of
-        // model changes (300ms / 1000ms maxWait). destroy() cancels a pending
-        // trailing export.
         const onContentSaved = this.options.onContentSaved;
         if (onContentSaved) {
             this.contentSaved = asyncDebounce(
@@ -354,9 +285,7 @@ export class BpmnModeler {
             this.onCommandStackChanged(() => void this.contentSaved!());
         }
 
-        // Stamp the mode attribute before the first paint so a design-at-creation
-        // instance hides its engine chrome from frame one (the panel filter is
-        // already seeded from `propertiesPanelMode`).
+        // Apply before the first paint to avoid flashing engine controls in design mode.
         this.setModeAttribute(normalizeMode(this.options.mode));
     }
 
@@ -391,11 +320,6 @@ export class BpmnModeler {
         this.lintHandle().startInPageLinting(config, configToken);
     }
 
-    /**
-     * The shared lint handle methods over this instance's defensively-resolved
-     * {@link LintConfigService} (absent when created without a lint module). The
-     * designer composes the identical helper, so the two surfaces stay in lockstep.
-     */
     private lintHandle(): LintHandleMethods {
         return createLintHandleMethods(
             () => this.getModeler().get<LintConfigService>("bpmnLintConfig", false) ?? undefined,
@@ -403,13 +327,6 @@ export class BpmnModeler {
         );
     }
 
-    /**
-     * Composes the container-scopable focus features onto the fresh modeler:
-     * the "Escape → focus canvas" guard and the canvas focus reticle. Both are
-     * scoped to this instance's canvas container and panel parent so several
-     * modelers on one page never cross-fire. Disposers are recorded so a
-     * re-`create()` or {@link destroy} tears them down.
-     */
     private installFocusFeatures(): void {
         const canvas = this.getModeler().get<{
             getContainer(): HTMLElement;
@@ -420,10 +337,6 @@ export class BpmnModeler {
         const eventBus = () => this.getModeler().get<any>("eventBus");
         const selection = () => this.getModeler().get<{ get(): unknown[] }>("selection");
 
-        // Escape re-homes focus onto the canvas so keyboard-driven modelling
-        // (A/N/arrows, owned by bpmn-js's canvas-scoped Keyboard service) works
-        // even from the panel or a search field; a further Escape on the focused
-        // canvas clears the selection. Roots scope the guard to this instance.
         this.focusDisposers.push(
             installKeyboardFocus({
                 roots: [canvasContainer, this.options.propertiesPanel.parent],
@@ -441,10 +354,7 @@ export class BpmnModeler {
             }),
         );
 
-        // The reticle beside the "Open minimap" control lights up green while the
-        // canvas holds keyboard focus with nothing selected. It subscribes to
-        // diagram-js's deduplicated `canvas.focus.changed` rather than a
-        // container-level focusin (which would false-positive on the lint chip).
+        // Canvas focus events exclude controls such as the lint chip that would match container focusin.
         this.focusDisposers.push(
             installCanvasFocusIndicator({
                 parent: canvasContainer,
@@ -486,13 +396,7 @@ export class BpmnModeler {
         this._rootElement = undefined;
     }
 
-    /**
-     * Subscribes to the `commandStack.changed` event on the modeler's event bus.
-     *
-     * @internal Raw change hook. The designed API exposes the debounced
-     *   `onContentSaved` event instead; this stays for the host adapter.
-     * @param cb Callback invoked whenever the command stack changes.
-     */
+    /** @internal Use onContentSaved for debounced content notifications. */
     onCommandStackChanged(cb: () => void): void {
         this.getModeler().get<any>("eventBus").on("commandStack.changed", cb);
     }
@@ -506,14 +410,7 @@ export class BpmnModeler {
         return this.getModeler().getDefinitions();
     }
 
-    /**
-     * Returns every `bpmn:ScriptTask` in the diagram that carries an inline
-     * script, for the host's "Generate Script Files for Script Tasks" command. The
-     * scan and filtering rules live in {@link collectInlineScriptTasks} so the
-     * bulk path and the single-open path stay in agreement.
-     *
-     * @internal Host-adapter surface (inline-scripting capability).
-     */
+    /** @internal */
     collectInlineScriptTasks(): ScriptTaskScript[] {
         return collectInlineScriptTasks(this.getModeler().get<any>("elementRegistry"));
     }
@@ -573,9 +470,7 @@ export class BpmnModeler {
         this.getModeler();
         this.settings = { ...this.settings, ...settings };
 
-        // `colorTheme` is deliberately not applied here: the page theme is host
-        // policy driven through `theme` / {@link setTheme}. It stays in the
-        // settings type/defaults but is inert on this path.
+        // colorTheme stays inert here; the host controls theme through setTheme.
 
         if (this.engine === "c7") {
             const tb = this.getModeler().get<any>("transactionBoundaries");
@@ -591,12 +486,7 @@ export class BpmnModeler {
         }
     }
 
-    /**
-     * Triggers the align-to-origin plugin if the setting is enabled.
-     *
-     * @internal Host-adapter surface (invoked on save by the VS Code editor
-     *   controller); folded behind the `alignToOrigin` setting in the public API.
-     */
+    /** @internal */
     alignElementsToOrigin(): void {
         if (this.settings.alignToOrigin) {
             this.getModeler().get<any>("alignToOrigin").align();
@@ -620,18 +510,7 @@ export class BpmnModeler {
         return this.getModeler().get(name);
     }
 
-    /**
-     * Persists a chosen script format back to the BPMN model via the
-     * bpmn-js command stack. Used after the host's Quick-Pick fallback
-     * resolves an unsupported / empty `camunda:scriptFormat` so the next
-     * open of the same script skips the prompt.
-     *
-     * - `script-task`: writes to the element's `scriptFormat`.
-     * - `execution-listener` / `task-listener`: writes to the listener's
-     *   nested `camunda:Script.scriptFormat`.
-     *
-     * @internal Host-adapter surface (inline-scripting capability).
-     */
+    /** @internal */
     updateScriptFormat(
         elementId: string,
         kind: ScriptKind,
@@ -648,10 +527,7 @@ export class BpmnModeler {
         }
 
         if (kind === "script-task") {
-            // `scriptFormat` is a plain BPMN attribute on the script task, not a
-            // Camunda-namespaced one — it is the exact property the panel's
-            // "Format" field reads/writes, so a `camunda:` prefix would persist
-            // an attribute the field never displays (leaving it blank).
+            // Script-task scriptFormat is unnamespaced; camunda:scriptFormat would be ignored by the panel.
             modeling.updateModdleProperties(element, element.businessObject, {
                 scriptFormat,
             });
@@ -670,18 +546,7 @@ export class BpmnModeler {
         });
     }
 
-    /**
-     * Persists updated script content to the appropriate moddle property
-     * via the bpmn-js command stack so the change is undoable and serialised
-     * back to the BPMN XML.
-     *
-     * - `script-task`: writes to the element's `script` string property.
-     * - `execution-listener` / `task-listener`: locates the listener at
-     *   `listenerIndex` within the parent's filtered list of that listener
-     *   type, then writes to its nested `camunda:Script` element's `value`.
-     *
-     * @internal Host-adapter surface (inline-scripting capability).
-     */
+    /** @internal */
     updateScriptContent(
         elementId: string,
         kind: ScriptKind,
@@ -697,10 +562,7 @@ export class BpmnModeler {
             return;
         }
 
-        // Pre-declare this write as tab-originated *before* the moddle write:
-        // `commandStack.changed` fires synchronously inside it, and the watcher
-        // must see the new content as its baseline or it would report our own
-        // keystroke back to the host as a model-side change.
+        // commandStack.changed fires during the write; set the baseline first to avoid echoing our own edit.
         modeler
             .get<ScriptSourceWatcher>("scriptSourceWatcher", false)
             ?.noteApplied(elementId, kind, listenerIndex, content);
@@ -724,15 +586,7 @@ export class BpmnModeler {
         });
     }
 
-    /**
-     * Hands the host's current set of open inline-script editors to the
-     * {@link OpenScriptEditorsStore}, which locks the matching properties-panel
-     * script fields (single-writer arbitration). C7-only: the store/provider
-     * modules are not registered for C8, so the service is resolved defensively
-     * and the call is a no-op there.
-     *
-     * @internal Host-adapter surface (inline-scripting capability).
-     */
+    /** @internal C7 only; C8 does not register the script-editor store. */
     applyOpenScriptEditors(refs: OpenScriptEditorRef[]): void {
         this.getModeler().get<OpenScriptEditorsStore>("openScriptEditorsStore", false)?.set(refs);
     }
@@ -757,12 +611,8 @@ export class BpmnModeler {
     }
 
     /**
-     * Switches the design/implement mode live on this same bpmn-js instance —
-     * no re-import, no engine-data loss. Delegates to {@link applyMode}, which
-     * flips the panel filter (firing `propertiesPanel.providersChanged` so the
-     * live panel re-derives), stamps `data-bpmn-mode`, and fires `onModeChanged`
-     * once per actual change.
-     * Unrelated to {@link setTheme} despite the shared "mode" wording.
+     * Switches Design / Implement without re-importing or losing engine data.
+     * Fires onModeChanged once per actual change.
      */
     setMode(mode: ModelerMode): void {
         applyMode(this.modePorts(), mode);
@@ -780,10 +630,6 @@ export class BpmnModeler {
             .getMode();
     }
 
-    /**
-     * Maps the {@link ModePorts} seam onto this instance's DI services. The panel
-     * filter is the mode source of truth.
-     */
     private modePorts(): ModePorts {
         const modeler = this.getModeler();
         const filter = modeler.get<{
@@ -794,58 +640,29 @@ export class BpmnModeler {
             getFilterMode: () => filter.getMode(),
             setFilterMode: (mode) => filter.setMode(mode),
             setModeAttribute: (mode) => this.setModeAttribute(mode),
-            // Re-resolves the in-page lint config for the new mode (a per-mode
-            // `config`, or the mode default that drops the engine layer in
-            // design). Absent lint module → no service → no-op.
             setLintMode: (mode) =>
                 this.getModeler().get<LintConfigService>("bpmnLintConfig", false)?.setMode(mode),
             onModeChanged: this.options.onModeChanged,
         };
     }
 
-    /** Stamps {@link MODE_ATTRIBUTE} on the container + panel parent (both modes). */
     private setModeAttribute(mode: ModelerMode): void {
         this.container.setAttribute(MODE_ATTRIBUTE, mode);
         this.options.propertiesPanel.parent.setAttribute(MODE_ATTRIBUTE, mode);
     }
 
-    /**
-     * Hands the host's per-activity implementation-resolution map to the
-     * code-link DI service, which caches it and refreshes the context pad so the
-     * "Go to implementation" entry hides for tasks whose implementation does not
-     * exist in the workspace.
-     *
-     * The service is resolved defensively (`get(..., false)`): a consumer that
-     * omits the codeLink capability registers no `codeLinkMapClient`, and a
-     * stray status push must then be a no-op rather than throw.
-     *
-     * @internal Host-adapter surface (code-link capability).
-     */
+    /** @internal A missing code-link capability must tolerate host status pushes. */
     applyImplementationStatus(resolved: Record<string, boolean>): void {
         this.getModeler().get<CodeLinkMapClient>("codeLinkMapClient", false)?.applyStatus(resolved);
     }
 
-    /**
-     * Emits a non-fatal warning to the console (preserved for dev/tests) and, if
-     * a host sink is wired via the `onWarning` option, forwards it to the channel.
-     */
     private warn(message: string): void {
         console.warn(message);
         this.onWarningSink?.(message);
     }
 
-    /**
-     * Re-derives the element-template engine profile from the freshly imported
-     * definitions and pushes it to the `elementTemplates` service, which
-     * re-indexes and fires `elementTemplates.changed` so the chooser/panel
-     * refresh live. Called after every import (open, migration rewrite, new
-     * diagram) since those replace the definitions the version rides on.
-     *
-     * Engines come from the diagram, not a setting, to match Camunda Modeler
-     * and the library's own lint rule; templates without `engines` stay visible
-     * by library semantics. The service is fetched defensively — the C7 base
-     * modeler may not register it, and `{}` clears any prior value.
-     */
+    // Read the engine profile from imported definitions to match template engine filtering.
+    // C7 may omit the service; an empty profile clears any previous engine version.
     private applyEnginesFromDefinitions(): void {
         const definitions = this.getModeler().getDefinitions();
         const engines = deriveEngines(

--- a/packages/bpmn-modeler/src/propertiesPanelClipboard.ts
+++ b/packages/bpmn-modeler/src/propertiesPanelClipboard.ts
@@ -1,74 +1,25 @@
-/**
- * @internal Host-adapter surface — routes the panel's plain-text copy/paste
- * through the extension-host clipboard bridge. Not part of the public API;
- * folded behind the `clipboard` option's bridge.
- */
+/** @internal */
 import { isTextEditingSurface } from "@miragon/bpmn-modeler-types";
 
-/**
- * Writes the current text selection to the extension-host clipboard.
- */
 function handleCopy(writeClipboard: (text: string) => void): void {
     const text = window.getSelection()?.toString() ?? "";
     if (text) writeClipboard(text);
 }
 
-/**
- * Reads from the extension-host clipboard and pastes into the target element.
- */
 function handlePaste(el: HTMLElement, requestClipboard: () => Promise<string>): void {
     requestClipboard().then((text) => {
         if (text) dispatchPasteOrInsert(el, text);
     });
 }
 
-/**
- * Installs the webview-level keyboard / clipboard guard.
- *
- * Registers two `keydown` listeners on `document`, each with a deliberately
- * chosen phase:
- *
- * 1. **Capture phase — Ctrl/Cmd+C/V bridge for contenteditable.** VS Code
- *    webview iframes lack clipboard permissions, and bpmn-js's
- *    `DirectEditing._handleKey` calls `stopPropagation()` on every keydown
- *    from the label overlay. Capture-phase fires before that stopPropagation,
- *    so the bridge can intercept the keys and route them through the
- *    extension host. A `document.execCommand` polyfill covers non-keyboard
- *    triggers (VS Code command palette); a dedup flag prevents double
- *    handling when both layers fire.
- *
- * 2. **Bubble phase — Ctrl/Cmd+A guard.** Each text surface owns its own
- *    Ctrl+A: browser native for `<input>`/`<textarea>`, `LabelClipboardModule`
- *    for the BPMN label overlay, CodeMirror 6 for the Camunda 8 FEEL editor.
- *    Bubble-phase lets those owners run first (capture + target phases).
- *    Then, at `document` during bubble, we always call `stopPropagation()`
- *    so the event never reaches `window`. This is what blocks the Theia
- *    standalone host from forwarding the keystroke to its outer shell:
- *    Theia's webview pre-bootstrap (`@theia/plugin-ext/.../pre/main.js`)
- *    listens on the inner iframe's `window` in bubble phase and posts the
- *    event unconditionally (it does NOT gate on `defaultPrevented`). Without
- *    `stopPropagation` here the outer shell receives a synthetic Ctrl+A and
- *    runs `CommonCommands.SELECT_ALL` = `document.execCommand('selectAll')`
- *    against the whole Theia shell, visibly selecting the file explorer,
- *    toolbar, etc. `stopPropagation` (not `stopImmediatePropagation`) leaves
- *    bpmn-js's `Keyboard` listener intact because it sits on the same node.
- *    For text surfaces we additionally call `stopImmediatePropagation()` to
- *    block bpmn-js (same-node, same-phase, registered after us).
- *
- * @param requestClipboard Async callback that reads clipboard text via the extension host.
- * @param writeClipboard Callback that writes text to the extension host clipboard.
- */
+// Capture copy/paste before direct editing stops propagation; let text editors handle select-all first.
 let polyfillInstalled = false;
 
 export function installContentEditableClipboardPolyfill(
     requestClipboard: () => Promise<string>,
     writeClipboard: (text: string) => void,
 ): void {
-    // Page-global by nature: the two document listeners and the execCommand
-    // monkey-patch below act on `document`, so a second install would stack
-    // duplicate handlers and double-wrap execCommand. This stays owned by the
-    // single-instance bootstrap (not the per-instance facade); the guard makes
-    // a repeat call a no-op should a multi-instance consumer wire it twice.
+    // Document listeners and the execCommand patch are page-global; repeated installs would duplicate handling.
     if (polyfillInstalled) {
         return;
     }
@@ -112,32 +63,18 @@ export function installContentEditableClipboardPolyfill(
             if (!(e.metaKey || e.ctrlKey)) return;
             if (e.key !== "a") return;
 
-            // Stop the bubble before it reaches `window`. Theia's webview
-            // pre-bootstrap listens there and forwards keydowns to the
-            // outer shell unconditionally (it does NOT gate on
-            // defaultPrevented), which would otherwise run a global
-            // SELECT_ALL against the Theia chrome. Same-node listeners
-            // (bpmn-js's Keyboard) still fire because stopPropagation
-            // doesn't affect them.
+            // Theia forwards window keydowns even when defaultPrevented, triggering select-all in the outer shell.
             e.stopPropagation();
 
             const el = document.activeElement;
             if (!isTextEditingSurface(el)) {
-                // Canvas / no text surface: let bpmn-js handle selectElements.
                 return;
             }
 
-            // Block bpmn-js's Keyboard listener (same node, same phase,
-            // registered after us). stopPropagation alone would leave it
-            // running because it doesn't affect same-node listeners.
+            // Same-node bpmn-js listeners still run after stopPropagation, so text surfaces need this stronger stop.
             e.stopImmediatePropagation();
 
-            /**
-             * Contenteditable surfaces (BPMN label, FEEL editor) own their
-             * own selection via scoped handlers run in earlier phases.
-             * For `<input>`/`<textarea>`, the native Ctrl+A default action
-             * is unreliable inside webview iframes, so we select explicitly.
-             */
+            // Native select-all is unreliable for input/textarea in webviews; contenteditables have their own handlers.
             if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
                 el.select();
             }
@@ -172,17 +109,7 @@ export function installContentEditableClipboardPolyfill(
     });
 }
 
-/**
- * Dispatches a synthetic `ClipboardEvent("paste")` on the target element.
- * Falls back to `execCommand("insertText")` when no JS handler consumes it.
- *
- * Editors with JS paste handlers (e.g. CodeMirror 6 / FEEL editor) consume
- * the ClipboardEvent themselves; plain contenteditable elements (e.g.
- * diagram-js TextBox) rely on the explicit insertText fallback.
- *
- * @param el The target contenteditable element.
- * @param text The plain text to paste.
- */
+// Synthetic paste has no native insertion default, so unhandled contenteditables need insertText.
 function dispatchPasteOrInsert(el: HTMLElement, text: string): void {
     const dt = new DataTransfer();
     dt.setData("text/plain", text);

--- a/packages/bpmn-modeler/src/publicApi.spec.ts
+++ b/packages/bpmn-modeler/src/publicApi.spec.ts
@@ -30,8 +30,6 @@ import type {
     DesignerCapabilities,
     DesignerOptions,
 } from "./design/publicApi";
-// The three model-navigation types must be re-exported from both barrels — the
-// public proof that a /design consumer can name the port and its references.
 import type {
     ModelNavigationPort as ModelNavigationPortFromRoot,
     ModelReference as ModelReferenceFromRoot,
@@ -42,7 +40,6 @@ import type {
     ModelReference as ModelReferenceFromDesign,
     ReferenceKind as ReferenceKindFromDesign,
 } from "./design/index";
-// …and from the /viewer barrel — the same public proof for a /viewer consumer.
 import type {
     ModelNavigationPort as ModelNavigationPortFromViewer,
     ModelReference as ModelReferenceFromViewer,
@@ -56,57 +53,35 @@ import type {
     SurfaceHandle,
 } from "./modeSession/publicApi";
 
-// A minimal stub of the injected `@miragon/bpmn-modeler/lint` namespace. The
-// on-tiers below all require a `module`, so migration failures are compile-time.
 const _lintModule: LintModule = { createLintModule: () => ({}) };
 
-/**
- * Type-level conformance + scenario spec for the public API.
- *
- * The assertions below are compile-checked (this file is type-checked by
- * `tsconfig.spec.json`); the single runtime `it` exists only so the test runner
- * has something to execute — esbuild strips the types without checking them, so
- * the guarantee is the `tsc` pass, not the vitest run.
- *
- * `satisfies` is used instead of a plain annotation so the checks cannot be
- * widened away by an over-broad target type.
- */
+// These fixtures require tsc: Vitest strips types without checking conformance.
+// Use satisfies to validate each fixture without widening its inferred type.
 
-// Conformance: the BpmnModeler class satisfies the full handle. If a future
-// refactor reshapes one of these members, this line stops compiling.
 const _conformance = (modeler: BpmnModeler): BpmnModelerHandle => modeler;
 void _conformance;
 
-// Class→handle conformance for the viewer and designer too: a forgotten method
-// on either class (e.g. a missing captureViewState) is a compile error here
-// rather than a runtime `undefined` on the handle the factory returns.
 const _viewerConformance = (v: BpmnViewer): BpmnViewerHandle => v;
 void _viewerConformance;
 const _designerConformance = (d: BpmnDesigner): BpmnDesignerHandle => d;
 void _designerConformance;
 
-// The captured view-state shape is frozen: viewport, an optional plane id, and
-// the selection id list. A field drop/rename breaks this literal.
 const _viewState = {
     viewport: { x: 0, y: 0, width: 100, height: 100 },
     rootElementId: "SubProcess_1_plane",
     selectedElementIds: ["Task_1"],
 } satisfies ViewState;
 void _viewState;
-// rootElementId is optional — a top-level-plane snapshot omits it.
 const _viewStateTopLevel = {
     viewport: { x: 0, y: 0, width: 100, height: 100 },
     selectedElementIds: [],
 } satisfies ViewState;
 void _viewStateTopLevel;
 
-// Structural sanity check that the frozen stable subset stays a subset of the
-// full handle as the surface grows.
 type _HandleIsSuperset = BpmnModelerHandle extends StableModelerSurface ? true : never;
 const _handleSuperset: _HandleIsSuperset = true;
 void _handleSuperset;
 
-// Element templates arrive as fetched data, not a path.
 const _scenarioTemplates = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -114,8 +89,6 @@ const _scenarioTemplates = {
 } satisfies ModelerOptions;
 void _scenarioTemplates;
 
-// [A] Escape hatches: extra DI modules alongside a custom moddle extension for
-// a host's own BPMN namespace (bpmiq's sticky-note case).
 const _scenarioEscapeHatches = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -126,8 +99,6 @@ const _scenarioEscapeHatches = {
 } satisfies ModelerOptions;
 void _scenarioEscapeHatches;
 
-// An async ModelNavigationPort (GitHub-API resolution before opening a tab).
-// The return type must accept `async`.
 const _asyncNavigation: ModelNavigationPort = {
     async openReference({ id, kind }) {
         await Promise.resolve();
@@ -142,8 +113,6 @@ const _scenarioAsyncNav = {
 } satisfies ModelerOptions;
 void _scenarioAsyncNav;
 
-// A host may keep navigation visibility in sync with its own workspace index.
-// Without these optional hooks, syntactically valid references stay visible.
 const _formAwareNavigation = {
     openReference: (_reference) => undefined,
     isReferenceAvailable: ({ id, kind }) => kind !== "form" || id === "Form_Request",
@@ -151,9 +120,6 @@ const _formAwareNavigation = {
 } satisfies ModelNavigationPort;
 void _formAwareNavigation;
 
-// Graceful `{ module, config }` linting. The literal type-checks against the
-// BpmnlintConfig mirror; unresolvable rules degrade at runtime and surface via
-// onLintResults({ results, unresolved }).
 const _scenarioLintConfig = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -168,8 +134,6 @@ const _scenarioLintConfig = {
 } satisfies ModelerOptions;
 void _scenarioLintConfig;
 
-// Per-mode `config` map: one instance lints Design and Implement differently,
-// re-resolved on setMode. Either key is optional.
 const _scenarioLintByMode = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -183,8 +147,6 @@ const _scenarioLintByMode = {
 } satisfies ModelerOptions;
 void _scenarioLintByMode;
 
-// External tier: `{ module, results: "external" }`. `module` is required — the
-// external tier still needs LintConfigService to paint host-pushed results.
 const _scenarioLintExternal = {
     engine: "c8",
     propertiesPanel: { parent: document.createElement("div") },
@@ -192,8 +154,6 @@ const _scenarioLintExternal = {
 } satisfies ModelerOptions;
 void _scenarioLintExternal;
 
-// Migration failures are compile-time: an object tier without `module` is
-// rejected, and `config` never rides the external variant.
 const _lintMissingModule = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -210,17 +170,10 @@ const _lintExternalMissingModule = {
 } satisfies ModelerOptions;
 void _lintExternalMissingModule;
 
-// Type-level entry conformance (no runtime load): the real `/lint` subpath
-// namespace structurally satisfies the public LintModule contract. If
-// createLintModule's signature drifts from LintModule, this line stops
-// compiling — keeping the structural interface in sync with the implementation.
 type _EntryConformsToLintModule = typeof import("./bpmnlint") extends LintModule ? true : never;
 const _entryConforms: _EntryConformsToLintModule = true;
 void _entryConforms;
 
-// [B] Opinionated built-ins: each tier/override type-checks in isolation, and
-// the target factory type is nameable. These exercise the built-in and event
-// declarations the scenario literals above don't reach.
 const _themes = ["light", "dark", "automatic"] satisfies ThemeMode[];
 void _themes;
 const _lintOff: LintingOptions = false;
@@ -230,18 +183,11 @@ void [_lintOff, _lintExternal, _lintConfig];
 const _clipboard: ClipboardOptions = {
     bridge: { requestClipboard: () => Promise.resolve(""), writeClipboard: () => undefined },
 };
-// A host with two protocol channels (VS Code) supplies a separate `text`
-// bridge; the package forwards it to createClipboardModules' text binding and
-// drives the contenteditable polyfill from it.
 const _clipboardWithText: ClipboardOptions = {
     bridge: { requestClipboard: () => Promise.resolve(""), writeClipboard: () => undefined },
     text: { requestClipboard: () => Promise.resolve(""), writeClipboard: () => undefined },
 };
 void _clipboardWithText;
-// The runtime factory accepts the same clipboard override — omit it for the
-// native browser clipboard, or pass `{ bridge }` to route through a host. The
-// runtime options extend {@link ModelerOptions} (engine + nested
-// `propertiesPanel`), plus the internal `handleGlobalEscape`.
 const _createWithClipboard = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -265,9 +211,6 @@ const _builtinsShape = {
 } satisfies ModelerOptions;
 void _builtinsShape;
 
-// [B] Design/implement mode is a built-in runtime toggle (#1442). The mode
-// literals type-check against the option, an unknown mode is rejected, and
-// onModeChanged narrows its argument to ModelerMode.
 const _modes = ["design", "implement"] satisfies ModelerMode[];
 void _modes;
 const _scenarioDesignMode = {
@@ -284,7 +227,6 @@ const _rejectsUnknownMode = {
     mode: "view",
 } satisfies ModelerOptions;
 void _rejectsUnknownMode;
-// The handle carries the live setMode/getMode pair.
 const _modeHandle = (m: BpmnModelerHandle) => {
     m.setMode("design");
     const mode: ModelerMode = m.getMode();
@@ -292,9 +234,6 @@ const _modeHandle = (m: BpmnModelerHandle) => {
 };
 void _modeHandle;
 
-// The drill-down plane accessor is public on all three handles (host-driven
-// restore across an instance switch), so a modeler handle narrows without an
-// adapter and a viewer/designer exposes the same manager.
 const _rootElementAccessors = (
     m: BpmnModelerHandle,
     v: BpmnViewerHandle,
@@ -304,12 +243,10 @@ const _rootElementAccessors = (
 };
 void _rootElementAccessors;
 
-// The async factory signature is nameable.
 type _FactoryReturn = ReturnType<CreateModeler>;
 const _factoryReturns: _FactoryReturn extends Promise<BpmnModelerHandle> ? true : never = true;
 void _factoryReturns;
 
-// Demo-webapp-shaped literal — model navigation only, no code-link/scripting.
 const _demoShape = {
     engine: "c7",
     propertiesPanel: { parent: document.createElement("div") },
@@ -324,9 +261,6 @@ const _demoShape = {
 } satisfies ModelerOptions;
 void _demoShape;
 
-// Frozen core-service contract (#1408): each keyed lookup resolves to its
-// vendor diagram-js/bpmn-js type without an explicit type argument. If an
-// overload regresses, one of these annotations stops compiling.
 const _coreServices = (m: BpmnModelerHandle) => {
     const canvas: CoreModelerServices["canvas"] = m.getService("canvas");
     const commandStack: CoreModelerServices["commandStack"] = m.getService("commandStack");
@@ -339,8 +273,6 @@ const _coreServices = (m: BpmnModelerHandle) => {
 };
 void _coreServices;
 
-// Non-core names keep the generic escape hatch: an explicit type argument is
-// honoured, and a bare call defaults to `unknown`.
 const _escapeHatch = (m: BpmnModelerHandle) => {
     const custom = m.getService<{ translate(s: string): string }>("customTranslator");
     const untyped: unknown = m.getService("anythingElse");
@@ -348,17 +280,9 @@ const _escapeHatch = (m: BpmnModelerHandle) => {
 };
 void _escapeHatch;
 
-// ── Viewer subpath conformance (#1405) ──────────────────────────────────────
-
-// Subset compatibility (acceptance criterion): every BpmnViewerHandle member is
-// signature-identical to its BpmnModelerHandle counterpart, so a modeler handle
-// narrows to a viewer handle with no adapter. If a viewer member drifts from the
-// modeler's shape, this line stops compiling.
 const _modelerSatisfiesViewerHandle = (m: BpmnModelerHandle): BpmnViewerHandle => m;
 void _modelerSatisfiesViewerHandle;
 
-// CoreViewerServices is the readonly Pick of CoreModelerServices: each shared key
-// keeps its exact vendor type, and the editing keys are absent.
 const _coreViewerServices = (v: BpmnViewerHandle) => {
     const canvas: CoreModelerServices["canvas"] = v.getService("canvas");
     const elementRegistry: CoreModelerServices["elementRegistry"] = v.getService("elementRegistry");
@@ -375,8 +299,6 @@ type _ViewerServicesAreModelerSubset = keyof CoreViewerServices extends keyof Co
 const _viewerServicesSubset: _ViewerServicesAreModelerSubset = true;
 void _viewerServicesSubset;
 
-// ViewerOptions is minimal: no engine, no editor-only built-ins, and an
-// optional (readonly) properties panel.
 const _viewerOptions = {
     theme: "dark",
     propertiesPanel: { parent: document.createElement("div") },
@@ -399,7 +321,6 @@ const _viewerRejectsLinting = {
 } satisfies ViewerOptions;
 void _viewerRejectsLinting;
 
-// The viewer handle carries no editing methods.
 const _viewerHasNoEditing = (v: BpmnViewerHandle) => {
     // @ts-expect-error — `newDiagram` is a modeler-only method.
     void v.newDiagram;
@@ -408,18 +329,9 @@ const _viewerHasNoEditing = (v: BpmnViewerHandle) => {
 };
 void _viewerHasNoEditing;
 
-// ── Designer subpath conformance (#1196) ────────────────────────────────────
-
-// Subset compatibility: every BpmnDesignerHandle member is signature-identical
-// to its BpmnModelerHandle counterpart, so a modeler handle narrows to a designer
-// handle with no adapter. If a designer member drifts from the modeler's shape,
-// this line stops compiling.
 const _modelerSatisfiesDesignerHandle = (m: BpmnModelerHandle): BpmnDesignerHandle => m;
 void _modelerSatisfiesDesignerHandle;
 
-// Design mode is fully editable, so CoreDesignerServices is the full
-// CoreModelerServices set (not the viewer's readonly Pick): each of the seven
-// keys resolves to its exact vendor type, including modeling + commandStack.
 const _coreDesignerServices = (d: BpmnDesignerHandle) => {
     const canvas: CoreModelerServices["canvas"] = d.getService("canvas");
     const commandStack: CoreModelerServices["commandStack"] = d.getService("commandStack");
@@ -436,7 +348,6 @@ type _DesignerServicesEqualModeler = keyof CoreDesignerServices extends keyof Co
 const _designerServicesEqual: _DesignerServicesEqualModeler = true;
 void _designerServicesEqual;
 
-// DesignerOptions requires the panel host and accepts the engine-neutral knobs.
 const _designerOptions = {
     propertiesPanel: { parent: document.createElement("div") },
     theme: "dark",
@@ -456,9 +367,6 @@ const _designerRejectsEngine = {
 } satisfies DesignerOptions;
 void _designerRejectsEngine;
 
-// Linting is now injection-only on /design exactly as on the root: `false` is
-// valid (off), and an on-tier accepts the injected module plus the result/toggle
-// sinks. The engine-neutral Design config resolves automatically.
 const _designerAcceptsLinting = {
     propertiesPanel: { parent: document.createElement("div") },
     linting: { module: _lintModule },
@@ -471,7 +379,6 @@ const _designerLintOff = {
     linting: false,
 } satisfies DesignerOptions;
 void _designerLintOff;
-// A by-mode config resolves its `design` entry on the designer.
 const _designerByModeLint = {
     propertiesPanel: { parent: document.createElement("div") },
     linting: { module: _lintModule, config: { design: { extends: "bpmnlint:recommended" } } },
@@ -485,14 +392,12 @@ const _designerRejectsElementTemplates = {
 } satisfies DesignerOptions;
 void _designerRejectsElementTemplates;
 
-// The one engine-neutral host capability: modelNavigation is accepted, …
 const _designerAcceptsNavigation = {
     propertiesPanel: { parent: document.createElement("div") },
     capabilities: { modelNavigation: _asyncNavigation },
 } satisfies DesignerOptions;
 void _designerAcceptsNavigation;
 
-// … while the engine-bound ports stay compile-time-rejected on /design.
 const _designerRejectsCodeLink = {
     propertiesPanel: { parent: document.createElement("div") },
     // @ts-expect-error — codeLink is engine-bound, absent from DesignerCapabilities.
@@ -507,11 +412,9 @@ const _designerRejectsScripting = {
 } satisfies DesignerOptions;
 void _designerRejectsScripting;
 
-// DesignerCapabilities carries exactly the navigation port.
 const _designerCapabilities = { modelNavigation: _asyncNavigation } satisfies DesignerCapabilities;
 void _designerCapabilities;
 
-// The re-exported navigation types are structurally the same from either barrel.
 const _navPortRoot: ModelNavigationPortFromRoot = _asyncNavigation;
 const _navPortDesign: ModelNavigationPortFromDesign = _navPortRoot;
 void (_navPortDesign satisfies ModelNavigationPortFromDesign);
@@ -522,13 +425,11 @@ const _kindRoot: ReferenceKindFromRoot = "process";
 const _kindDesign: ReferenceKindFromDesign = _kindRoot;
 void _kindDesign;
 
-// The /viewer surface accepts the same one engine-neutral capability, …
 const _viewerAcceptsNavigation = {
     capabilities: { modelNavigation: _asyncNavigation },
 } satisfies ViewerOptions;
 void _viewerAcceptsNavigation;
 
-// … while the engine-bound ports stay compile-time-rejected on /viewer too.
 const _viewerRejectsCodeLink = {
     // @ts-expect-error — codeLink is engine-bound, absent from ViewerCapabilities.
     capabilities: { codeLink: {} },
@@ -541,18 +442,14 @@ const _viewerRejectsScripting = {
 } satisfies ViewerOptions;
 void _viewerRejectsScripting;
 
-// ViewerCapabilities carries exactly the navigation port, …
 const _viewerCapabilities = { modelNavigation: _asyncNavigation } satisfies ViewerCapabilities;
 void _viewerCapabilities;
 
-// … and is structurally identical to DesignerCapabilities (mutually assignable),
-// the own-interface guarantee: the viewer must not import from src/design/*.
 const _viewerCapsAsDesigner: DesignerCapabilities = _viewerCapabilities;
 void _viewerCapsAsDesigner;
 const _designerCapsAsViewer: ViewerCapabilities = { modelNavigation: _asyncNavigation };
 void (_designerCapsAsViewer satisfies DesignerCapabilities);
 
-// The re-exported navigation types are the same from the /viewer barrel too.
 const _navPortViewer: ModelNavigationPortFromViewer = _navPortRoot;
 void (_navPortViewer satisfies ModelNavigationPortFromDesign);
 const _refViewer: ModelReferenceFromViewer = _refRoot;
@@ -560,10 +457,6 @@ void _refViewer;
 const _kindViewer: ReferenceKindFromViewer = _kindRoot;
 void _kindViewer;
 
-// ── Mode-session subpath conformance (#1447) ────────────────────────────────
-
-// SurfaceHandle is the union of all three handles: a modeler, a viewer, and a
-// designer all satisfy it (the modeler is the superset arm).
 const _surfaceHandleAcceptsAll = (
     m: BpmnModelerHandle,
     v: BpmnViewerHandle,
@@ -574,7 +467,6 @@ const _surfaceHandleAcceptsAll = (
 };
 void _surfaceHandleAcceptsAll;
 
-// The design/implement contexts: implement additionally carries `mode`.
 const _surfaceContext = {
     container: document.createElement("div"),
     engine: "c7",
@@ -584,8 +476,6 @@ void _surfaceContext;
 const _modelerContext = { ..._surfaceContext, mode: "design" } satisfies ModelerSurfaceContext;
 void _modelerContext;
 
-// A consumer may inject any subset of factories; the implement factory serves
-// both Design and Implement on a tagged model via `ctx.mode`.
 const _allFactories = {
     view: async (_ctx: SurfaceContext) => ({}) as BpmnViewerHandle,
     design: async (_ctx: SurfaceContext) => ({}) as BpmnDesignerHandle,
@@ -597,13 +487,11 @@ const _allFactories = {
 } satisfies SurfaceFactories;
 void _allFactories;
 
-// A single-factory session is legal (one mode, no strip).
 const _singleFactory = {
     view: async (_ctx: SurfaceContext) => ({}) as BpmnViewerHandle,
 } satisfies SurfaceFactories;
 void _singleFactory;
 
-// The implement slot demands a modeler; a designer factory is rejected.
 const _designerImplementFactory = async (
     _ctx: ModelerSurfaceContext,
 ): Promise<BpmnDesignerHandle> => ({}) as BpmnDesignerHandle;
@@ -623,8 +511,6 @@ const _modeSessionOptions = {
 } satisfies ModeSessionOptions;
 void _modeSessionOptions;
 
-// The /mode barrel re-exports the factory, the strip, and the mode model —
-// checked at the type level so this line loads no runtime graph.
 type _ModeBarrel = typeof import("./modeSession");
 const _modeBarrelExports = (b: _ModeBarrel) => {
     void b.createModeSession;

--- a/packages/bpmn-modeler/src/publicApi.ts
+++ b/packages/bpmn-modeler/src/publicApi.ts
@@ -14,13 +14,7 @@ import type {
     LintRunEvent,
 } from "@miragon/bpmn-modeler-types";
 import type { ClipboardBridge } from "@miragon/bpmn-modeler-clipboard";
-// Type-only import — erased at build (same contract as modeler.ts's
-// LintConfigService import), so referencing the lint module's types here never
-// pulls the lint stack into the main bundle.
 import type { LintCallbacks, LintTierInit } from "./bpmnlint/LintConfigService";
-// Type-only — erased at build (same contract as the LintConfigService import),
-// so the lint config types cross into the main entry without pulling the lint
-// stack into the main bundle.
 import type { LintConfigOption } from "./bpmnlint/lintConfigResolution";
 import type { ModelerCapabilities } from "./capabilities";
 import type { ViewportManager } from "./viewport";
@@ -70,6 +64,7 @@ export type { LintConfigByMode, LintConfigOption } from "./bpmnlint/lintConfigRe
  */
 export type ThemeMode = "light" | "dark" | "automatic";
 
+// A structural interface avoids API Extractor rollup failures on relative import() types.
 /**
  * [B] The namespace of `@miragon/bpmn-modeler/lint`, imported and handed in by
  * the host. The lint stack (`bpmn-js-bpmnlint`, `bpmnlint`, the rule plugin, and
@@ -80,10 +75,6 @@ export type ThemeMode = "light" | "dark" | "automatic";
  * ```ts
  * linting: { module: await import("@miragon/bpmn-modeler/lint") }
  * ```
- *
- * Declared structurally (not `typeof import("./bpmnlint")`) because
- * api-extractor rollups of relative `import()` types are fragile; a type-level
- * conformance check in `publicApi.spec.ts` keeps the two in sync.
  */
 export interface LintModule {
     createLintModule(tier: LintTierInit, callbacks: LintCallbacks): unknown;
@@ -108,11 +99,6 @@ export interface LintModule {
  *   computes and pushes through {@link BpmnModelerHandle.applyLintResults}; no
  *   in-webview linter runs. `module` is still required — the external tier needs
  *   {@link LintModule} to paint and to service a `startInPageLinting` handback.
- *
- * `results?: never` on the config variant makes the union discriminable on
- * `results`, so the runtime tier selection narrows without type guards. `module`
- * being required on both object variants makes a missed migration a compile-time
- * error, not a silent runtime downgrade.
  */
 export type LintingOptions =
     | false

--- a/packages/bpmn-modeler/src/styles/dark-theme/token-sim.css
+++ b/packages/bpmn-modeler/src/styles/dark-theme/token-sim.css
@@ -1,19 +1,5 @@
 @import "colors.css";
 
-/*
-:root {
-    --token-simulation-green-base-44: #10D070;
-    --token-simulation-grey-base-40: #666666;
-    --token-simulation-grey-darken-30: #212121;
-    --token-simulation-grey-lighten-56: #909090;
-    --token-simulation-red-base-62: #FF3D3D;
-    --token-simulation-silver-base-97: #F8F8F8;
-    --token-simulation-silver-darken-94: #EFEFEF;
-
-    --token-simulation-white: #FFFFFF;
-}
-*/
-
 [data-bpmn-theme="dark"] .bjs-container.simulation .djs-container {
     box-shadow: inset 0 0 0 4px var(--dt-primary-a0) !important;
 }

--- a/packages/bpmn-modeler/src/theme.ts
+++ b/packages/bpmn-modeler/src/theme.ts
@@ -1,51 +1,18 @@
-/**
- * Per-instance theme controller for the modeler.
- *
- * The authoritative mechanism is a `data-bpmn-theme="light" | "dark"` attribute
- * the controller toggles on the scope roots it is handed (a modeler's canvas
- * container + its `propertiesPanel.parent`). The dark stylesheet's rules are all
- * scoped under `[data-bpmn-theme="dark"]`, so theming one instance never leaks
- * onto another on the same page.
- *
- * {@link applyLegacyThemeLink} keeps the pre-attribute `#theme-link` href swap
- * alive as a permanent, page-global compatibility fallback for consumers that
- * still link `lightTheme.css` / `darkTheme.css` themselves. It is a silent no-op
- * when no `#theme-link` is present — the attribute mechanism stands on its own.
- *
- * `"automatic"` resolves the kind from the OS/browser `prefers-color-scheme` and
- * keeps following it live; `"light"` / `"dark"` force a fixed kind and stop
- * following. A host's own light/dark chrome (e.g. VS Code's `<body>` classes) is
- * host policy: the host adapter maps that signal to a forced mode — the package
- * never reads host chrome.
- *
- * @internal Not part of the public handle; reached through
- *   {@link BpmnModeler.setTheme}, and reusable by the viewer/design-mode surfaces
- *   that take plain scope roots rather than a modeler.
- */
+/** @internal */
 import type { ThemeMode } from "./publicApi";
 
 export type ResolvedThemeKind = "light" | "dark";
 
-/** The attribute the dark stylesheet's `[data-bpmn-theme="dark"]` rules key off. */
 export const THEME_ATTRIBUTE = "data-bpmn-theme";
 
 export class ThemeController {
-    // `undefined` (not `"automatic"`) until the first setMode so that an initial
-    // setMode("automatic") actually engages instead of hitting the same-mode
-    // early return.
+    // Leave unset so the first automatic-mode call applies the theme instead of returning early.
     private mode: ThemeMode | undefined;
     private mediaQuery?: MediaQueryList;
     private mediaListener?: (event: MediaQueryListEvent) => void;
 
     constructor(private readonly scopeRoots: readonly HTMLElement[]) {}
 
-    /**
-     * Switches the theme mode. `"automatic"` applies the current
-     * `prefers-color-scheme` and installs a `change` listener so a later
-     * OS/browser theme switch is reflected live; a forced `"light"`/`"dark"`
-     * stops that listener so the fixed choice is not overwritten on the next
-     * scheme change. A no-op when the mode is unchanged.
-     */
     setMode(mode: ThemeMode): void {
         if (mode === this.mode) {
             return;
@@ -60,7 +27,6 @@ export class ThemeController {
         }
     }
 
-    /** Detaches the scheme listener and removes the attribute from every root. */
     dispose(): void {
         this.stopFollowingPreferredScheme();
         for (const root of this.scopeRoots) {
@@ -68,7 +34,6 @@ export class ThemeController {
         }
     }
 
-    /** Sets the attribute on every scope root and mirrors it to the legacy link. */
     private apply(kind: ResolvedThemeKind): void {
         for (const root of this.scopeRoots) {
             root.setAttribute(THEME_ATTRIBUTE, kind);
@@ -76,11 +41,6 @@ export class ThemeController {
         applyLegacyThemeLink(kind);
     }
 
-    /**
-     * Applies the current `prefers-color-scheme` and installs a single live
-     * `change` listener for it (idempotent — a second automatic entry re-applies
-     * but does not stack listeners).
-     */
     private startFollowingPreferredScheme(): void {
         const query = window.matchMedia("(prefers-color-scheme: dark)");
         this.apply(query.matches ? "dark" : "light");
@@ -106,14 +66,7 @@ export class ThemeController {
     }
 }
 
-/**
- * Swaps the legacy `#theme-link` stylesheet between `lightTheme.css` and
- * `darkTheme.css`, comparing the current href first to avoid a redundant DOM
- * mutation. A silent no-op when no `#theme-link` is present — the attribute
- * mechanism is authoritative, so a missing legacy link is not an error.
- *
- * @param kind `"dark"` to apply the dark stylesheet, `"light"` for the light one.
- */
+// Preserve compatibility with consumers that still use a page-global #theme-link.
 function applyLegacyThemeLink(kind: ResolvedThemeKind): void {
     const theme = document.querySelector<HTMLLinkElement>("#theme-link");
     if (!theme) {

--- a/packages/bpmn-modeler/src/viewState.ts
+++ b/packages/bpmn-modeler/src/viewState.ts
@@ -25,41 +25,24 @@ export interface ViewState {
     selectedElementIds: string[];
 }
 
-/**
- * The three managers the capture/apply composition reads and writes. Kept
- * module-internal — consumers reach this through the composed
- * `captureViewState` / `applyViewState` handle methods, never the managers
- * directly.
- */
 export interface ViewStateManagers {
     viewport: ViewportManager;
     rootElement: RootElementManager;
     selection: SelectionManager;
 }
 
-/**
- * Reads the live plane, viewbox, and selection off the managers into a plain
- * {@link ViewState}.
- */
-export function captureViewState(m: ViewStateManagers): ViewState {
+export function captureViewState(managers: ViewStateManagers): ViewState {
     return {
-        rootElementId: m.rootElement.getRootElementId(),
-        viewport: m.viewport.getViewport(),
-        selectedElementIds: m.selection.getSelectedElementIds(),
+        rootElementId: managers.rootElement.getRootElementId(),
+        viewport: managers.viewport.getViewport(),
+        selectedElementIds: managers.selection.getSelectedElementIds(),
     };
 }
 
-/**
- * Re-applies a captured {@link ViewState}, in the one order that works:
- * **root → viewport → selection**. Viewbox coordinates are plane-relative, so
- * the root must switch first; and the drill-down centring handler scrolls on
- * `root.set`, which the subsequent viewbox apply must overwrite — reversing the
- * two would leave the canvas centred on the plane rather than at the saved
- * viewbox. A missing root id (top-level plane) or missing element ids degrade
- * gracefully rather than throwing.
- */
-export function applyViewState(m: ViewStateManagers, state: ViewState): void {
-    m.rootElement.setRootElementById(state.rootElementId);
-    m.viewport.setViewport(state.viewport);
-    m.selection.selectElementsByIds(state.selectedElementIds);
+// Restore the root first: coordinates are plane-relative, and root.set scrolls the canvas.
+// Applying the saved viewport afterward overrides that automatic centering.
+export function applyViewState(managers: ViewStateManagers, state: ViewState): void {
+    managers.rootElement.setRootElementById(state.rootElementId);
+    managers.viewport.setViewport(state.viewport);
+    managers.selection.selectElementsByIds(state.selectedElementIds);
 }

--- a/packages/bpmn-modeler/src/viewer/index.ts
+++ b/packages/bpmn-modeler/src/viewer/index.ts
@@ -1,26 +1,8 @@
 /**
- * `@miragon/bpmn-modeler/viewer` — the host-free, readonly BPMN viewer subpath.
- *
- * A view-only surface: it wraps bpmn-js's NavigatedViewer + outline and the
- * mode-invariant canvas chrome (minimap, readonly token simulation, keyboard
- * focus — ADR 0022), and drags none of the Camunda editing stack
- * (camunda-bpmn-js, CodeMirror, lint) into the module graph. It does carry the
- * browser-only diff rendering primitives, the shared i18n translator via `DiffLegend` (#1439),
- * and — when a consumer opts in via `propertiesPanel` — the engine-neutral
- * readonly panel (preact via `@bpmn-io/properties-panel`, #1443). When a consumer
- * opts into `capabilities.modelNavigation` (#1445), it also registers a
- * diagram-js context pad carrying only the "Navigate to referenced model" entry —
- * the one interaction a readonly surface still offers. See ADR 0014 and its
- * amendments.
- *
- * Deliberately imports **no CSS**: `cssCodeSplit: false` on the lib build would
- * fold any stylesheet reachable from here into the shared `dist/bpmn-modeler.css`
- * (the modeler's `styles.css`), pulling the editor chrome's CSS back in. The
- * viewer's own sheet ships separately as `@miragon/bpmn-modeler/viewer.css`
- * (built by `vite.viewer-css.config.mts`), which a consumer loads instead.
+ * Readonly BPMN viewing and browser diff rendering, without the Camunda editing stack.
+ * Load `@miragon/bpmn-modeler/viewer.css` separately.
  */
 
-// ── Public factory + API surface ─────────────────────────────────────────────
 export { createViewer } from "./createViewer";
 export type {
     ViewerOptions,
@@ -31,23 +13,19 @@ export type {
 } from "./publicApi";
 export type { ThemeMode } from "../publicApi";
 
-// ── Model-navigation capability — the one engine-neutral host port on /viewer ─
 export type {
     ModelNavigationPort,
     ModelReference,
     ReferenceKind,
 } from "@miragon/bpmn-model-navigation";
 
-// ── Viewport / selection — public, referenced by the viewer handle ───────────
 export { ViewportManager } from "../viewport";
 export type { ViewportData } from "../viewport";
 export { SelectionManager } from "../selection";
 export type { RootElementManager } from "../rootElement";
 export type { ViewState } from "../viewState";
 
-// ── Diff view — public rendering primitives + in-page coordinator ────────────
-// The data layer (`computeDiff`/`sideView`) is the Node-safe
-// `@miragon/bpmn-modeler/diff` subpath; these are the browser-only primitives.
+// Diff computation is also usable in Node through @miragon/bpmn-modeler/diff.
 export { DiffViewer } from "./diff/DiffViewer";
 export type { DiffMarkerClass } from "./diff/DiffViewer";
 export { DiffLegend } from "./diff/DiffLegend";
@@ -55,5 +33,4 @@ export type { DiffLegendCallbacks, DiffLegendContext } from "./diff/DiffLegend";
 export { DiffNavigator } from "./diff/DiffNavigator";
 export { DiffPaneCoordinator } from "./diff/DiffPaneCoordinator";
 
-// ── Re-export so the rolled-up `.d.ts` stays self-contained ──────────────────
 export { NoModelerError } from "@miragon/bpmn-modeler-types";

--- a/packages/bpmn-modeler/src/viewer/viewer.ts
+++ b/packages/bpmn-modeler/src/viewer/viewer.ts
@@ -5,10 +5,7 @@ import MinimapModule from "diagram-js-minimap";
 import TokenSimulationViewerModule from "bpmn-js-token-simulation/lib/viewer";
 import { ImportXMLError, ImportXMLResult, SaveXMLResult } from "bpmn-js/lib/BaseViewer";
 import { createModelNavigationModule } from "@miragon/bpmn-model-navigation";
-// Deep imports on purpose: the lib barrel side-effect-imports its CSS, and the
-// viewer entry must stay CSS-free (`cssCodeSplit: false` would fold any
-// reachable sheet into the shared `dist/bpmn-modeler.css`). Gated by
-// `architecture.spec.ts`; the panel sheets ship via `viewer.css` instead.
+// Deep imports avoid the barrel's CSS side effects; viewer styles must stay separate from editor CSS.
 import PropertiesPanelModule from "@miragon/bpmn-modeler-properties-panel/render/index";
 import NeutralPropertiesProviderModule from "@miragon/bpmn-modeler-properties-panel/provider/index";
 import { ModeFilterModule } from "@miragon/bpmn-modeler-properties-panel/modeFilter/ModeFilterProvider";
@@ -32,31 +29,8 @@ import type { ThemeMode } from "../publicApi";
 import type { CoreViewerServices, ViewerOptions } from "./publicApi";
 
 /**
- * Encapsulates one readonly bpmn-js viewer instance — the view-only analogue of
- * {@link BpmnModeler}.
- *
- * Wraps `bpmn-js/lib/NavigatedViewer` (mouse + keyboard pan/zoom, no editing)
- * plus `bpmn-js/lib/features/outline`, the one module the base viewer lacks for
- * *visible* selection/hover, and the mode-invariant canvas chrome every surface
- * shares (ADR 0022): the minimap, the readonly token-simulation variant, and the
- * keyboard-focus features. Viewport and selection concerns delegate to the
- * shared {@link ViewportManager} / {@link SelectionManager}, so the same
- * `ServiceAccessor`-based managers back both the modeler and the viewer.
- *
- * With `options.propertiesPanel` set, the engine-neutral properties panel
- * (`@miragon/bpmn-modeler-properties-panel`) mounts readonly: the renderer
- * derives readonly from the absent `modeling` service and disables every entry.
- * Without the option, none of the panel modules enter the DI graph.
- *
- * With `options.capabilities.modelNavigation` set, a diagram-js context pad
- * carrying only the "Navigate to referenced model" entry is registered — the one
- * interaction a readonly surface still offers. Without it, no `contextPad`
- * service enters the graph.
- *
- * Per-instance by construction: bound to its own `container`, so several viewers
- * (or a viewer beside a modeler) can coexist on a page. Use {@link createViewer}
- * as the factory. Every accessor throws {@link NoModelerError} before
- * {@link init} or after {@link destroy}.
+ * An independent readonly BPMN surface with optional properties and model navigation.
+ * Create it with {@link createViewer}; accessors require a live instance.
  */
 export class BpmnViewer {
     private viewer: NavigatedViewer | undefined = undefined;
@@ -65,17 +39,12 @@ export class BpmnViewer {
 
     private _selection: SelectionManager | undefined;
 
-    // Drill-down plane tracking, composed into captureViewState/applyViewState
-    // and exposed via the public `rootElement` getter for host-driven restore.
     private _rootElement: RootElementManager | undefined;
 
-    // Per-instance theme controller, created lazily on the first setTheme.
     private themeController?: ThemeController;
 
-    // Disposes the canvas-size observer installed by loadDiagram.
     private stopObservingSize?: () => void;
 
-    // Teardown for the container-scoped focus features installed in init().
     private focusDisposers: Array<() => void> = [];
 
     /**
@@ -129,12 +98,7 @@ export class BpmnViewer {
         applyViewStateComposition(this.viewStateManagers(), state);
     }
 
-    /**
-     * The three managers backing view-state capture/apply. Reading `viewport`
-     * throws {@link NoModelerError} before {@link init}; the root manager is
-     * created and cleared in lockstep with it, so the assertion never fires
-     * after that guard passes.
-     */
+    // Accessing viewport guards initialization; all three managers share its lifecycle.
     private viewStateManagers() {
         return {
             viewport: this.viewport,
@@ -143,22 +107,11 @@ export class BpmnViewer {
         };
     }
 
-    /**
-     * Creates and mounts the bpmn-js viewer, then wires the viewport/selection
-     * managers. Async for API-stability symmetry with {@link BpmnModeler.init}.
-     *
-     * @internal Construction step invoked by {@link createViewer}; not part of
-     *   the public handle.
-     */
+    /** @internal */
     async init(): Promise<void> {
         const panel = this.options.propertiesPanel;
 
-        // diagram-js's plain context pad, never bpmn-js's — the latter's provider
-        // drags connect/create/direct-editing/popup-menu and injects `modeling`,
-        // which a readonly viewer never registers. Registered only with the
-        // capability, so an omitted port leaves the graph byte-identical (no
-        // `contextPad` service). ContextPad's deps (interaction-events, scheduler,
-        // overlays) are already in the viewer graph.
+        // bpmn-js's context pad requires modeling; use diagram-js's to preserve readonly behavior.
         const navigationPort = this.options.capabilities?.modelNavigation;
         const capModules = navigationPort
             ? [ContextPadModule, createModelNavigationModule(navigationPort)]
@@ -167,29 +120,20 @@ export class BpmnViewer {
         this.viewer = new NavigatedViewer({
             container: this.container,
             moddleExtensions: this.options.moddleExtensions,
-            // Ship the minimap collapsed; the toggle lives in the canvas corner.
             minimap: { open: false },
             ...(panel && {
                 propertiesPanel: {
                     parent: panel.parent,
-                    // Mount the FEEL popup (an unconditional panel dependency)
-                    // inside the instance container — it defaults to
-                    // document.body, outside this instance's theme scope.
+                    // Keep popups within this instance's theme scope instead of document.body.
                     feelPopupContainer: this.container,
                 },
             }),
-            // Outline is Modeler-only upstream; it is the single addition that
-            // makes selection/hover visible on the otherwise chrome-free viewer.
+            // NavigatedViewer omits Outline, which is needed to make selection and hover visible.
             additionalModules: [
                 OutlineModule,
                 MinimapModule,
-                // The readonly simulation variant: no canvas lock or modelling
-                // disable, since the viewer never registers `modeling`.
+                // The readonly variant does not require the absent modeling service.
                 TokenSimulationViewerModule,
-                // The full design-parity panel set: renderer + neutral provider
-                // + mode filter (identity here, no engine provider to reduce) +
-                // the host custom-group slot. The renderer attaches on
-                // `diagram.init` and renders readonly (no `modeling` service).
                 ...(panel
                     ? [
                           PropertiesPanelModule,
@@ -211,12 +155,6 @@ export class BpmnViewer {
         this.installFocusFeatures();
     }
 
-    /**
-     * Composes the container-scopable focus features onto the fresh viewer: the
-     * "Escape → focus canvas" guard and the canvas focus reticle, the same pair
-     * the editable surfaces install. The viewer has no search pad, so those
-     * ports are inert.
-     */
     private installFocusFeatures(): void {
         const canvas = this.getViewer().get<{
             getContainer(): HTMLElement;

--- a/packages/bpmn-modeler/src/viewport.ts
+++ b/packages/bpmn-modeler/src/viewport.ts
@@ -16,19 +16,12 @@ export interface ViewportData {
     scale?: number;
 }
 
-/** Accessor for a service from the bpmn-js DI container, by name. */
 type ServiceAccessor = <T>(name: string) => T;
 
-// Zoom floor when focusing an element, so a far-zoomed-out view still shows it
-// legibly. Never zooms out past the user's current level.
+// Keep focused elements legible without zooming out from the current view.
 const MIN_FOCUS_ZOOM = 0.75;
 
-/**
- * Reads, writes, and subscribes to canvas viewbox changes.
- *
- * Decoupled from the modeler through a {@link ServiceAccessor} so the
- * viewport concern can be tested and composed independently.
- */
+/** Reads, restores, and subscribes to canvas viewbox changes. */
 export class ViewportManager {
     constructor(private readonly getService: ServiceAccessor) {}
 
@@ -66,9 +59,7 @@ export class ViewportManager {
             return this.fitViewport();
         }
         const canvas = this.getService<any>("canvas");
-        // The container size at restore time is not the size at save time
-        // (VS Code re-show / panel layout race), so zoom must be pinned
-        // explicitly rather than derived from width/height.
+        // Pin saved zoom explicitly because the container may have resized since capture.
         if (viewport.scale !== undefined && Number.isFinite(viewport.scale) && viewport.scale > 0) {
             const { outer } = canvas.viewbox();
             canvas.viewbox({
@@ -104,28 +95,19 @@ export class ViewportManager {
         const canvas = this.getService<any>("canvas");
         const { inner, outer } = canvas.viewbox();
 
-        // Leaving bpmn-js's identity transform alone keeps the diagram
-        // visible, just not centred; fitting against an unlaid-out container
-        // would divide by it and blank the canvas instead.
+        // Fitting a zero-sized container would produce a NaN transform and blank the canvas.
         if (!this.isCanvasSized()) {
             return false;
         }
 
-        // No elements — nothing to fit; let bpmn-js handle the degenerate case.
         if (!inner.width || !inner.height) {
             canvas.zoom("fit-viewport");
             return true;
         }
 
-        // Insets are margins, not hard constraints. A palette whose stylesheet
-        // has not been applied yet measures as a full-width block, which would
-        // swallow the viewport and shrink the diagram to nothing; capping each
-        // inset keeps half the canvas available whatever the chrome reports.
+        // An unstyled palette can measure as full-width; cap insets so it cannot consume the viewport.
         const maxInsetX = outer.width / 4;
         const maxInsetY = outer.height / 4;
-        // Scope the palette lookup to this modeler's own container: with two
-        // modelers on a page a bare `document.querySelector` would measure the
-        // first palette, insetting the wrong canvas.
         const paletteWidth =
             canvas.getContainer().querySelector(".djs-palette")?.getBoundingClientRect().width ??
             50;
@@ -141,13 +123,9 @@ export class ViewportManager {
 
         const scale = Math.min(1, availableWidth / inner.width, availableHeight / inner.height);
 
-        // Center the diagram inside the inset area: split the leftover space
-        // evenly, then shift by the inset so each side keeps its own margin.
         const marginX = inset.left + (availableWidth - inner.width * scale) / 2;
         const marginY = inset.top + (availableHeight - inner.height * scale) / 2;
 
-        // Map diagram-space to a viewbox so the diagram's top-left lands at
-        // (marginX, marginY) px; box width/height pin the resulting scale.
         canvas.viewbox({
             x: inner.x - marginX / scale,
             y: inner.y - marginY / scale,
@@ -175,8 +153,6 @@ export class ViewportManager {
         }
 
         const viewbox = canvas.viewbox();
-        // scale = outer/viewbox width; below the floor, widen the box (smaller
-        // viewbox = higher zoom).
         const scale = viewbox.width > 0 ? viewbox.outer.width / viewbox.width : MIN_FOCUS_ZOOM;
         const width = scale < MIN_FOCUS_ZOOM ? viewbox.outer.width / MIN_FOCUS_ZOOM : viewbox.width;
         const height =

--- a/packages/bpmn-modeler/vite.config.mts
+++ b/packages/bpmn-modeler/vite.config.mts
@@ -4,19 +4,14 @@ import { isAbsolute, resolve } from "node:path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import dts from "unplugin-dts/vite";
 
-// One shared inventory drives both bundling/declaration emission and the peer
-// dependency guard. Everything else bare is a real dependency and stays
-// external — see `external` below and ADR 0006.
+// Share the inventory with the peer guard to keep bundled libraries and runtime requirements aligned.
 const inlinedLibraries = JSON.parse(
     readFileSync(new URL("./inlined-libraries.json", import.meta.url), "utf8"),
 ) as { name: string; sourceRoot: string }[];
 const INLINED_LIBS = inlinedLibraries.map(({ name }) => name);
 const INLINED_LIB_SRC = inlinedLibraries.map(({ sourceRoot }) => sourceRoot);
 
-// These descriptor JSON files are lazy imports of the inlined diff library.
-// Turn exactly these two into JavaScript chunks so the published Node entry
-// never relies on JSON import attributes. All other npm dependencies remain
-// external.
+// Bundle descriptors as JavaScript so Node consumers do not need JSON import attributes.
 const INLINED_DESCRIPTOR_JSON = new Set([
     "camunda-bpmn-moddle/resources/camunda.json",
     "zeebe-bpmn-moddle/resources/zeebe.json",
@@ -26,16 +21,12 @@ function isInlined(id: string): boolean {
     return INLINED_LIBS.some((name) => id === name || id.startsWith(`${name}/`));
 }
 
-// Bundle relatives, absolute (alias-resolved) paths, the inlined libs, and CSS;
-// externalise every other bare specifier so the bpmn-io stack is never bundled.
-// `@oxc-project/runtime` is Vite 8's oxc transform-helper runtime (the tslib
-// analogue for its own lowering) — inline it so consumers never take a
-// dependency on our build tool's internals.
 function isExternal(id: string): boolean {
     if (id.startsWith(".") || isAbsolute(id)) return false;
     if (id.endsWith(".css")) return false;
     if (isInlined(id)) return false;
     if (INLINED_DESCRIPTOR_JSON.has(id)) return false;
+    // Consumers must not need a dependency on Vite's transform runtime.
     if (id === "@oxc-project/runtime" || id.startsWith("@oxc-project/runtime/")) return false;
     return true;
 }
@@ -48,11 +39,7 @@ export default defineConfig({
         dts({
             tsconfigPath: "./tsconfig.lib.json",
             include: ["src", ...INLINED_LIB_SRC],
-            // Keep the `@miragon/*` specifiers in the emitted d.ts (do NOT rewrite
-            // them to source `.ts` paths); api-extractor then resolves them via
-            // tsconfig `paths` and inlines the ones listed in `bundledPackages`,
-            // producing one self-contained `dist/index.d.ts` with only bare npm
-            // externals left as imports.
+            // Preserve package specifiers so API Extractor can resolve and inline bundled declarations.
             pathsToAliases: false,
             bundleTypes: {
                 bundledPackages: INLINED_LIBS,
@@ -65,40 +52,17 @@ export default defineConfig({
     },
     build: {
         target: "es2021",
+        // Viewer, design, and mode CSS are built separately to avoid merging them into the editor sheet.
         cssCodeSplit: false,
         commonjsOptions: { transformMixedEsModules: true },
         chunkSizeWarningLimit: 1200,
         lib: {
             entry: {
                 index: resolve(__dirname, "src/index.ts"),
-                // Data-layer subpath (`@miragon/bpmn-modeler/diff`): no CSS,
-                // bpmn-js, i18n, or preact — Node-safe (check-diff-node.mjs).
                 diff: resolve(__dirname, "src/diff/index.ts"),
-                // Injectable lint subpath (`@miragon/bpmn-modeler/lint`, #1407):
-                // the lint stack a host imports and hands in via `linting.module`,
-                // so it never lands in a `linting: false` consumer's bundle. Its
-                // CSS still folds into `dist/bpmn-modeler.css` (cssCodeSplit off).
                 lint: resolve(__dirname, "src/bpmnlint/index.ts"),
-                // Readonly viewer subpath (`@miragon/bpmn-modeler/viewer`, #1405):
-                // NavigatedViewer + outline plus the browser-only diff rendering
-                // primitives (#1439), none of the editor stack. It imports no CSS
-                // (so `cssCodeSplit: false` cannot fold any into
-                // `dist/bpmn-modeler.css`); its sheet ships as `dist/viewer.css`
-                // via `vite.viewer-css.config.mts`.
                 viewer: resolve(__dirname, "src/viewer/index.ts"),
-                // Engine-neutral design subpath (`@miragon/bpmn-modeler/design`,
-                // #1196): base bpmn-js Modeler + a plain-BPMN properties panel,
-                // none of the Camunda editor stack. Like `/viewer` it imports no
-                // CSS (its sheet ships as `dist/design.css` via
-                // `vite.viewer-css.config.mts`); purity gated by
-                // `check-design-pure-entry.mjs`.
                 design: resolve(__dirname, "src/design/index.ts"),
-                // Mode-session subpath (`@miragon/bpmn-modeler/mode`, #1447): the
-                // View↔Design↔Implement session + opt-in strip, with the surface
-                // factories injected by the consumer so it value-imports no
-                // bpmn-js/Camunda code. Imports no CSS (its sheet ships as
-                // `dist/mode.css` via `vite.viewer-css.config.mts`); purity gated
-                // by `check-mode-pure-entry.mjs`.
                 mode: resolve(__dirname, "src/modeSession/index.ts"),
             },
             formats: ["es"],

--- a/packages/bpmn-modeler/vite.themes.config.mts
+++ b/packages/bpmn-modeler/vite.themes.config.mts
@@ -3,15 +3,8 @@ import { resolve } from "node:path";
 
 import stripThemeScope from "./scripts/postcss-strip-theme-scope.mjs";
 
-// The two legacy theme stylesheets ship as standalone CSS entries a consumer
-// links via `#theme-link` (the permanent compatibility fallback for the
-// authoritative `data-bpmn-theme` attribute mechanism). The dark source is
-// authored scoped under `[data-bpmn-theme="dark"]`; `stripThemeScope` removes
-// that scope here so the split `darkTheme.css` stays un-scoped as before (the
-// light input has no attribute, so the plugin is a no-op on it). CSS cannot be a
-// Vite lib entry, so this is a separate CSS-only rollup. The output names are a
-// de-facto contract — `#theme-link` swaps `lightTheme.css` ↔ `darkTheme.css` by
-// name — so keep them exact.
+// CSS cannot be a Vite library entry, so legacy theme sheets need a separate build.
+// Strip dark scoping for page-global links; preserve filenames used by #theme-link swaps.
 export default defineConfig({
     root: __dirname,
     cacheDir: "../../node_modules/.vite/bpmn-modeler-themes",

--- a/packages/bpmn-modeler/vite.viewer-css.config.mts
+++ b/packages/bpmn-modeler/vite.viewer-css.config.mts
@@ -1,15 +1,8 @@
 import { defineConfig } from "vite";
 import { resolve } from "node:path";
 
-// The readonly viewer's stylesheet ships as a standalone `dist/viewer.css`
-// entry (`@miragon/bpmn-modeler/viewer.css`), because the viewer's `index.ts`
-// imports no CSS: `cssCodeSplit: false` on the main lib build would otherwise
-// fold any viewer-reachable sheet into `dist/bpmn-modeler.css`, dragging the
-// editor chrome back in. CSS cannot be a Vite *lib* entry, so this is a separate
-// CSS-only rollup (the same pattern as `vite.themes.config.mts`), but WITHOUT
-// `stripThemeScope`: the viewer sheet keeps its `[data-bpmn-theme="dark"]`
-// scoping so per-instance theming works. `emptyOutDir: false` so it does not
-// wipe the lib build's `dist/`.
+// CSS cannot be a Vite library entry. Build separate sheets here so the main
+// library build does not merge them into the editor CSS; retain per-instance theme scoping.
 export default defineConfig({
     root: __dirname,
     cacheDir: "../../node_modules/.vite/bpmn-modeler-viewer-css",

--- a/packages/dmn-modeler/scripts/check-dts.mjs
+++ b/packages/dmn-modeler/scripts/check-dts.mjs
@@ -1,11 +1,4 @@
-// The published type surface must not leak the private webview↔host protocol,
-// the engine core, an un-bundled private workspace lib, or dmn-js itself. Fails
-// the build if the rolled-up `dist/index.d.ts` names a protocol symbol
-// (`HostApi`/`Query`/`Command`), references `@miragon/bpmn-modeler-shared` /
-// `@miragon/bpmn-modeler-core`, imports a private workspace lib (those are
-// inlined, so a surviving import means the roll-up leaked a dependency the
-// consumer cannot install), or imports `dmn-js` (consumers lack our ambient
-// `src/types/*.d.ts`, so a surviving `from "dmn-js"` would not type-check).
+// Consumers cannot resolve private workspace imports or our local dmn-js ambient types.
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
@@ -13,14 +6,10 @@ import { dirname, resolve } from "node:path";
 const distDir = resolve(dirname(fileURLToPath(import.meta.url)), "../dist");
 const ENTRY_DTS = ["index.d.ts"];
 
-// Whole-word protocol type names + the private protocol/engine packages, plus a
-// bare `dmn-js` module specifier (the ambient types must not leak into the dist).
 const FORBIDDEN_CONTENT =
     /\bHostApi\b|\bQuery\b|\bCommand\b|@miragon\/bpmn-modeler-shared|@miragon\/bpmn-modeler-core|\bfrom\s+["']dmn-js/g;
 
-// Private workspace libs are inlined at build time — none may survive as an
-// import in the flattened d.ts. `@miragon/bpmn-modeler-diff` is transitively
-// reachable through the modeler-types barrel, so guard it too.
+// The diff package is reachable transitively through the modeler-types barrel.
 const PRIVATE_LIBS = [
     "@miragon/bpmn-modeler-types",
     "@miragon/bpmn-modeler-i18n-extras",
@@ -44,9 +33,7 @@ function checkEntry(fileName) {
         failures.push(`leaked private symbols: ${[...new Set(contentHits)].join(", ")}`);
     }
 
-    // Invalid-ambient guard: a function re-exported from a bundled lib can be
-    // rolled up with its implementation *body*, producing `declare function …() {`
-    // or `declare async function …` — both illegal in a `.d.ts`.
+    // Declaration rollup can incorrectly retain implementation bodies on re-exports.
     if (
         /\bdeclare\s+async\s+function\b/.test(dts) ||
         /\bdeclare\s+function\b[^;{]*\)[^;]*\{/.test(dts)

--- a/packages/dmn-modeler/scripts/check-externals.mjs
+++ b/packages/dmn-modeler/scripts/check-externals.mjs
@@ -1,10 +1,4 @@
-// Externals gate: every bare specifier the built bundle imports must be a
-// declared `dependencies` key. The Vite lib build externalises the whole dmn-js
-// stack (only the two private libs are inlined), so a bare import that is not a
-// declared dependency is a leak a real installer cannot resolve — either an
-// un-inlined private workspace lib or an undeclared transitive external. This
-// mechanises the JS side of the "no leaked private lib / undeclared external"
-// property (`check-dts.mjs` covers the types side).
+// Undeclared externals may resolve in the monorepo but fail in a consumer install.
 import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
@@ -14,7 +8,6 @@ const distDir = join(pkgRoot, "dist");
 const manifest = JSON.parse(readFileSync(join(pkgRoot, "package.json"), "utf8"));
 const declared = new Set(Object.keys(manifest.dependencies ?? {}));
 
-// import/export … from "x"; bare `import "x"`; dynamic import("x"); require("x").
 const SPECIFIER_PATTERNS = [
     /\bfrom\s*["']([^"']+)["']/g,
     /\bimport\s*["']([^"']+)["']/g,
@@ -22,7 +15,6 @@ const SPECIFIER_PATTERNS = [
     /\brequire\s*\(\s*["']([^"']+)["']/g,
 ];
 
-/** The installable package name of a bare specifier (`@scope/name/sub` → `@scope/name`). */
 function packageName(spec) {
     const parts = spec.split("/");
     return spec.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
@@ -44,13 +36,12 @@ if (jsFiles.length === 0) {
     process.exit(1);
 }
 
-const undeclared = new Map(); // package name → set of files
+const undeclared = new Map();
 for (const file of jsFiles) {
     const code = readFileSync(file, "utf8");
     for (const pattern of SPECIFIER_PATTERNS) {
         for (const match of code.matchAll(pattern)) {
             const spec = match[1];
-            // Relatives, absolutes, and Node builtins never come from dependencies.
             if (spec.startsWith(".") || spec.startsWith("/") || spec.startsWith("node:")) continue;
             const name = packageName(spec);
             if (!declared.has(name)) {

--- a/packages/dmn-modeler/scripts/postcss-strip-theme-scope.d.mts
+++ b/packages/dmn-modeler/scripts/postcss-strip-theme-scope.d.mts
@@ -1,5 +1,4 @@
 import type { PluginCreator } from "postcss";
 
-/** Strips the `[data-dmn-theme="dark"]` scope so the legacy split sheet stays un-scoped. */
 declare const stripThemeScope: PluginCreator<void>;
 export default stripThemeScope;

--- a/packages/dmn-modeler/scripts/postcss-strip-theme-scope.mjs
+++ b/packages/dmn-modeler/scripts/postcss-strip-theme-scope.mjs
@@ -1,26 +1,12 @@
 import selectorParser from "postcss-selector-parser";
 
-/**
- * PostCSS plugin that strips the `[data-dmn-theme="dark"]` scope from every
- * selector, turning the single scoped source (`dark-theme/*.css`) back into the
- * legacy un-scoped `darkTheme.css` shape linked via `#theme-link`.
- *
- * Two cases, matching the authored scoping conventions:
- *   - the attribute stands alone in its compound (`[data-dmn-theme="dark"] S`)
- *     → replace it with `:root`, preserving the descendant relationship;
- *   - the attribute is compounded onto another simple selector
- *     (`:root[data-dmn-theme="dark"]`, `.properties-panel-parent[data-dmn-theme="dark"]`)
- *     → delete just the attribute node, leaving the rest of the compound.
- *
- * A no-op on selectors that never mention the attribute (e.g. the light input).
- */
+// Legacy split stylesheets must work without a data-dmn-theme attribute.
 const ATTRIBUTE = "data-dmn-theme";
 
 function isCombinator(node) {
     return node?.type === "combinator";
 }
 
-/** The non-combinator nodes sharing `attr`'s compound (contiguous, no combinator). */
 function compoundSize(attr) {
     const siblings = attr.parent.nodes;
     const index = siblings.indexOf(attr);
@@ -34,6 +20,7 @@ const transform = selectorParser((selectors) => {
     selectors.walkAttributes((attr) => {
         if (attr.attribute !== ATTRIBUTE) return;
         if (compoundSize(attr) === 1) {
+            // Preserve the descendant relationship when removing a standalone scope.
             attr.replaceWith(selectorParser.pseudo({ value: ":root" }));
         } else {
             attr.remove();

--- a/packages/dmn-modeler/scripts/smoke-consumer.mjs
+++ b/packages/dmn-modeler/scripts/smoke-consumer.mjs
@@ -1,24 +1,5 @@
-// Scratch-consumer smoke test: proves the *packed* tarball works once installed
-// like a real dependency, not just that it builds in-repo.
-//
-// Runs from a throwaway project (`npm init -y`, `type: module`,
-// `npm install <tarball> jsdom esbuild`) where `@miragon/dmn-modeler` resolves
-// through node_modules — the same path an out-of-repo consumer takes. It asserts:
-//   1. no `workspace:*` range survived the pack (yarn rewrites them to real
-//      versions; a survivor would `npm install`-fail for a real consumer);
-//   2. every `exports` subpath resolves to a file that exists;
-//   3. the package + its externalised dmn-js stack **bundle** and import, and
-//      `createModeler` + `loadDiagram` of a minimal DMN succeeds.
-//
-// Step 3 goes through esbuild on purpose. The dmn-js stack (dmn-js,
-// dmn-js-shared, dmn-js-drd, …) ships no `exports` maps and uses extensionless
-// deep imports, so it does not resolve under Node's native ESM resolver — only
-// through a bundler, which is how every real consumer (Vite/webpack/esbuild)
-// and the webview host use it. We therefore bundle a tiny consumer entry the
-// same way, then run it. A direct `import("@miragon/dmn-modeler")` under bare
-// `node` would fail on dmn-js internals and prove nothing about real usage.
-// If dmn-js cannot render under jsdom in the scratch app this degrades to
-// import-only and says so.
+// Run from a scratch ESM project with the packed tarball, jsdom, and esbuild installed.
+// dmn-js uses extensionless deep imports that need a bundler to resolve.
 import { createRequire } from "node:module";
 import { existsSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -31,7 +12,6 @@ function fail(message) {
     process.exit(1);
 }
 
-// 1. No workspace: range survived the pack.
 const installedManifest = require(`${PKG}/package.json`);
 for (const field of [
     "dependencies",
@@ -46,7 +26,6 @@ for (const field of [
     }
 }
 
-// 2. Every exports subpath resolves to a real file.
 const SUBPATHS = [".", "./styles.css", "./light-theme.css", "./dark-theme.css"];
 for (const subpath of SUBPATHS) {
     const specifier = subpath === "." ? PKG : `${PKG}/${subpath.slice(2)}`;
@@ -61,11 +40,6 @@ for (const subpath of SUBPATHS) {
     }
 }
 
-// 3. Bundle a consumer entry with esbuild (resolving the dmn-js stack a real
-//    bundler would), then import the bundle and stand up a modeler. CSS/font
-//    assets the stack imports are dropped — the smoke exercises behaviour, not
-//    styling. A minimal DRD with one decision table, mirroring the sample the
-//    webview host uses for standalone runs.
 const MINIMAL_DMN = `<?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="smoke" name="Smoke" namespace="http://camunda.org/schema/1.0/dmn">
   <decision id="decision_1" name="Decision 1">
@@ -112,9 +86,7 @@ try {
 
 const { JSDOM } = await import("jsdom");
 const dom = new JSDOM(`<!doctype html><html><body></body></html>`, { pretendToBeVisual: true });
-// jsdom implements none of these; a real browser (every actual consumer's
-// environment) does. Stub them so the theme code, diagram-js layout and the
-// properties panel's rAF-scheduled render run headless.
+// Supply browser APIs missing from jsdom for headless rendering.
 dom.window.matchMedia ??= (query) => ({
     matches: false,
     media: query,
@@ -132,8 +104,7 @@ dom.window.cancelAnimationFrame ??= (id) => clearTimeout(id);
 dom.window.SVGElement.prototype.getBBox ??= () => ({ x: 0, y: 0, width: 0, height: 0 });
 globalThis.requestAnimationFrame = dom.window.requestAnimationFrame;
 globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame;
-// defineProperty, not assignment: Node >=21 ships `navigator` as a getter-only
-// global, so `globalThis.navigator = …` throws.
+// Node exposes navigator as a getter-only global, so assignment would throw.
 for (const key of ["window", "document", "navigator", "HTMLElement", "Node", "SVGElement"]) {
     Object.defineProperty(globalThis, key, {
         value: dom.window[key],
@@ -172,6 +143,5 @@ try {
     );
 }
 
-// The headless modeler leaves rAF/timer-scheduled render work pending; exit
-// explicitly so a late headless-only throw can't fail an otherwise-passed smoke.
+// Pending headless render timers can throw after the smoke has completed.
 process.exit(0);

--- a/packages/dmn-modeler/src/architecture.spec.ts
+++ b/packages/dmn-modeler/src/architecture.spec.ts
@@ -3,20 +3,7 @@ import { join, normalize } from "node:path";
 import postcss from "postcss";
 import { describe, expect, it } from "vitest";
 
-/**
- * Import-direction gate for `@miragon/dmn-modeler`.
- *
- * The published package may reach only *downward* — relatives, the private
- * workspace libs it inlines at build time, and bare npm specifiers. It must
- * never name the private webview↔host protocol (`@miragon/bpmn-modeler-shared`),
- * the extension engine (`@miragon/bpmn-modeler-core`), or anything under
- * `apps/`. Conversely, no `libs/*` may depend on the package (that would invert
- * the layering `packages → libs`, not `libs → packages`).
- *
- * Text-scan rather than archunit's graph: under this workspace's
- * `moduleResolution: "bundler"` tsconfig archunit resolves no cross-file edges
- * (see `libs/modeler-core/src/architecture.spec.ts`).
- */
+// Archunit resolves no cross-file edges with this workspace’s bundler resolution.
 const PKG_SRC = __dirname;
 const REPO_ROOT = normalize(join(__dirname, "../../.."));
 const LIBS_ROOT = join(REPO_ROOT, "libs");
@@ -56,7 +43,6 @@ function importedModules(content: string): string[] {
     );
 }
 
-/** `@miragon/dmn-modeler` exactly, or a subpath of it. */
 const PACKAGE_SELF = /^@miragon\/dmn-modeler(\/|$)/;
 
 describe("dmn-modeler import direction", () => {
@@ -82,11 +68,7 @@ describe("dmn-modeler import direction", () => {
     });
 
     it("package TS source reads no VS Code `<body>` theme classes", () => {
-        // Theme is host policy: the package resolves light/dark from
-        // `prefers-color-scheme` or an injected mode, never by reading the host's
-        // chrome. A `vscode-*` body class in TS source would mean the watcher
-        // leaked back in. (CSS files legitimately style `body.vscode-dark`; this
-        // gate is TS-only, matching listSourceFiles.)
+        // Host chrome must be mapped to a theme mode outside the package.
         const VSCODE_CLASS = /vscode-(dark|light|high-contrast)/;
         const offenders: string[] = [];
         for (const file of listSourceFiles(PKG_SRC)) {
@@ -101,10 +83,6 @@ describe("dmn-modeler import direction", () => {
     });
 
     it("every top-level dark-theme selector is scoped under data-dmn-theme", () => {
-        // The dark sheet is authored scoped so per-instance theming never leaks
-        // across instances (and the legacy split is derived by stripping the
-        // scope). A top-level rule that forgot the attribute would paint every
-        // instance dark. Nested rules are exempt — their parent carries the scope.
         const DARK_DIR = join(PKG_SRC, "styles", "dark-theme");
         const offenders: string[] = [];
         for (const entry of readdirSync(DARK_DIR)) {

--- a/packages/dmn-modeler/src/createModeler.ts
+++ b/packages/dmn-modeler/src/createModeler.ts
@@ -11,13 +11,8 @@ export async function createModeler(
 ): Promise<DmnModelerHandle> {
     i18n.extend(i18nExtras);
     const modeler = new DmnModeler(container, options);
-    // Always engage theming so the per-instance `data-dmn-theme` attribute is set
-    // from the first frame; `"automatic"` then follows `prefers-color-scheme`.
     modeler.setTheme(options.theme ?? "automatic");
-    // The i18n instance is a page-global singleton, so a locale set here is
-    // page-wide; only touch it when the caller is explicit, so a default call
-    // would not stomp a language the host already set. Runs before the caller's
-    // first `loadDiagram`, so the initial import already renders translated.
+    // Preserve the page-global locale unless explicitly overridden.
     if (options.locale) {
         i18n.setLanguage(options.locale as SupportedLocale);
     }

--- a/packages/dmn-modeler/src/modeler.ts
+++ b/packages/dmn-modeler/src/modeler.ts
@@ -53,7 +53,6 @@ interface FocusableCanvas extends ResizableCanvas {
     isFocused(): boolean;
 }
 
-/** DRD canvas surface the focus reticle attaches to and reads focus from. */
 interface FocusIndicatorCanvas {
     getContainer(): HTMLElement;
     isFocused(): boolean;
@@ -80,7 +79,7 @@ interface ViewboxCanvas extends ResizableCanvas {
     viewbox(box: Viewbox): void;
 }
 
-/** @internal Runtime implementation of the public per-instance handle. */
+/** @internal */
 export class DmnModeler implements DmnModelerHandle {
     private readonly modeler: VendorDmnModeler;
     private readonly stopObservingSize: () => void;
@@ -88,8 +87,6 @@ export class DmnModeler implements DmnModelerHandle {
     private disposeFocusIndicator?: () => void;
     private destroyed = false;
 
-    // Per-instance theme controller, created lazily on the first setTheme. Scopes
-    // `data-dmn-theme` to this instance's container + panel parent.
     private themeController?: ThemeController;
 
     constructor(
@@ -100,16 +97,11 @@ export class DmnModeler implements DmnModelerHandle {
 
         this.modeler = new VendorDmnModeler({
             container,
-            // TranslateModule is an opinionated built-in on every view (the
-            // host-set locale is page-global). The Manager rebuilds each view's
-            // `additionalModules` from these per-view arrays only — a
-            // `common.additionalModules` entry would be dropped — so it must be
-            // registered on all four.
+            // dmn-js drops common.additionalModules, so each view needs TranslateModule.
             drd: {
                 propertiesPanel: {
                     ...options.propertiesPanel,
-                    // The FEEL popup defaults to document.body, outside this
-                    // instance's `data-dmn-theme` scope; mount it in the container.
+                    // The default document.body mount lies outside this instance’s theme scope.
                     feelPopupContainer: container,
                 },
                 additionalModules: [
@@ -223,18 +215,15 @@ export class DmnModeler implements DmnModelerHandle {
         this.assertLive();
         const localeBefore = i18n.getLocale();
         i18n.setLanguage(locale as SupportedLocale);
-        // setLanguage resolves unknown codes to "en"; compare the resolved locale
-        // so a repeated push (the host re-sends on every reload) does not re-import.
+        // Compare resolved locales: unknown codes fall back to "en".
         if (i18n.getLocale() === localeBefore) {
             return;
         }
         const activeView = this.modeler.getActiveView();
-        // Nothing rendered yet — the first import will render translated already.
         if (!activeView) {
             return;
         }
-        // Re-opening clears the DRD viewbox/selection; capture and restore it so a
-        // language switch does not also move the diagram.
+        // Reopening resets the DRD viewbox; preserve it to avoid moving the diagram.
         const viewbox = this.isDrdViewActive()
             ? this.getActiveViewboxCanvas()?.viewbox()
             : undefined;
@@ -295,17 +284,11 @@ export class DmnModeler implements DmnModelerHandle {
             this.unbindCommandStack();
             this.activeEventBus = eventBus;
             this.activeEventBus?.on("commandStack.changed", this.handleContentChanged);
-            // The active viewer changed (or cleared) — re-attach the focus
-            // reticle, which only lives on the diagram-js-based DRD view.
             this.syncCanvasFocusIndicator();
         }
     }
 
-    /**
-     * (Re)installs the green focus reticle on the active DRD view, tearing down
-     * any previous one. The decision-table and literal-expression views are not
-     * diagram-js based (no canvas focus), so it is installed only for `drd`.
-     */
+    // Only the DRD view has diagram-js canvas focus.
     private syncCanvasFocusIndicator(): void {
         this.disposeFocusIndicator?.();
         this.disposeFocusIndicator = undefined;

--- a/packages/dmn-modeler/src/postcss-strip-theme-scope.spec.ts
+++ b/packages/dmn-modeler/src/postcss-strip-theme-scope.spec.ts
@@ -3,12 +3,6 @@ import { describe, expect, it } from "vitest";
 
 import stripThemeScope from "../scripts/postcss-strip-theme-scope.mjs";
 
-/**
- * The plugin derives the legacy un-scoped `darkTheme.css` from the single
- * `[data-dmn-theme="dark"]`-scoped source. It must remove every mention of the
- * attribute while preserving the selector's structure, so the split sheet keeps
- * matching the same elements a bare `#theme-link` swap always did.
- */
 function strip(css: string): string {
     return postcss([stripThemeScope()]).process(css, { from: undefined }).css;
 }

--- a/packages/dmn-modeler/src/publicApi.ts
+++ b/packages/dmn-modeler/src/publicApi.ts
@@ -1,15 +1,3 @@
-/**
- * The public TypeScript surface of the host-free DMN modeler facade.
- *
- * Engine features are split into the same categories used by ADR 0007:
- *
- * - **[A] Engine-intrinsic** features are always present.
- * - **[B] Opinionated built-ins** have a useful default and may be replaced.
- *
- * The `on*` members are outbound notifications, documented separately from
- * either category. They do not provide host capabilities to the modeler.
- */
-
 /** A view editor supported by dmn-js. */
 export type DmnViewType = "drd" | "decisionTable" | "literalExpression" | "boxedExpression";
 
@@ -75,7 +63,7 @@ export interface DmnKeyboardOptions {
 }
 
 /**
- * [B] Theme selection for a single instance. The modeler toggles a
+ * Theme selection for a single instance. The modeler toggles a
  * `data-dmn-theme` attribute on its container + panel parent (the authoritative
  * mechanism — dark rules are scoped under `[data-dmn-theme="dark"]`, so two
  * instances on one page can hold different themes) and mirrors the choice onto a
@@ -89,49 +77,43 @@ export type DmnThemeMode = "light" | "dark" | "automatic";
 
 /** Per-instance configuration for {@link createModeler}. */
 export interface DmnModelerOptions {
-    // ── [A] Engine-intrinsic ───────────────────────────────────────────────
-
-    /** [A] The properties-panel host owned by this modeler instance. */
+    /** The properties-panel host owned by this modeler instance. */
     propertiesPanel: { parent: HTMLElement };
 
     /**
-     * [A] Extra DI modules for individual view editors. Caller modules are
+     * Extra DI modules for individual view editors. Caller modules are
      * appended after the facade defaults, allowing deliberate overrides.
      */
     additionalModules?: DmnAdditionalModules;
 
-    /** [A] Extra moddle descriptors, merged over the bundled Camunda descriptor. */
+    /** Extra moddle descriptors, merged over the bundled Camunda descriptor. */
     moddleExtensions?: Record<string, object>;
 
     /**
-     * [A] Expression-language configuration. When supplied it replaces the
+     * Expression-language configuration. When supplied it replaces the
      * facade's six-language default.
      */
     expressionLanguages?: DmnExpressionLanguages;
 
-    /** [A] Data types shown by editors. When supplied they replace the defaults. */
+    /** Data types shown by editors. When supplied they replace the defaults. */
     dataTypes?: string[];
 
-    /** [A] Per-editor keyboard configuration. */
+    /** Per-editor keyboard configuration. */
     keyboard?: DmnKeyboardOptions;
 
-    // ── [B] Opinionated built-ins ───────────────────────────────────────────
-
     /**
-     * [B] Colour theme — defaults to `"automatic"`. Theming always engages: the
+     * Colour theme — defaults to `"automatic"`. Theming always engages: the
      * instance gets a `data-dmn-theme` attribute from the first frame regardless
      * of whether this is set.
      */
     theme?: DmnThemeMode;
 
     /**
-     * [B] UI locale — defaults to the page's current locale (`"en"`). Page-global:
+     * UI locale — defaults to the page's current locale (`"en"`). Page-global:
      * the i18n instance is a singleton, so this sets the locale for every modeler
      * on the page. An unknown code resolves to `"en"`.
      */
     locale?: string;
-
-    // ── Events (outbound notifications) ────────────────────────────────────
 
     /** Fired for every active editor `commandStack.changed` notification. */
     onContentChanged?: () => void;
@@ -145,38 +127,38 @@ export interface DmnModelerOptions {
 
 /** The independent instance handle returned by {@link createModeler}. */
 export interface DmnModelerHandle {
-    /** [A] Load DMN XML, replacing any currently loaded document. */
+    /** Load DMN XML, replacing any currently loaded document. */
     loadDiagram(xml: string): Promise<DmnOperationResult>;
 
-    /** [A] Serialise the current document as formatted DMN XML. */
+    /** Serialise the current document as formatted DMN XML. */
     exportDiagram(): Promise<string>;
 
-    /** [A] Return the active view, if the loaded document has one. */
+    /** Return the active view, if the loaded document has one. */
     getActiveView(): DmnView | undefined;
 
-    /** [A] Return every view in the loaded document. */
+    /** Return every view in the loaded document. */
     getViews(): DmnView[];
 
-    /** [A] Open a view previously returned by this handle. */
+    /** Open a view previously returned by this handle. */
     openView(view: DmnView): Promise<DmnOperationResult>;
 
-    /** [A] Whether the decision requirements diagram is active. */
+    /** Whether the decision requirements diagram is active. */
     isDrdViewActive(): boolean;
 
-    /** [A] Focus the active DRD canvas; safely does nothing in other views. */
+    /** Focus the active DRD canvas; safely does nothing in other views. */
     focusCanvas(): void;
 
-    /** [A] Whether the active DRD canvas owns focus; false in other views. */
+    /** Whether the active DRD canvas owns focus; false in other views. */
     isCanvasFocused(): boolean;
 
     /**
-     * [B] Switch the colour theme live. Toggles this instance's `data-dmn-theme`
+     * Switch the colour theme live. Toggles this instance's `data-dmn-theme`
      * attribute and mirrors it to a legacy `#theme-link` when present.
      */
     setTheme(theme: DmnThemeMode): void;
 
     /**
-     * [B] Set the page-global UI locale and re-open the active view so its already
+     * Set the page-global UI locale and re-open the active view so its already
      * rendered labels re-translate. A no-op when the resolved locale is unchanged
      * (an unknown code resolves to `"en"`). Because it re-opens the active view it
      * re-fires `onViewChanged` and clears that view's undo history, like a
@@ -184,17 +166,17 @@ export interface DmnModelerHandle {
      */
     setLocale(locale: string): Promise<void>;
 
-    /** [A] Tear down this instance and all of its listeners and observers. */
+    /** Tear down this instance and all of its listeners and observers. */
     destroy(): void;
 
     /**
-     * [A] Unstable escape hatch into the active dmn-js viewer's DI graph. The
+     * Unstable escape hatch into the active dmn-js viewer's DI graph. The
      * service names and returned shapes are not covered by this facade's API.
      */
     getService<T = unknown>(name: string): T;
 }
 
-/** [A] Factory signature for one independent DMN modeler instance. */
+/** Factory signature for one independent DMN modeler instance. */
 export type CreateDmnModeler = (
     container: HTMLElement,
     options: DmnModelerOptions,

--- a/packages/dmn-modeler/src/styles/base.css
+++ b/packages/dmn-modeler/src/styles/base.css
@@ -1,8 +1,3 @@
-/* dmn-js base stylesheets — the modeler's stock sheets, unmodified.
- *
- * Shipped as `@miragon/dmn-modeler/styles.css` (a consumer needs them to render
- * at all) and re-imported by both the light and dark theme entries so the stock
- * list lives in exactly one place. */
 @import "dmn-js/dist/assets/diagram-js.css";
 @import "dmn-js/dist/assets/dmn-js-decision-table.css";
 @import "dmn-js/dist/assets/dmn-js-decision-table-controls.css";

--- a/packages/dmn-modeler/src/styles/canvas.css
+++ b/packages/dmn-modeler/src/styles/canvas.css
@@ -1,10 +1,4 @@
-/* Modeler-DOM tweaks that are not part of the stock dmn-js sheets and are
- * theme-agnostic. Kept separate so the vendored sheets stay unmodified. */
-
-/* dmn-js only sets `outline-offset` on the focused DRD canvas, leaving the raw
- * user-agent focus outline — which some hosts (VS Code) paint in a jarring
- * accent colour around the whole canvas. Suppress it (matches the BPMN
- * package's `default.css`). */
+/* Replace the browser’s canvas outline with the focus indicator. */
 .djs-container svg:focus {
     outline: none;
 }

--- a/packages/dmn-modeler/src/styles/canvasFocusIndicator.css
+++ b/packages/dmn-modeler/src/styles/canvasFocusIndicator.css
@@ -1,7 +1,4 @@
-/* The DRD canvas focus reticle installed per instance (see
-   canvasFocusIndicator.ts). Unlike the BPMN canvas, the DMN DRD ships no
-   minimap, so the reticle takes the top-right corner outright — the DRD
-   definitions box sits top-left, keeping this corner clear. */
+/* The DRD has no minimap, leaving the top-right corner free for the indicator. */
 .canvas-focus-indicator {
     position: absolute;
     top: 20px;
@@ -10,7 +7,7 @@
     height: 31px;
     z-index: 10;
     pointer-events: none;
-    color: rgba(85, 85, 85, 0.55); /* theme-neutral base = light-canvas idle grey */
+    color: rgba(85, 85, 85, 0.55);
 }
 
 .canvas-focus-indicator svg {
@@ -19,24 +16,19 @@
     height: 100%;
 }
 
-/* The __on glyph is display:none while unfocused, and display:none terminates a
-   CSS animation — so re-displaying on each focus gain restarts the finite pulse
-   automatically, no JS timer needed. */
+/* display:none resets the animation so each focus gain restarts the pulse. */
 .canvas-focus-indicator:not(.is-focused) .canvas-focus-indicator__off {
     display: block;
 }
 
 .canvas-focus-indicator.is-focused .canvas-focus-indicator__on {
     display: block;
-    color: #00e676; /* fill="currentColor" → reticle in the Miragon komet green */
-    /* Steady glow the greeting pulse settles into: the animation runs a finite
-       2 iterations with no fill-mode, so it reverts to this static filter. */
+    color: #00e676;
     filter: drop-shadow(0 0 3px rgba(0, 230, 118, 0.55));
     animation: canvas-focus-pulse 1.1s ease-in-out 2;
 }
 
-/* drop-shadow (not box-shadow) so the glow hugs the glyph silhouette, not a square.
-   Keyframes start and end at the steady-state glow so the settle is seamless. */
+/* drop-shadow follows the glyph silhouette; matching endpoints avoid a jump. */
 @keyframes canvas-focus-pulse {
     0%,
     100% {
@@ -49,13 +41,10 @@
 
 @media (prefers-reduced-motion: reduce) {
     .canvas-focus-indicator.is-focused .canvas-focus-indicator__on {
-        animation: none; /* the static filter above keeps "on" distinguishable */
+        animation: none;
     }
 }
 
-/* Dark theme lightens the idle outline (the canvas is dark); the green + glow
-   already read on dark. Scoped to the per-instance `data-dmn-theme` root that
-   wraps this reticle, matching the package's per-instance theming. */
 [data-dmn-theme="dark"] .canvas-focus-indicator {
     color: rgba(190, 190, 190, 0.6);
 }

--- a/packages/dmn-modeler/src/styles/dark-theme/base-layout.css
+++ b/packages/dmn-modeler/src/styles/dark-theme/base-layout.css
@@ -1,14 +1,5 @@
-/* Dark-theme overrides for the host page layout.
- *
- * `styles.css` hardcodes a light body, light panel dividers and a blue resizer
- * accent. Any 1-px rounding gap in the flex layout (e.g. a collapsed panel at
- * width 0) lets the white body show through as a bright strip, so the surfaces
- * are repainted from the same `--dt-*` scale the diagram and panel use.
- *
- * These are page chrome (not inside a modeler instance's container), so they key
- * off the root attribute the host adapter sets — `:root[data-dmn-theme="dark"]`.
- * `.properties-panel-parent` is both a per-instance scope root and page chrome,
- * so it carries both forms (cf. the bpmn package's properties-panel.css). */
+/* Paint layout gaps dark to prevent bright strips at fractional panel widths.
+ * Page chrome needs the root theme attribute because it sits outside modeler containers. */
 @import "./colors.css";
 
 :root[data-dmn-theme="dark"],
@@ -21,13 +12,11 @@
     color: var(--dt-surface-a70);
 }
 
-/* Properties-panel divider. */
 .properties-panel-parent[data-dmn-theme="dark"],
 :root[data-dmn-theme="dark"] .properties-panel-parent {
     border-left-color: var(--dt-surface-a30);
 }
 
-/* Resizer handle between canvas and panel. */
 :root[data-dmn-theme="dark"] .panel-resizer {
     border-left-color: var(--dt-surface-a20);
 }
@@ -37,15 +26,13 @@
     border-left-color: var(--dt-primary-a10);
 }
 
-/* Restore the resting divider colour while the toggle button is hovered, so the
- * button's own hover styling doesn't stack into a halo. */
+/* Avoid a doubled hover halo behind the toggle button. */
 :root[data-dmn-theme="dark"] .panel-resizer:has(.panel-resizer-toggle:hover) {
     background-color: transparent;
     border-left-color: var(--dt-surface-a20);
 }
 
-/* Override the accent custom properties the collapsed resizer's pseudo-element
- * line segments read, so the swap wins regardless of stylesheet load order. */
+/* Override the pseudo-element variables so stylesheet load order cannot restore the accent. */
 :root[data-dmn-theme="dark"] .panel-resizer.collapsed {
     --panel-resizer-accent-color: var(--dt-surface-a30);
     --panel-resizer-accent-hover-color: var(--dt-primary-a10);

--- a/packages/dmn-modeler/src/styles/dark-theme/colors.css
+++ b/packages/dmn-modeler/src/styles/dark-theme/colors.css
@@ -1,12 +1,8 @@
 [data-dmn-theme="dark"] {
-    /** Base colors */
     --dt-dark-a0: #000000;
     --dt-light-a0: #ffffff;
 
-    /** Dark theme primary colors — fixed neutral grey so the diagram does
-     *  not pick up the host theme's accent (e.g. a brand-coloured button bg).
-     *  Selection outlines, palette entries and other interaction affordances
-     *  derive from this scale. */
+    /* Neutral interaction colours keep host brand accents out of the diagram. */
     --dt-primary-a0: #bdbdbd;
     --dt-primary-a0-opacity-30: color-mix(in srgb, #bdbdbd 30%, transparent);
     --dt-primary-a10: color-mix(in srgb, #bdbdbd 85%, white 15%);
@@ -17,7 +13,6 @@
     --dt-primary-a40-opacity-15: color-mix(in srgb, #bdbdbd 15%, transparent);
     --dt-primary-a50: color-mix(in srgb, #bdbdbd 25%, white 75%);
 
-    /** Dark theme surface colors — driven by --vscode-editor-background / foreground */
     --dt-surface-a0: var(--vscode-editor-background, #121212);
     --dt-surface-a10: var(--vscode-editorWidget-background, #282828);
     --dt-surface-a20: var(--vscode-input-background, #3f3f3f);
@@ -27,7 +22,6 @@
     --dt-surface-a60: color-mix(in srgb, var(--vscode-editor-background, #121212) 10%, var(--vscode-editor-foreground, #F2F2F2) 90%);
     --dt-surface-a70: var(--vscode-editor-foreground, #F2F2F2);
 
-    /** Dark theme tonal surface colors — bg tinted toward accent */
     --dt-surface-tonal-a0: color-mix(in srgb, var(--vscode-editor-background, #121212) 70%, #bdbdbd 30%);
     --dt-surface-tonal-a10: color-mix(in srgb, var(--vscode-editor-background, #121212) 60%, #bdbdbd 40%);
     --dt-surface-tonal-a20: color-mix(in srgb, var(--vscode-input-background, #3f3f3f) 65%, #bdbdbd 35%);
@@ -37,9 +31,7 @@
 
     --dt-color-red-a10: var(--vscode-errorForeground, #E65C57);
     --dt-color-red-a10-invert-opacity-60: color-mix(in srgb, #15999e 60%, transparent);
-    /** Dark-mode error background: a muted red tinted surface, not the
-     *  near-white pink used in light mode. Mixes the error foreground with
-     *  the editor background so it stays readable behind the error text. */
+    /* A muted error background keeps the error text legible on dark surfaces. */
     --dt-color-red-a20: color-mix(in srgb, var(--vscode-errorForeground, #E65C57) 22%, var(--vscode-editor-background, #121212));
 
     --dt-color-blue-a50: var(--vscode-textLink-foreground, hsl(205, 100%, 50%));

--- a/packages/dmn-modeler/src/styles/dark-theme/decision-table.css
+++ b/packages/dmn-modeler/src/styles/dark-theme/decision-table.css
@@ -1,13 +1,3 @@
-/* Dark theme for the dmn-js decision-table editor (grid, header, hit-policy,
- * controls, context menus).
- *
- * Every colour the table paints derives from the semantic component variables
- * declared on `.dmn-decision-table-container`. Remapping them to the `--dt-*`
- * scale re-themes the whole surface without touching the structural rules, and
- * keeps single-meaning semantics intact (e.g. white-on-blue affordances stay
- * light). The grid lines are the one judgement call: their light-mode value is
- * near-black `grey-15`; on dark that becomes a soft `--dt-surface-a30` so the
- * grid reads without the harsh bright lines a literal inversion would give. */
 @import "./colors.css";
 
 [data-dmn-theme="dark"] .dmn-decision-table-container {
@@ -52,7 +42,6 @@
     --view-drd-button-color: var(--dt-surface-a70);
     --view-drd-button-hover-background-color: var(--dt-surface-a30);
 
-    /* decision-table-controls.css */
     --allowed-values-placeholder-color: var(--dt-surface-a60);
     --cell-description-editor-border-color: var(--dt-primary-a20);
     --create-inputs-border-color: var(--dt-surface-a30);

--- a/packages/dmn-modeler/src/styles/dark-theme/diagram-js.css
+++ b/packages/dmn-modeler/src/styles/dark-theme/diagram-js.css
@@ -1,11 +1,3 @@
-/* Dark theme for the DRD (Decision Requirements Diagram) canvas.
- *
- * The DRD is a diagram-js surface, so the generic diagram-js custom properties
- * (canvas, palette, context-pad, popup, search, selection) are driven from the
- * same `--dt-*` scale the BPMN dark theme uses. dmn-js's DrdRenderer paints
- * shapes with the same inline `style` defaults as bpmn-js (`fill: white`,
- * `stroke: rgb(34, 36, 42)`), so the value-scoped recolour rules below mirror
- * the BPMN theme exactly. */
 @import "./colors.css";
 
 [data-dmn-theme="dark"] .djs-parent {
@@ -77,44 +69,32 @@
     --tooltip-error-color: var(--dt-color-red-a20);
 }
 
-/**
- * The canvas
- */
 [data-dmn-theme="dark"] .djs-container {
     background-color: var(--canvas-fill-color) !important;
 }
 
-/*
- * Recolour ONLY dmn-js's default paint (`fill: white`, `stroke: rgb(34, 36, 42)`),
- * scoping each rule to the known value so a user's "Set color" choice (a
- * different inline value) survives. `fill: none` shapes match nothing and stay
- * transparent.
- */
+/* Target only default paint values to preserve custom colours and transparent shapes. */
 
-/* defaultFillColor (white) → dark surface */
 [data-dmn-theme="dark"] .djs-shape > .djs-visual > [style*="fill: white"] {
     fill: var(--bpmn-shape-fill-color) !important;
 }
 
-/* defaultStrokeColor used as a fill (filled markers, decision icons) → light */
 [data-dmn-theme="dark"] .djs-shape > .djs-visual > [style*="fill: rgb(34, 36, 42)"],
 [data-dmn-theme="dark"] defs marker > [style*="fill: rgb(34, 36, 42)"] {
     fill: var(--bpmn-shape-stroke-color) !important;
 }
 
-/* defaultStrokeColor (rgb(34, 36, 42)) → light stroke */
 [data-dmn-theme="dark"] .djs-shape > .djs-visual > [style*="stroke: rgb(34, 36, 42)"],
 [data-dmn-theme="dark"] .djs-connection > .djs-visual > [style*="stroke: rgb(34, 36, 42)"],
 [data-dmn-theme="dark"] defs marker > [style*="stroke: rgb(34, 36, 42)"] {
     stroke: var(--bpmn-shape-stroke-color) !important;
 }
 
-/* Embedded labels — recolour only the default black text. */
 [data-dmn-theme="dark"] .djs-shape > .djs-visual > text[style*="fill: rgb(34, 36, 42)"] {
     fill: var(--bpmn-label-color) !important;
 }
 
-/* External labels sit on the dark canvas, so always light. */
+/* External labels always sit on the dark canvas. */
 [data-dmn-theme="dark"] .djs-label .djs-visual text {
     fill: var(--bpmn-label-color) !important;
 }
@@ -127,16 +107,10 @@
     background-color: var(--dt-surface-a10) !important;
 }
 
-/**
- * Context pad
- */
 [data-dmn-theme="dark"] .djs-context-pad {
     color: var(--dt-primary-a50) !important;
 }
 
-/**
- * Search box
- */
 [data-dmn-theme="dark"] .djs-search-container .djs-search-result {
     color: var(--dt-surface-a40) !important;
     background-color: var(--dt-surface-a10) !important;
@@ -146,9 +120,6 @@
     filter: invert(0.7);
 }
 
-/**
- * Popup
- */
 [data-dmn-theme="dark"] .djs-popup-title {
     color: var(--dt-surface-a70) !important;
 }
@@ -157,20 +128,11 @@
     color: var(--dt-primary-a50) !important;
 }
 
-/**
- * "Powered by bpmn.io" attribution logo — dmn-js inlines the logo SVG with a
- * hardcoded `fill="#000000"` on its paths (not `currentColor` like bpmn-js), so
- * a `color` override is a no-op here; recolour the paths directly to a muted
- * light grey. The logo markup itself must not be altered (bpmn.io licence).
- */
+/* The logo hardcodes path fills, so color has no effect. Preserve its licensed markup. */
 [data-dmn-theme="dark"] .bjs-powered-by svg path {
     fill: var(--dt-surface-a60) !important;
 }
 
-/**
- * DRD definitions box (top-left name/id panel) — drives off the dmn-js grey
- * palette, which we leave light, so override the semantic variables here.
- */
 [data-dmn-theme="dark"] .dmn-drd-container {
     --dmn-definitions-background-color: var(--dt-surface-a10);
     --dmn-definitions-border-color: var(--dt-surface-a30);

--- a/packages/dmn-modeler/src/styles/dark-theme/index.css
+++ b/packages/dmn-modeler/src/styles/dark-theme/index.css
@@ -1,9 +1,2 @@
-/* dmn-js dark theme — the stock stylesheets plus dark overrides layered on top.
- *
- * The dmn-js assets are imported first so the override files below win on
- * cascade. This entry builds the legacy split `darkTheme.css` a consumer links
- * via `#theme-link`; `scripts/postcss-strip-theme-scope.mjs` strips the
- * `[data-dmn-theme="dark"]` scope from the overrides so the split sheet stays
- * un-scoped and page-global as before. */
 @import "../base.css";
 @import "./overrides.css";

--- a/packages/dmn-modeler/src/styles/dark-theme/literal-expression.css
+++ b/packages/dmn-modeler/src/styles/dark-theme/literal-expression.css
@@ -1,8 +1,3 @@
-/* Dark theme for the dmn-js literal-expression editor (decision name header,
- * the FEEL textarea, and the variables table).
- *
- * Same approach as the decision table: remap the semantic component variables
- * declared on `.dmn-literal-expression-container` to the `--dt-*` scale. */
 @import "./colors.css";
 
 [data-dmn-theme="dark"] .dmn-literal-expression-container {

--- a/packages/dmn-modeler/src/styles/dark-theme/overrides.css
+++ b/packages/dmn-modeler/src/styles/dark-theme/overrides.css
@@ -1,10 +1,3 @@
-/* The dark-theme override rules only — every top-level selector scoped under
- * `[data-dmn-theme="dark"]` (page chrome keys off the root attribute
- * `:root[data-dmn-theme="dark"]`). This is the single authored source:
- * `themes.css` imports it (after the unscoped light base) for the merged
- * in-bundle sheet, and `index.css` imports it after the stock dmn-js defaults to
- * build the legacy `darkTheme.css` split (the scope is stripped from that output
- * by `scripts/postcss-strip-theme-scope.mjs`). */
 @import "./colors.css";
 @import "./base-layout.css";
 @import "./shared.css";

--- a/packages/dmn-modeler/src/styles/dark-theme/properties-panel.css
+++ b/packages/dmn-modeler/src/styles/dark-theme/properties-panel.css
@@ -1,9 +1,3 @@
-/* Dark theme for the DMN properties panel.
- *
- * DMN renders into the same `@bpmn-io/properties-panel` as BPMN, so this is the
- * BPMN dark theme's panel mapping verbatim (the host-page layout overrides live
- * in base-layout.css instead). The `--*` variable contract is owned by the
- * shared properties-panel package, so the two webviews stay in lockstep. */
 @import "./colors.css";
 
 [data-dmn-theme="dark"] .bio-properties-panel {
@@ -154,12 +148,7 @@
     color: var(--dt-surface-a70) !important;
 }
 
-/**
- * CodeMirror (FEEL expression editor) — @bpmn-io/properties-panel does not
- * pass darkMode:true to feelers/feel-editor, so the light cm-theme is always
- * used. Its syntax-highlight colors are unreadable on a dark background, so
- * override all text colors inside the editor.
- */
+/* The properties panel never enables the FEEL editor’s darkMode, leaving light syntax colours. */
 [data-dmn-theme="dark"] .bio-properties-panel-feel-editor-container .cm-editor {
     color: var(--dt-surface-a70) !important;
     caret-color: var(--dt-surface-a70) !important;
@@ -182,7 +171,6 @@
     color: inherit !important;
 }
 
-/* Autocomplete & tooltip popups */
 [data-dmn-theme="dark"] .cm-tooltip {
     background-color: var(--dt-surface-a0) !important;
     border: 1px solid var(--dt-surface-a30) !important;
@@ -198,14 +186,12 @@
     color: var(--dt-surface-a70) !important;
 }
 
-/* Completion info panel (function signature / examples) */
 [data-dmn-theme="dark"] .cm-completionInfo {
     background-color: var(--dt-surface-a0) !important;
     border: 1px solid var(--dt-surface-a30) !important;
     color: var(--dt-surface-a70) !important;
 }
 
-/* Diagnostics (lint errors/warnings) */
 [data-dmn-theme="dark"] .cm-diagnostic {
     background-color: var(--dt-surface-a0) !important;
     color: var(--dt-surface-a70) !important;

--- a/packages/dmn-modeler/src/styles/dark-theme/shared.css
+++ b/packages/dmn-modeler/src/styles/dark-theme/shared.css
@@ -1,12 +1,4 @@
-/* Dark overrides for the dmn-js shared form controls (`.dms-input`,
- * `.dms-select`, hints, separators, badges).
- *
- * dmn-js derives these from a light grey/blue/red `--color-*` palette declared
- * on `.dmn-js-parent`. That base palette is deliberately left intact —
- * `--color-white` and `--color-grey-225-10-15` are each used both as a surface
- * *and* as text/icon-on-coloured-background, so inverting them wholesale breaks
- * the latter. Instead the single-meaning *semantic* variables are remapped to
- * the `--dt-*` scale, which is safe. */
+/* Base palette colours serve both backgrounds and text; remap semantic variables to preserve contrast. */
 @import "./colors.css";
 
 [data-dmn-theme="dark"] .dmn-js-parent {

--- a/packages/dmn-modeler/src/styles/dark-theme/simulation.css
+++ b/packages/dmn-modeler/src/styles/dark-theme/simulation.css
@@ -1,30 +1,17 @@
-/* Dark theme for the @emaarco/dmn-js-simulation add-on (simulate/reset
- * controls, input form, result bar, matched-row highlights, and the DRD
- * floating input panel + fired-decision badge).
- *
- * The package ships a light-only default theme built entirely from
- * `--dmn-sim-*` variables on `:root`. Remapping them onto the `--dt-*` scale
- * re-themes every control for dark mode; because this file is imported after
- * the package sheet, the equal-specificity `:root` block wins on cascade. A
- * few package rules hardcode colours the variables can't reach (a white glass
- * panel, a light chip, a fixed disabled grey) — those get direct overrides. */
 @import "./colors.css";
 
 [data-dmn-theme="dark"] {
-    /* surfaces & text */
     --dmn-sim-surface: var(--dt-surface-a20);
     --dmn-sim-ink: var(--dt-surface-a70);
     --dmn-sim-muted: var(--dt-surface-a60);
     --dmn-sim-line: var(--dt-surface-a30);
 
-    /* accent (primary buttons, focus) */
     --dmn-sim-accent: var(--dt-color-blue-a50);
     --dmn-sim-accent-ink: color-mix(in srgb, var(--dt-color-blue-a50) 80%, white 20%);
     --dmn-sim-accent-soft: color-mix(in srgb, var(--dt-color-blue-a50) 20%, transparent);
     --dmn-sim-on-accent: var(--dt-light-a0);
 
-    /* functional colours — no `--dt` green/yellow exist, so derive dark-legible
-       values from the VS Code chart colours with neutral-grey-safe fallbacks. */
+    /* The theme palette has no green or yellow, so use chart colours with dark-safe fallbacks. */
     --dmn-sim-success: var(--vscode-charts-green, #89d185);
     --dmn-sim-success-soft: color-mix(in srgb, var(--vscode-charts-green, #89d185) 22%, var(--vscode-editor-background, #121212));
     --dmn-sim-warning: var(--vscode-charts-yellow, #cca700);
@@ -32,15 +19,12 @@
     --dmn-sim-danger: var(--dt-color-red-a10);
     --dmn-sim-danger-soft: var(--dt-color-red-a20);
 
-    /* row highlighting */
     --dmn-sim-match-bg: color-mix(in srgb, var(--dt-color-blue-a50) 18%, transparent);
     --dmn-sim-match-accent: var(--dt-color-blue-a50);
     --dmn-sim-candidate-bg: color-mix(in srgb, var(--dt-surface-a70) 8%, transparent);
 
-    /* DRD fired-decision indicator */
     --dmn-sim-fired: var(--dmn-sim-success);
 
-    /* elevation — black-based so cards lift off the dark editor surface */
     --dmn-sim-shadow-1: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.4);
     --dmn-sim-shadow-2: 0 4px 12px rgba(0, 0, 0, 0.4);
     --dmn-sim-shadow-3: 0 12px 32px rgba(0, 0, 0, 0.5);
@@ -51,17 +35,12 @@
     background: color-mix(in srgb, var(--dt-surface-a10) 92%, transparent);
 }
 
-/* The output chip hardcodes `rgba(29, 29, 29, 0.05)` — a subtle light tint reads
-   on the dark result bar instead. */
+/* The output chip hardcodes a dark tint that disappears on the dark result bar. */
 [data-dmn-theme="dark"] .dmn-sim-output {
     background: color-mix(in srgb, var(--dt-surface-a70) 8%, transparent);
 }
 
-/* The disabled Simulate button hardcodes a `#9a9a9a` label on a `--dmn-sim-line`
-   background; both land on similar mid-greys in dark mode, killing the
-   contrast. Match the repo's disabled-button treatment (see the simple-mode /
-   edit buttons in decision-table.css): a darker surface with a muted `a40`
-   label that stays legible. */
+/* The default disabled label and background converge to similar greys in dark mode. */
 [data-dmn-theme="dark"] .dmn-sim-run:disabled {
     background: var(--dt-surface-a20);
     color: var(--dt-surface-a40);

--- a/packages/dmn-modeler/src/styles/light-theme/index.css
+++ b/packages/dmn-modeler/src/styles/light-theme/index.css
@@ -1,6 +1,1 @@
-/* dmn-js light theme — the modeler's stock stylesheets, unmodified.
- *
- * This entry builds the legacy split `lightTheme.css` a consumer links via
- * `#theme-link`. The same stock list is folded into the in-bundle `themes.css`
- * as the light base beneath the scoped dark overrides. */
 @import "../base.css";

--- a/packages/dmn-modeler/src/styles/themes.css
+++ b/packages/dmn-modeler/src/styles/themes.css
@@ -1,8 +1,3 @@
-/* The in-bundle theme sheet: the unscoped stock dmn-js defaults (the light look)
- * plus the dark overrides scoped under `[data-dmn-theme="dark"]`. Folded into
- * `dist/dmn-modeler.css` via `src/index.ts`, so a consumer that loads
- * `styles.css` gets per-instance theming with no extra `<link>`. The legacy
- * split `lightTheme.css` / `darkTheme.css` are built separately for the
- * `#theme-link` fallback (see `vite.themes.config.mts`). */
+/* Scope dark overrides so instances can use different themes on the same page. */
 @import "./light-theme/index.css";
 @import "./dark-theme/overrides.css";

--- a/packages/dmn-modeler/src/theme.spec.ts
+++ b/packages/dmn-modeler/src/theme.spec.ts
@@ -2,14 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { THEME_ATTRIBUTE, ThemeController } from "./theme";
 
-/**
- * Per-instance theme controller. Each test constructs its own
- * {@link ThemeController} over plain scope roots, so there is no page-singleton
- * state to reset — a fresh controller starts with `mode === undefined`, which is
- * why a first `setMode("automatic")` engages rather than short-circuiting on the
- * same-mode guard.
- */
-
 const THEME_BASE = "http://localhost/assets/";
 
 function setThemeLink(css: "lightTheme.css" | "darkTheme.css"): HTMLLinkElement {
@@ -31,10 +23,6 @@ function makeRoot(): HTMLElement {
     return div;
 }
 
-/**
- * Minimal `window.matchMedia` stub: a single controllable `matches` flag plus a
- * `change`-listener registry so a test can emit a live OS/browser theme switch.
- */
 function stubMatchMedia(initialDark: boolean) {
     let matches = initialDark;
     const listeners = new Set<(event: MediaQueryListEvent) => void>();

--- a/packages/dmn-modeler/src/theme.ts
+++ b/packages/dmn-modeler/src/theme.ts
@@ -1,50 +1,18 @@
-/**
- * Per-instance theme controller for the DMN modeler.
- *
- * The authoritative mechanism is a `data-dmn-theme="light" | "dark"` attribute
- * the controller toggles on the scope roots it is handed (a modeler's canvas
- * container + its `propertiesPanel.parent`). The dark stylesheet's rules are all
- * scoped under `[data-dmn-theme="dark"]`, so theming one instance never leaks
- * onto another on the same page.
- *
- * {@link applyLegacyThemeLink} keeps the pre-attribute `#theme-link` href swap
- * alive as a permanent, page-global compatibility fallback for consumers that
- * still link `lightTheme.css` / `darkTheme.css` themselves. It is a silent no-op
- * when no `#theme-link` is present — the attribute mechanism stands on its own.
- *
- * `"automatic"` resolves the kind from the OS/browser `prefers-color-scheme` and
- * keeps following it live; `"light"` / `"dark"` force a fixed kind and stop
- * following. A host's own light/dark chrome (e.g. VS Code's `<body>` classes) is
- * host policy: the host adapter maps that signal to a forced mode — the package
- * never reads host chrome.
- *
- * @internal Not part of the public handle; reached through
- *   {@link DmnModeler.setTheme}.
- */
 import type { DmnThemeMode } from "./publicApi";
 
 export type ResolvedThemeKind = "light" | "dark";
 
-/** The attribute the dark stylesheet's `[data-dmn-theme="dark"]` rules key off. */
 export const THEME_ATTRIBUTE = "data-dmn-theme";
 
+/** @internal */
 export class ThemeController {
-    // `undefined` (not `"automatic"`) until the first setMode so that an initial
-    // setMode("automatic") actually engages instead of hitting the same-mode
-    // early return.
+    // Leave unset so the first automatic mode applies instead of returning early.
     private mode: DmnThemeMode | undefined;
     private mediaQuery?: MediaQueryList;
     private mediaListener?: (event: MediaQueryListEvent) => void;
 
     constructor(private readonly scopeRoots: readonly HTMLElement[]) {}
 
-    /**
-     * Switches the theme mode. `"automatic"` applies the current
-     * `prefers-color-scheme` and installs a `change` listener so a later
-     * OS/browser theme switch is reflected live; a forced `"light"`/`"dark"`
-     * stops that listener so the fixed choice is not overwritten on the next
-     * scheme change. A no-op when the mode is unchanged.
-     */
     setMode(mode: DmnThemeMode): void {
         if (mode === this.mode) {
             return;
@@ -59,7 +27,6 @@ export class ThemeController {
         }
     }
 
-    /** Detaches the scheme listener and removes the attribute from every root. */
     dispose(): void {
         this.stopFollowingPreferredScheme();
         for (const root of this.scopeRoots) {
@@ -67,7 +34,6 @@ export class ThemeController {
         }
     }
 
-    /** Sets the attribute on every scope root and mirrors it to the legacy link. */
     private apply(kind: ResolvedThemeKind): void {
         for (const root of this.scopeRoots) {
             root.setAttribute(THEME_ATTRIBUTE, kind);
@@ -75,11 +41,6 @@ export class ThemeController {
         applyLegacyThemeLink(kind);
     }
 
-    /**
-     * Applies the current `prefers-color-scheme` and installs a single live
-     * `change` listener for it (idempotent — a second automatic entry re-applies
-     * but does not stack listeners).
-     */
     private startFollowingPreferredScheme(): void {
         const query = window.matchMedia("(prefers-color-scheme: dark)");
         this.apply(query.matches ? "dark" : "light");
@@ -105,14 +66,7 @@ export class ThemeController {
     }
 }
 
-/**
- * Swaps the legacy `#theme-link` stylesheet between `lightTheme.css` and
- * `darkTheme.css`, comparing the current href first to avoid a redundant DOM
- * mutation. A silent no-op when no `#theme-link` is present — the attribute
- * mechanism is authoritative, so a missing legacy link is not an error.
- *
- * @param kind `"dark"` to apply the dark stylesheet, `"light"` for the light one.
- */
+// Keep compatibility with consumers that switch themes through #theme-link.
 function applyLegacyThemeLink(kind: ResolvedThemeKind): void {
     const theme = document.querySelector<HTMLLinkElement>("#theme-link");
     if (!theme) {

--- a/packages/dmn-modeler/vite.config.mts
+++ b/packages/dmn-modeler/vite.config.mts
@@ -3,30 +3,21 @@ import { isAbsolute, resolve } from "node:path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import dts from "unplugin-dts/vite";
 
-// The private workspace libs inlined into the bundle (their source is pulled in
-// via the tsconfig path aliases). Everything else bare is a real dependency and
-// stays external — see `external` below. Keep this list in sync with the
-// `devDependencies` `workspace:*` entries and the architecture spec.
+// Private workspace libraries must be inlined because consumers cannot install them.
 const INLINED_LIBS = ["@miragon/bpmn-modeler-types", "@miragon/bpmn-modeler-i18n-extras"];
 
-// The source roots of the inlined libs — their per-file declarations must be
-// emitted so api-extractor can flatten them into `dist/index.d.ts` (they carry
-// no built `types` entry of their own).
+// Emit private-library declarations so API Extractor can inline their types.
 const INLINED_LIB_SRC = ["../../libs/modeler-types/src", "../../libs/bpmn-i18n-extras/src"];
 
 function isInlined(id: string): boolean {
     return INLINED_LIBS.some((name) => id === name || id.startsWith(`${name}/`));
 }
 
-// Bundle relatives, absolute (alias-resolved) paths, the inlined libs, and CSS;
-// externalise every other bare specifier so the dmn-js stack is never bundled.
-// `@oxc-project/runtime` is Vite 8's oxc transform-helper runtime (the tslib
-// analogue for its own lowering) — inline it so consumers never take a
-// dependency on our build tool's internals.
 function isExternal(id: string): boolean {
     if (id.startsWith(".") || isAbsolute(id)) return false;
     if (id.endsWith(".css")) return false;
     if (isInlined(id)) return false;
+    // Inline transform helpers to avoid exposing a build-tool dependency.
     if (id === "@oxc-project/runtime" || id.startsWith("@oxc-project/runtime/")) return false;
     return true;
 }
@@ -39,11 +30,7 @@ export default defineConfig({
         dts({
             tsconfigPath: "./tsconfig.lib.json",
             include: ["src", ...INLINED_LIB_SRC],
-            // Keep the `@miragon/*` specifiers in the emitted d.ts (do NOT rewrite
-            // them to source `.ts` paths); api-extractor then resolves them via
-            // tsconfig `paths` and inlines the ones listed in `bundledPackages`,
-            // producing one self-contained `dist/index.d.ts` with only bare npm
-            // externals left as imports.
+            // API Extractor needs package specifiers to resolve and inline bundledPackages.
             pathsToAliases: false,
             bundleTypes: {
                 bundledPackages: INLINED_LIBS,

--- a/packages/dmn-modeler/vite.themes.config.mts
+++ b/packages/dmn-modeler/vite.themes.config.mts
@@ -3,15 +3,8 @@ import { resolve } from "node:path";
 
 import stripThemeScope from "./scripts/postcss-strip-theme-scope.mjs";
 
-// The two legacy theme stylesheets ship as standalone CSS entries a consumer
-// links via `#theme-link` (the permanent compatibility fallback for the
-// authoritative `data-dmn-theme` attribute mechanism). The dark source is
-// authored scoped under `[data-dmn-theme="dark"]`; `stripThemeScope` removes
-// that scope here so the split `darkTheme.css` stays un-scoped as before (the
-// light input has no attribute, so the plugin is a no-op on it). CSS cannot be a
-// Vite lib entry, so this is a separate CSS-only rollup. The output names are a
-// de-facto contract — `#theme-link` swaps `lightTheme.css` ↔ `darkTheme.css` by
-// name — so keep them exact.
+// CSS needs a separate build because Vite library entries cannot be CSS.
+// Preserve the filenames: legacy #theme-link switching depends on them.
 export default defineConfig({
     root: __dirname,
     cacheDir: "../../node_modules/.vite/dmn-modeler-themes",


### PR DESCRIPTION
## Issue

N/A

## Description

Reduce redundant internal commentary across the BPMN package, tests, and build scripts while preserving consumer guidance, examples, API tags, and explanations of hidden constraints.
Correct stale lint initialization documentation, remove commented-out CSS, and clarify local names without changing runtime behavior or public APIs.
Validation: package build/typecheck and declaration/bundle guards passed; 240 tests passed (3 skipped), formatting passed, and ESLint reported no errors (110 existing warnings).
A syntax-tree comparison confirmed that executable changes are limited to local identifier renames.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A) — existing tests passed; no new behavior
- [x] Docs (or N/A) — comments and API documentation cleaned up
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A) — N/A, no architectural or public API changes
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A) — N/A, comments and local renames only
