### PR TITLE
fix(diff): detect execution property changes across engines

### DIFF
--- a/apps/demo-webapp/bpmn/diff-regressions.html
+++ b/apps/demo-webapp/bpmn/diff-regressions.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="icon" href="./favicon.svg" />
+        <title>BPMN diff regressions</title>
+    </head>
+    <body>
+        <main>
+            <h1>BPMN diff regressions</h1>
+            <p id="status">Running…</p>
+            <ol id="results"></ol>
+        </main>
+        <script type="module" src="./diffRegressions.ts"></script>
+    </body>
+</html>

--- a/apps/demo-webapp/bpmn/diffRegressions.ts
+++ b/apps/demo-webapp/bpmn/diffRegressions.ts
@@ -1,0 +1,33 @@
+import { computeDiff } from "@miragon/bpmn-modeler/diff";
+import { ALL_EXECUTION_PROPERTY_FIXTURES } from "../../../libs/bpmn-diff/src/__fixtures__/execution-properties";
+
+declare global {
+    interface Window {
+        __DIFF_REGRESSION_RESULT__?: { passed: number; failed: string[] };
+    }
+}
+
+const status = document.querySelector<HTMLElement>("#status")!;
+const results = document.querySelector<HTMLOListElement>("#results")!;
+
+async function run(): Promise<void> {
+    const failed: string[] = [];
+    for (const fixture of ALL_EXECUTION_PROPERTY_FIXTURES) {
+        const actual = await computeDiff(fixture.before, fixture.after);
+        const matches = JSON.stringify(actual) === JSON.stringify(fixture.expected);
+        const item = document.createElement("li");
+        item.textContent = `${matches ? "PASS" : "FAIL"}: ${fixture.name}`;
+        results.append(item);
+        if (!matches) failed.push(fixture.name);
+    }
+
+    const passed = ALL_EXECUTION_PROPERTY_FIXTURES.length - failed.length;
+    window.__DIFF_REGRESSION_RESULT__ = { passed, failed };
+    status.textContent =
+        failed.length === 0 ? `${passed} fixtures passed` : `${failed.length} fixtures failed`;
+    status.dataset.result = failed.length === 0 ? "passed" : "failed";
+
+    if (failed.length > 0) throw new Error(`BPMN diff regressions failed: ${failed.join(", ")}`);
+}
+
+void run();

--- a/apps/demo-webapp/vite.config.mts
+++ b/apps/demo-webapp/vite.config.mts
@@ -65,6 +65,7 @@ export default defineConfig(({ mode }) => {
                               index: resolve(__dirname, "bpmn/index.html"),
                               dual: resolve(__dirname, "bpmn/dual.html"),
                               diff: resolve(__dirname, "bpmn/diff.html"),
+                              diffRegressions: resolve(__dirname, "bpmn/diff-regressions.html"),
                               viewer: resolve(__dirname, "bpmn/viewer.html"),
                               design: resolve(__dirname, "bpmn/design.html"),
                           },

--- a/docs/adr/0029-compare-execution-properties-with-isolated-moddle-descriptors.md
+++ b/docs/adr/0029-compare-execution-properties-with-isolated-moddle-descriptors.md
@@ -1,0 +1,55 @@
+# 0029 — Compare execution properties with isolated moddle descriptors
+
+- Status: accepted (#1487)
+- Date: 2026-09-09
+- Category: bpmn-webview
+
+## Context
+
+The public `computeDiff` data layer established by ADR 0008 parsed BPMN without
+engine descriptors. Camunda 7 execution attributes and Camunda 8 extension
+elements were consequently generic or absent from the typed comparison, so
+execution-property edits could produce an empty diff.
+
+Registering the installed Camunda 7 and Zeebe descriptors on one `bpmn-moddle`
+instance is not viable. Both extend BPMN elements with `modelerTemplate`; moddle
+rejects the duplicate property and its lax XML reader can skip the complete
+process while returning only a warning.
+
+## Decision
+
+`computeDiff` parses both revisions twice: one pair with
+`camunda-bpmn-moddle`, and one with `zeebe-bpmn-moddle`. Before each comparison,
+the other engine's extension elements and attributes are removed from that
+pair. The two `bpmn-js-differ` results are merged and deduplicated without
+changing the public signature or result shape.
+
+Unknown namespaced attributes retained by moddle are compared in an additional
+textual pass. Containment traversal assigns a nested attribute to the nearest
+tracked BPMN owner and preserves the differ's process-to-participant mapping.
+References and parent links are not traversed. Parser warnings that report
+skipped XML content are promoted to failures.
+
+The private diff library owns both descriptor runtime dependencies. The public
+package inlines only their JSON resources as lazy JavaScript chunks; the parser
+and other npm dependencies remain external.
+
+## Alternatives considered / rejected
+
+**Register both descriptors together.** Rejected because the
+`modelerTemplate` collision makes valid mixed-engine input parse incompletely.
+
+**Compare execution properties as generic XML only.** Rejected because generic
+comparison loses descriptor defaults and creates textual false positives for
+typed values.
+
+## Consequences
+
+Camunda 7, Camunda 8, and mixed-engine documents retain engine semantics in
+diffs, while custom attributes have explicit textual semantics. Existing flow
+ordering, structural categories, serialization, and caller configuration stay
+unchanged.
+
+Each diff now performs four XML parses and two comparisons. The parser and
+descriptors remain lazy, but callers that invoke `computeDiff` accept the added
+CPU and allocation cost.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -68,6 +68,7 @@ contributor-facing record, not user documentation.
 | [0021](0021-mode-session-subpath.md) | Publish the View↔Design↔Implement session + opt-in strip via the `@miragon/bpmn-modeler/mode` subpath (consumer-injected surface factories); mode model moves to `@miragon/bpmn-modeler-types` | accepted |
 | [0022](0022-mode-invariant-canvas-chrome.md) | Minimap, token simulation, and the canvas focus reticle are mode-invariant: registered on `/viewer`, `/design`, and `createModeler` alike; design mode stops hiding the simulation toggle | accepted |
 | [0023](0023-mode-aware-linting.md) | Opt-in linting on `/design` and per-mode lint configs: injection-only on both surfaces, `LintingOptions.config` accepts a `{ design?, implement? }` map, Design default drops the Camunda engine layer, `setMode` re-resolves in-page; workspace config mode-invariant, viewer excluded | accepted |
+| [0029](0029-compare-execution-properties-with-isolated-moddle-descriptors.md) | Compare execution properties through isolated Camunda 7 and Camunda 8 moddle passes; compare custom attributes textually | accepted |
 
 ### dmn-webview
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -49,6 +49,7 @@
                 "dmn/main.ts",
                 "bpmn/dual.ts",
                 "bpmn/diff.ts",
+                "bpmn/diffRegressions.ts",
                 "bpmn/viewer.ts",
                 "bpmn/design.ts"
             ]

--- a/libs/bpmn-diff/README.md
+++ b/libs/bpmn-diff/README.md
@@ -19,13 +19,23 @@ const before = sideView(result, "before"); // added blanked
 const after = sideView(result, "after"); // removed blanked
 ```
 
-`computeDiff` parses both documents with `bpmn-moddle`, compares them with
-`bpmn-js-differ`, and sorts the id arrays by BPMN sequence-flow position (start
-event → end event), anchoring removed elements next to a surviving neighbour.
-The heavy `bpmn-moddle` parser loads through dynamic `import()`, so a consumer
-that never diffs never pays for it. It touches no DOM — the Node-safety gate is mechanised
-by the `node`-environment vitest suite and the package's `check-diff-node.mjs`
-smoke test.
+`computeDiff` parses each document separately with the Camunda 7 and Camunda 8
+moddle descriptors, compares both typed models with `bpmn-js-differ`, merges and
+deduplicates the categories, and sorts the ids by BPMN sequence-flow position
+(start event → end event). Removed elements are anchored next to a surviving
+neighbour. Separate engine parses are intentional: registering both descriptors
+on one moddle instance collides on `modelerTemplate` and can skip the process.
+
+Camunda 7 attributes and extension elements and Camunda 8/Zeebe extensions use
+their descriptor-defined types and defaults. Unknown namespaced attributes are
+compared as parsed strings by qualified name, including attributes nested below
+an extension element; XML attribute order is insignificant, while changing a
+custom namespace prefix is a textual change.
+
+The parser and both descriptors load through dynamic `import()`, so a consumer
+that never diffs never pays for them. The implementation touches no DOM — the
+Node-safety gate is mechanised by the `node`-environment vitest suite and the
+package's `check-diff-node.mjs` smoke test.
 
 `computeDiff` **throws** on parse/diff failure; the extension host wraps it in
 its own try/catch to log and drop.

--- a/libs/bpmn-diff/package.json
+++ b/libs/bpmn-diff/package.json
@@ -9,7 +9,9 @@
     },
     "dependencies": {
         "bpmn-js-differ": "3.2.0",
-        "bpmn-moddle": "10.2.0"
+        "bpmn-moddle": "10.2.0",
+        "camunda-bpmn-moddle": "7.0.2",
+        "zeebe-bpmn-moddle": "1.18.0"
     },
     "devDependencies": {
         "typescript": "6.0.3",

--- a/libs/bpmn-diff/src/__fixtures__/execution-properties.ts
+++ b/libs/bpmn-diff/src/__fixtures__/execution-properties.ts
@@ -127,7 +127,7 @@ const C8_OUTPUT_MAPPING_BEFORE = `<bpmn:serviceTask id="C8OutputTask_1">
     </bpmn:serviceTask>`;
 const C8_OUTPUT_MAPPING_AFTER = C8_OUTPUT_MAPPING_BEFORE.replace("oldOutput", "newOutput");
 
-export const EXECUTION_PROPERTY_FIXTURES: readonly ExecutionPropertyFixture[] = [
+const EXECUTION_PROPERTY_FIXTURES: readonly ExecutionPropertyFixture[] = [
     ...C7_ATTRIBUTE_FIXTURES,
     {
         name: "Camunda 7 extension elements",
@@ -282,7 +282,7 @@ export const EXECUTION_PROPERTY_FIXTURES: readonly ExecutionPropertyFixture[] = 
     },
 ];
 
-export const STRUCTURAL_CUSTOM_ATTRIBUTE_FIXTURE: ExecutionPropertyFixture = {
+const STRUCTURAL_CUSTOM_ATTRIBUTE_FIXTURE: ExecutionPropertyFixture = {
     name: "custom attributes do not turn added or removed owners into changes",
     before: definitions(`  <bpmn:process id="Process_1">
     <bpmn:task id="RemovedTask_1" custom:value="before" />
@@ -293,7 +293,7 @@ export const STRUCTURAL_CUSTOM_ATTRIBUTE_FIXTURE: ExecutionPropertyFixture = {
     expected: expected([], ["AddedTask_1"], ["RemovedTask_1"], ["AddedTask_1", "RemovedTask_1"]),
 };
 
-export const PARTICIPANT_OWNER_FIXTURE: ExecutionPropertyFixture = {
+const PARTICIPANT_OWNER_FIXTURE: ExecutionPropertyFixture = {
     name: "process attributes map to the participant visual",
     before: definitions(`  <bpmn:process id="Process_1" custom:version="old" />
   <bpmn:collaboration id="Collaboration_1">

--- a/libs/bpmn-diff/src/__fixtures__/execution-properties.ts
+++ b/libs/bpmn-diff/src/__fixtures__/execution-properties.ts
@@ -1,0 +1,313 @@
+import type { DiffResult } from "../diffResult";
+
+export interface ExecutionPropertyFixture {
+    name: string;
+    before: string;
+    after: string;
+    expected: DiffResult;
+}
+
+interface ElementFixture {
+    id: string;
+    xml: string;
+}
+
+const NS = `xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:custom="urn:miragon:custom"`;
+
+function definitions(rootElements: string): string {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions ${NS} id="Definitions_1" targetNamespace="urn:miragon:test">
+${rootElements}
+</bpmn:definitions>`;
+}
+
+function linear(elements: readonly ElementFixture[], processAttributes = ""): string {
+    const nodes = [
+        { id: "StartEvent_1", xml: '<bpmn:startEvent id="StartEvent_1" />' },
+        ...elements,
+        { id: "EndEvent_1", xml: '<bpmn:endEvent id="EndEvent_1" />' },
+    ];
+    const flows = nodes
+        .slice(0, -1)
+        .map(
+            (node, index) =>
+                `<bpmn:sequenceFlow id="Flow_${index + 1}" sourceRef="${node.id}" targetRef="${nodes[index + 1].id}" />`,
+        );
+    return definitions(`  <bpmn:process id="Process_1" isExecutable="true" ${processAttributes}>
+    ${nodes.map((node) => node.xml).join("\n    ")}
+    ${flows.join("\n    ")}
+  </bpmn:process>`);
+}
+
+function expected(
+    changed: readonly string[] = [],
+    added: readonly string[] = [],
+    removed: readonly string[] = [],
+    navigationOrder: readonly string[] = [...changed, ...added, ...removed],
+): DiffResult {
+    return {
+        added,
+        removed,
+        changed,
+        layoutChanged: [],
+        counts: {
+            added: added.length,
+            removed: removed.length,
+            changed: changed.length,
+            layoutChanged: 0,
+        },
+        navigationOrder,
+    };
+}
+
+const C7_ATTRIBUTES = [
+    ["class", "com.example.OldDelegate", "com.example.NewDelegate"],
+    ["delegateExpression", "${oldDelegate}", "${newDelegate}"],
+    ["asyncBefore", "false", "true"],
+    ["asyncAfter", "false", "true"],
+    ["decisionRef", "old-decision", "new-decision"],
+] as const;
+
+const C7_ATTRIBUTE_FIXTURES: readonly ExecutionPropertyFixture[] = C7_ATTRIBUTES.map(
+    ([attribute, beforeValue, afterValue]) => ({
+        name: `Camunda 7 ${attribute}`,
+        before: linear([
+            {
+                id: "BusinessRuleTask_1",
+                xml: `<bpmn:businessRuleTask id="BusinessRuleTask_1" camunda:${attribute}="${beforeValue}" />`,
+            },
+        ]),
+        after: linear([
+            {
+                id: "BusinessRuleTask_1",
+                xml: `<bpmn:businessRuleTask id="BusinessRuleTask_1" camunda:${attribute}="${afterValue}" />`,
+            },
+        ]),
+        expected: expected(["BusinessRuleTask_1"]),
+    }),
+);
+
+const C7_EXTENSION_BEFORE = `<bpmn:serviceTask id="C7ExtensionTask_1">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="endpoint" value="old" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>`;
+const C7_EXTENSION_AFTER = C7_EXTENSION_BEFORE.replace('value="old"', 'value="new"');
+
+const C8_TASK_DEFINITION_BEFORE = `<bpmn:serviceTask id="C8TaskDefinition_1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="old-job" retries="3" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>`;
+const C8_TASK_DEFINITION_AFTER = C8_TASK_DEFINITION_BEFORE.replace(
+    'type="old-job" retries="3"',
+    'type="new-job" retries="5"',
+);
+
+const C8_INPUT_MAPPING_BEFORE = `<bpmn:serviceTask id="C8InputTask_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="= oldInput" target="input" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>`;
+const C8_INPUT_MAPPING_AFTER = C8_INPUT_MAPPING_BEFORE.replace("oldInput", "newInput");
+
+const C8_OUTPUT_MAPPING_BEFORE = `<bpmn:serviceTask id="C8OutputTask_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="= oldOutput" target="output" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>`;
+const C8_OUTPUT_MAPPING_AFTER = C8_OUTPUT_MAPPING_BEFORE.replace("oldOutput", "newOutput");
+
+export const EXECUTION_PROPERTY_FIXTURES: readonly ExecutionPropertyFixture[] = [
+    ...C7_ATTRIBUTE_FIXTURES,
+    {
+        name: "Camunda 7 extension elements",
+        before: linear([{ id: "C7ExtensionTask_1", xml: C7_EXTENSION_BEFORE }]),
+        after: linear([{ id: "C7ExtensionTask_1", xml: C7_EXTENSION_AFTER }]),
+        expected: expected(["C7ExtensionTask_1"]),
+    },
+    {
+        name: "Camunda 8 task definition",
+        before: linear([{ id: "C8TaskDefinition_1", xml: C8_TASK_DEFINITION_BEFORE }]),
+        after: linear([{ id: "C8TaskDefinition_1", xml: C8_TASK_DEFINITION_AFTER }]),
+        expected: expected(["C8TaskDefinition_1"]),
+    },
+    {
+        name: "Camunda 8 input and output mappings",
+        before: linear([
+            { id: "C8InputTask_1", xml: C8_INPUT_MAPPING_BEFORE },
+            { id: "C8OutputTask_1", xml: C8_OUTPUT_MAPPING_BEFORE },
+        ]),
+        after: linear([
+            { id: "C8InputTask_1", xml: C8_INPUT_MAPPING_AFTER },
+            { id: "C8OutputTask_1", xml: C8_OUTPUT_MAPPING_AFTER },
+        ]),
+        expected: expected(["C8InputTask_1", "C8OutputTask_1"]),
+    },
+    {
+        name: "custom attribute addition, removal, and parsed string value",
+        before: linear([
+            { id: "CustomAdd_1", xml: '<bpmn:task id="CustomAdd_1" />' },
+            {
+                id: "CustomRemove_1",
+                xml: '<bpmn:task id="CustomRemove_1" custom:removed="yes" />',
+            },
+            {
+                id: "CustomValue_1",
+                xml: '<bpmn:task id="CustomValue_1" custom:value="old &amp; parsed" />',
+            },
+        ]),
+        after: linear([
+            { id: "CustomAdd_1", xml: '<bpmn:task id="CustomAdd_1" custom:added="yes" />' },
+            { id: "CustomRemove_1", xml: '<bpmn:task id="CustomRemove_1" />' },
+            {
+                id: "CustomValue_1",
+                xml: '<bpmn:task id="CustomValue_1" custom:value="new &amp; parsed" />',
+            },
+        ]),
+        expected: expected(["CustomAdd_1", "CustomRemove_1", "CustomValue_1"]),
+    },
+    {
+        name: "custom attributes on nested typed and generic extensions",
+        before: linear([
+            {
+                id: "NestedExtensionTask_1",
+                xml: `<bpmn:serviceTask id="NestedExtensionTask_1">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="typed" value="same" custom:flag="old" />
+        </camunda:properties>
+        <custom:container><custom:item custom:flag="old" /></custom:container>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>`,
+            },
+        ]),
+        after: linear([
+            {
+                id: "NestedExtensionTask_1",
+                xml: `<bpmn:serviceTask id="NestedExtensionTask_1">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="typed" value="same" custom:flag="new" />
+        </camunda:properties>
+        <custom:container><custom:item custom:flag="new" /></custom:container>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>`,
+            },
+        ]),
+        expected: expected(["NestedExtensionTask_1"]),
+    },
+    {
+        name: "typed defaults and attribute reordering",
+        before: linear([
+            {
+                id: "DefaultTask_1",
+                xml: '<bpmn:task id="DefaultTask_1" camunda:asyncBefore="false" custom:a="1" custom:b="2" />',
+            },
+        ]),
+        after: linear([
+            {
+                id: "DefaultTask_1",
+                xml: '<bpmn:task custom:b="2" id="DefaultTask_1" custom:a="1" />',
+            },
+        ]),
+        expected: expected(),
+    },
+    {
+        name: "nested subprocess owner",
+        before: linear([
+            {
+                id: "SubProcess_1",
+                xml: `<bpmn:subProcess id="SubProcess_1">
+      <bpmn:serviceTask id="NestedTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="nested" custom:version="old" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:subProcess>`,
+            },
+        ]),
+        after: linear([
+            {
+                id: "SubProcess_1",
+                xml: `<bpmn:subProcess id="SubProcess_1">
+      <bpmn:serviceTask id="NestedTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="nested" custom:version="new" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:subProcess>`,
+            },
+        ]),
+        expected: expected(["NestedTask_1"]),
+    },
+    {
+        name: "mixed C7 and C8 properties deduplicate across passes",
+        before: linear([
+            {
+                id: "MixedTask_1",
+                xml: `<bpmn:serviceTask id="MixedTask_1" camunda:class="OldDelegate">
+      <bpmn:extensionElements><zeebe:taskDefinition type="old-job" /></bpmn:extensionElements>
+    </bpmn:serviceTask>`,
+            },
+        ]),
+        after: linear([
+            {
+                id: "MixedTask_1",
+                xml: `<bpmn:serviceTask id="MixedTask_1" camunda:class="NewDelegate">
+      <bpmn:extensionElements><zeebe:taskDefinition type="new-job" /></bpmn:extensionElements>
+    </bpmn:serviceTask>`,
+            },
+        ]),
+        expected: expected(["MixedTask_1"]),
+    },
+    {
+        name: "custom prefix rename is a textual change",
+        before: linear([
+            { id: "PrefixTask_1", xml: '<bpmn:task id="PrefixTask_1" custom:value="same" />' },
+        ]),
+        after: linear([
+            { id: "PrefixTask_1", xml: '<bpmn:task id="PrefixTask_1" renamed:value="same" />' },
+        ]).replace('xmlns:custom="urn:miragon:custom"', 'xmlns:renamed="urn:miragon:custom"'),
+        expected: expected(["PrefixTask_1"]),
+    },
+];
+
+export const STRUCTURAL_CUSTOM_ATTRIBUTE_FIXTURE: ExecutionPropertyFixture = {
+    name: "custom attributes do not turn added or removed owners into changes",
+    before: definitions(`  <bpmn:process id="Process_1">
+    <bpmn:task id="RemovedTask_1" custom:value="before" />
+  </bpmn:process>`),
+    after: definitions(`  <bpmn:process id="Process_1">
+    <bpmn:task id="AddedTask_1" custom:value="after" />
+  </bpmn:process>`),
+    expected: expected([], ["AddedTask_1"], ["RemovedTask_1"], ["AddedTask_1", "RemovedTask_1"]),
+};
+
+export const PARTICIPANT_OWNER_FIXTURE: ExecutionPropertyFixture = {
+    name: "process attributes map to the participant visual",
+    before: definitions(`  <bpmn:process id="Process_1" custom:version="old" />
+  <bpmn:collaboration id="Collaboration_1">
+    <bpmn:participant id="Participant_1" processRef="Process_1" />
+  </bpmn:collaboration>`),
+    after: definitions(`  <bpmn:process id="Process_1" custom:version="new" />
+  <bpmn:collaboration id="Collaboration_1">
+    <bpmn:participant id="Participant_1" processRef="Process_1" />
+  </bpmn:collaboration>`),
+    expected: expected(["Participant_1"]),
+};
+
+export const ALL_EXECUTION_PROPERTY_FIXTURES: readonly ExecutionPropertyFixture[] = [
+    ...EXECUTION_PROPERTY_FIXTURES,
+    STRUCTURAL_CUSTOM_ATTRIBUTE_FIXTURE,
+    PARTICIPANT_OWNER_FIXTURE,
+];

--- a/libs/bpmn-diff/src/computeDiff.spec.ts
+++ b/libs/bpmn-diff/src/computeDiff.spec.ts
@@ -3,8 +3,13 @@ import { describe, expect, it } from "vitest";
 import { computeDiff } from "./computeDiff";
 import { sideView } from "./sideView";
 import { MOCK_DIFF_AFTER_XML, MOCK_DIFF_BEFORE_XML } from "./__fixtures__/mock-diff";
+import { ALL_EXECUTION_PROPERTY_FIXTURES } from "./__fixtures__/execution-properties";
 
 describe("computeDiff", () => {
+    it.each(ALL_EXECUTION_PROPERTY_FIXTURES)("compares $name", async (fixture) => {
+        await expect(computeDiff(fixture.before, fixture.after)).resolves.toEqual(fixture.expected);
+    });
+
     it("sorts each of the four categories into their expected ids", async () => {
         const result = await computeDiff(MOCK_DIFF_BEFORE_XML, MOCK_DIFF_AFTER_XML);
 
@@ -61,6 +66,17 @@ describe("computeDiff", () => {
 
     it("rejects on invalid XML instead of returning a partial result", async () => {
         await expect(computeDiff("this is not xml", MOCK_DIFF_AFTER_XML)).rejects.toThrow();
+    });
+
+    it("rejects when a descriptor failure makes the parser skip XML content", async () => {
+        const invalidDescriptorContent = MOCK_DIFF_BEFORE_XML.replace(
+            "</bpmn:serviceTask>",
+            "<bpmn:extensionElements><camunda:Unknown /></bpmn:extensionElements></bpmn:serviceTask>",
+        );
+
+        await expect(computeDiff(invalidDescriptorContent, MOCK_DIFF_AFTER_XML)).rejects.toThrow(
+            /unparsable content/i,
+        );
     });
 });
 

--- a/libs/bpmn-diff/src/computeDiff.ts
+++ b/libs/bpmn-diff/src/computeDiff.ts
@@ -1,87 +1,171 @@
 // Bundler (webpack + ts-loader) and consumer tsc programs (modeler-types,
 // modeler-core, the package) do not pick up this lib's ambient shims from
-// tsconfig `include` — only its own standalone build does — so both are pulled
+// tsconfig `include` — only its own standalone build does — so they are pulled
 // in explicitly via triple-slash references, which every program honours.
-//
-// The `bpmn-moddle` shim is intentionally *empty* (`declare module …{}`): the
-// moddle import below is fully cast, so it needs the module resolvable but never
-// its member types, and an empty declaration merges without conflict alongside a
-// consumer's own richer moddle shim.  See `./types/bpmn-moddle.d.ts`.
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="./types/bpmn-js-differ.d.ts" />
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="./types/bpmn-moddle.d.ts" />
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="./types/execution-moddle.d.ts" />
 
 import { diff } from "bpmn-js-differ";
 
 import { buildFlowOrder, buildRemovedAnchors, sortIdsByOrder } from "./bpmnFlowOrder";
 import { DiffCounts, DiffResult } from "./diffResult";
 
+const CAMUNDA_NAMESPACE = "http://camunda.org/schema/1.0/bpmn";
+const ZEEBE_NAMESPACE = "http://camunda.org/schema/zeebe/1.0";
+
+type Engine = "camunda" | "zeebe";
+
+interface PropertyDescriptor {
+    name: string;
+    isAttr?: boolean;
+    isAttribute?: boolean;
+    isReference?: boolean;
+    isVirtual?: boolean;
+}
+
+interface ModdleElement {
+    $type: string;
+    $attrs?: Record<string, string>;
+    $children?: ModdleElement[];
+    $descriptor: {
+        isGeneric?: boolean;
+        ns?: { prefix?: string; uri?: string };
+        properties?: PropertyDescriptor[];
+    };
+    $instanceOf?: (type: string) => boolean;
+    id?: string;
+    [key: string]: unknown;
+}
+
+interface ParseWarning {
+    message?: string;
+}
+
+interface ParseResult {
+    rootElement: ModdleElement;
+    warnings?: ParseWarning[];
+}
+
+interface ModdleFactory {
+    (packages?: Record<string, unknown>): {
+        fromXML: (xml: string) => Promise<ParseResult>;
+    };
+}
+
+interface EngineParse {
+    before: ModdleElement;
+    after: ModdleElement;
+}
+
+interface AttributeSnapshot {
+    owners: Set<string>;
+    attributes: Map<string, Map<string, string>>;
+}
+
 /**
  * Compares two BPMN XML documents and returns a serializable {@link DiffResult}.
  *
- * Node- and browser-safe: it touches no DOM.  The heavy `bpmn-moddle` parser
- * loads through dynamic `import()` (kept out of any bundle that never diffs);
- * `bpmn-js-differ` is a small static import — dynamic-importing it too tripped
- * api-extractor's declaration roll-up, and it still lands only in the `./diff`
- * chunk, which production consumers reach lazily.
+ * The documents are compared once with the Camunda 7 moddle descriptor and
+ * once with the Camunda 8 descriptor. Keeping the descriptors in separate
+ * moddle instances avoids their incompatible `modelerTemplate` definitions;
+ * the opposite engine's data is removed from each tree before comparison so
+ * every execution property is considered exactly once with its typed defaults.
+ * Unknown namespaced attributes are compared textually in a supplemental pass.
+ *
+ * Node- and browser-safe: it touches no DOM. The parser and descriptors load
+ * lazily, so consumers that never call this function do not pay their cost.
  *
  * Throws on parse or diff failure — callers that need a soft failure path
  * (e.g. the extension host) wrap this in their own try/catch.
  */
 export async function computeDiff(beforeXml: string, afterXml: string): Promise<DiffResult> {
-    // `bpmn-moddle` has no `default` export — its ESM dist only re-exports the
-    // factory as `BpmnModdle`.  Webpack's ESM→CJS interop does not synthesize
-    // `.default`, while Vite's dep optimizer exposes the named `BpmnModdle`, so
-    // we accept both shapes for forward-compat across bundlers.  It is a factory
-    // function, called without `new`.
-    const moddleMod = (await import("bpmn-moddle")) as unknown as {
-        default?: () => {
-            fromXML: (xml: string) => Promise<{ rootElement: unknown }>;
-        };
-        BpmnModdle?: () => {
-            fromXML: (xml: string) => Promise<{ rootElement: unknown }>;
-        };
+    const [moddleMod, camundaMod, zeebeMod] = await Promise.all([
+        import("bpmn-moddle"),
+        import("camunda-bpmn-moddle/resources/camunda.json"),
+        import("zeebe-bpmn-moddle/resources/zeebe.json"),
+    ]);
+
+    const moddleModule = moddleMod as unknown as {
+        default?: ModdleFactory;
+        BpmnModdle?: ModdleFactory;
     };
-    const createBpmnModdle = moddleMod.default ?? moddleMod.BpmnModdle;
+    const createBpmnModdle = moddleModule.default ?? moddleModule.BpmnModdle;
     if (typeof createBpmnModdle !== "function") {
         throw new Error("bpmn-moddle did not expose a factory under `default` or `BpmnModdle`.");
     }
-    const moddle = createBpmnModdle();
-    const beforeDefs = (await moddle.fromXML(beforeXml)).rootElement;
-    const afterDefs = (await moddle.fromXML(afterXml)).rootElement;
 
-    const result = diff(
-        beforeDefs as Parameters<typeof diff>[0],
-        afterDefs as Parameters<typeof diff>[1],
-    );
+    const camundaDescriptor = descriptorValue(camundaMod);
+    const zeebeDescriptor = descriptorValue(zeebeMod);
+    const beforeCamundaPrefixes = namespacePrefixes(beforeXml, CAMUNDA_NAMESPACE, "camunda");
+    const afterCamundaPrefixes = namespacePrefixes(afterXml, CAMUNDA_NAMESPACE, "camunda");
+    const beforeZeebePrefixes = namespacePrefixes(beforeXml, ZEEBE_NAMESPACE, "zeebe");
+    const afterZeebePrefixes = namespacePrefixes(afterXml, ZEEBE_NAMESPACE, "zeebe");
 
-    const added = Object.keys(result._added);
-    const removed = Object.keys(result._removed);
-    const changed = Object.keys(result._changed);
-    const layoutChanged = Object.keys(result._layoutChanged);
+    const [camunda, zeebe] = await Promise.all([
+        parseForEngine(
+            createBpmnModdle,
+            "camunda",
+            camundaDescriptor,
+            beforeXml,
+            afterXml,
+            ZEEBE_NAMESPACE,
+            beforeZeebePrefixes,
+            afterZeebePrefixes,
+        ),
+        parseForEngine(
+            createBpmnModdle,
+            "zeebe",
+            zeebeDescriptor,
+            beforeXml,
+            afterXml,
+            CAMUNDA_NAMESPACE,
+            beforeCamundaPrefixes,
+            afterCamundaPrefixes,
+        ),
+    ]);
+
+    const compared = [compare(camunda), compare(zeebe)];
+    const added = categoryIds(compared, "_added");
+    const removed = categoryIds(compared, "_removed");
+    const changed = categoryIds(compared, "_changed");
+    const layoutChanged = categoryIds(compared, "_layoutChanged");
+
+    const beforeAttributes = mergeAttributeSnapshots([
+        collectNamespacedAttributes(camunda.before, beforeCamundaPrefixes, beforeZeebePrefixes),
+        collectNamespacedAttributes(zeebe.before, beforeCamundaPrefixes, beforeZeebePrefixes),
+    ]);
+    const afterAttributes = mergeAttributeSnapshots([
+        collectNamespacedAttributes(camunda.after, afterCamundaPrefixes, afterZeebePrefixes),
+        collectNamespacedAttributes(zeebe.after, afterCamundaPrefixes, afterZeebePrefixes),
+    ]);
+    for (const id of changedAttributeOwners(beforeAttributes, afterAttributes)) {
+        if (!added.has(id) && !removed.has(id)) changed.add(id);
+    }
+
+    const addedIds = [...added];
+    const removedIds = [...removed];
+    const changedIds = [...changed];
+    const layoutChangedIds = [...layoutChanged];
     const counts: DiffCounts = {
-        added: added.length,
-        removed: removed.length,
-        changed: changed.length,
-        layoutChanged: layoutChanged.length,
+        added: addedIds.length,
+        removed: removedIds.length,
+        changed: changedIds.length,
+        layoutChanged: layoutChangedIds.length,
     };
 
-    // Order all id arrays by sequence-flow position so a stepper walks from
-    // start event to end event instead of in the differ's arbitrary insertion
-    // order.  Removed elements live only on the before canvas; anchor each one
-    // next to a surviving neighbour in the after order so it appears near where
-    // it sits in the flow.
+    const beforeDefs = camunda.before;
+    const afterDefs = camunda.after;
     const afterOrder = buildFlowOrder(afterDefs as never);
-    const removedAnchors = buildRemovedAnchors(removed, beforeDefs as never, afterOrder);
-    const sortedAdded = sortIdsByOrder(added, afterOrder);
-    const sortedRemoved = sortIdsByOrder(removed, removedAnchors);
-    const sortedChanged = sortIdsByOrder(changed, afterOrder);
-    const sortedLayoutChanged = sortIdsByOrder(layoutChanged, afterOrder);
+    const removedAnchors = buildRemovedAnchors(removedIds, beforeDefs as never, afterOrder);
+    const sortedAdded = sortIdsByOrder(addedIds, afterOrder);
+    const sortedRemoved = sortIdsByOrder(removedIds, removedAnchors);
+    const sortedChanged = sortIdsByOrder(changedIds, afterOrder);
+    const sortedLayoutChanged = sortIdsByOrder(layoutChangedIds, afterOrder);
 
-    // Merged navigation order: dedup across categories, then sort once more so
-    // removed elements interleave with added/changed at their anchored
-    // positions instead of sitting in their own block.
     const merged: string[] = [];
     const seen = new Set<string>();
     for (const id of [...sortedAdded, ...sortedRemoved, ...sortedChanged, ...sortedLayoutChanged]) {
@@ -100,4 +184,293 @@ export async function computeDiff(beforeXml: string, afterXml: string): Promise<
         counts,
         navigationOrder,
     };
+}
+
+function descriptorValue(module: unknown): unknown {
+    const descriptorModule = module as { default?: unknown };
+    return descriptorModule.default ?? module;
+}
+
+async function parseForEngine(
+    createBpmnModdle: ModdleFactory,
+    engine: Engine,
+    descriptor: unknown,
+    beforeXml: string,
+    afterXml: string,
+    excludedNamespace: string,
+    beforeExcludedPrefixes: ReadonlySet<string>,
+    afterExcludedPrefixes: ReadonlySet<string>,
+): Promise<EngineParse> {
+    const moddle = createBpmnModdle({ [engine]: descriptor });
+    const [beforeResult, afterResult] = await Promise.all([
+        moddle.fromXML(beforeXml),
+        moddle.fromXML(afterXml),
+    ]);
+    assertNoSkippedContent(beforeResult, engine, "before");
+    assertNoSkippedContent(afterResult, engine, "after");
+    stripEngineData(beforeResult.rootElement, excludedNamespace, beforeExcludedPrefixes);
+    stripEngineData(afterResult.rootElement, excludedNamespace, afterExcludedPrefixes);
+    return { before: beforeResult.rootElement, after: afterResult.rootElement };
+}
+
+function assertNoSkippedContent(result: ParseResult, engine: Engine, revision: string): void {
+    const skipped = result.warnings?.find((warning) =>
+        warning.message?.toLowerCase().includes("unparsable content"),
+    );
+    if (skipped) {
+        throw new Error(
+            `Failed to parse ${revision} BPMN with the ${engine} descriptor: ${skipped.message}`,
+        );
+    }
+}
+
+function compare(parsed: EngineParse): ReturnType<typeof diff> {
+    return diff(
+        parsed.before as Parameters<typeof diff>[0],
+        parsed.after as Parameters<typeof diff>[1],
+    );
+}
+
+function categoryIds(
+    results: readonly ReturnType<typeof diff>[],
+    category: "_added" | "_removed" | "_changed" | "_layoutChanged",
+): Set<string> {
+    return new Set(results.flatMap((result) => Object.keys(result[category])));
+}
+
+function namespacePrefixes(xml: string, namespace: string, canonicalPrefix: string): Set<string> {
+    const prefixes = new Set([canonicalPrefix]);
+    const declaration = /\bxmlns:([\w.-]+)\s*=\s*(["'])(.*?)\2/g;
+    for (const match of xml.matchAll(declaration)) {
+        if (match[3] === namespace) prefixes.add(match[1]);
+    }
+    return prefixes;
+}
+
+function stripEngineData(
+    root: ModdleElement,
+    excludedNamespace: string,
+    excludedPrefixes: ReadonlySet<string>,
+): void {
+    walkContainment(root, (element) => {
+        stripAttributes(element, excludedPrefixes);
+        for (const property of containmentProperties(element)) {
+            const value = element[property];
+            if (Array.isArray(value)) {
+                const retained = value.filter(
+                    (child): child is ModdleElement =>
+                        !isModdleElement(child) ||
+                        !belongsToNamespace(child, excludedNamespace, excludedPrefixes),
+                );
+                if (retained.length !== value.length) element[property] = retained;
+            } else if (
+                isModdleElement(value) &&
+                belongsToNamespace(value, excludedNamespace, excludedPrefixes)
+            ) {
+                delete element[property];
+            }
+        }
+    });
+
+    walkContainment(root, (element) => {
+        const extensionElements = element.extensionElements;
+        if (
+            isModdleElement(extensionElements) &&
+            Array.isArray(extensionElements.values) &&
+            extensionElements.values.length === 0 &&
+            Object.keys(extensionElements.$attrs ?? {}).length === 0
+        ) {
+            delete element.extensionElements;
+        }
+    });
+}
+
+function stripAttributes(element: ModdleElement, excludedPrefixes: ReadonlySet<string>): void {
+    if (element.$attrs) {
+        for (const name of Object.keys(element.$attrs)) {
+            if (hasPrefix(name, excludedPrefixes)) delete element.$attrs[name];
+        }
+    }
+    if (element.$descriptor.isGeneric) {
+        for (const name of Object.keys(element)) {
+            if (hasPrefix(name, excludedPrefixes)) delete element[name];
+        }
+    }
+}
+
+function belongsToNamespace(
+    element: ModdleElement,
+    namespace: string,
+    prefixes: ReadonlySet<string>,
+): boolean {
+    return element.$descriptor.ns?.uri === namespace || hasPrefix(element.$type, prefixes);
+}
+
+function hasPrefix(name: string, prefixes: ReadonlySet<string>): boolean {
+    const separator = name.indexOf(":");
+    return separator > 0 && prefixes.has(name.slice(0, separator));
+}
+
+function walkContainment(root: ModdleElement, visit: (element: ModdleElement) => void): void {
+    const seen = new Set<ModdleElement>();
+    const walk = (element: ModdleElement): void => {
+        if (seen.has(element)) return;
+        seen.add(element);
+        visit(element);
+        for (const property of containmentProperties(element)) {
+            const value = element[property];
+            if (Array.isArray(value)) {
+                for (const child of value) if (isModdleElement(child)) walk(child);
+            } else if (isModdleElement(value)) {
+                walk(value);
+            }
+        }
+    };
+    walk(root);
+}
+
+function containmentProperties(element: ModdleElement): string[] {
+    if (element.$descriptor.isGeneric) return element.$children ? ["$children"] : [];
+    return (element.$descriptor.properties ?? [])
+        .filter(
+            (property) =>
+                !property.isVirtual &&
+                !property.isReference &&
+                !property.isAttr &&
+                !property.isAttribute,
+        )
+        .map((property) => property.name);
+}
+
+function isModdleElement(value: unknown): value is ModdleElement {
+    return Boolean(
+        value && typeof value === "object" && "$type" in value && "$descriptor" in value,
+    );
+}
+
+function collectNamespacedAttributes(
+    root: ModdleElement,
+    camundaPrefixes: ReadonlySet<string>,
+    zeebePrefixes: ReadonlySet<string>,
+): AttributeSnapshot {
+    const snapshot: AttributeSnapshot = { owners: new Set(), attributes: new Map() };
+    const processVisuals = trackedProcessVisuals(root);
+    const seen = new Set<ModdleElement>();
+
+    const walk = (element: ModdleElement, inheritedOwner?: string, path = element.$type): void => {
+        if (seen.has(element)) return;
+        seen.add(element);
+        const owner = trackedId(element, processVisuals) ?? inheritedOwner;
+        if (owner) snapshot.owners.add(owner);
+
+        if (owner) {
+            const attributes = customAttributes(element, camundaPrefixes, zeebePrefixes);
+            if (attributes.length > 0) {
+                const owned = snapshot.attributes.get(owner) ?? new Map<string, string>();
+                for (const [name, value] of attributes) owned.set(`${path}@${name}`, value);
+                snapshot.attributes.set(owner, owned);
+            }
+        }
+
+        for (const property of containmentProperties(element)) {
+            const value = element[property];
+            if (Array.isArray(value)) {
+                const typeOccurrences = new Map<string, number>();
+                for (const child of value) {
+                    if (!isModdleElement(child)) continue;
+                    const occurrence = typeOccurrences.get(child.$type) ?? 0;
+                    typeOccurrences.set(child.$type, occurrence + 1);
+                    walk(child, owner, `${path}.${property}[${child.$type}:${occurrence}]`);
+                }
+            } else if (isModdleElement(value)) {
+                walk(value, owner, `${path}.${property}`);
+            }
+        }
+    };
+
+    walk(root);
+    return snapshot;
+}
+
+function customAttributes(
+    element: ModdleElement,
+    camundaPrefixes: ReadonlySet<string>,
+    zeebePrefixes: ReadonlySet<string>,
+): [string, string][] {
+    const attributes: Record<string, unknown> = element.$descriptor.isGeneric
+        ? element
+        : (element.$attrs ?? {});
+    return Object.entries(attributes).filter(
+        (entry): entry is [string, string] =>
+            typeof entry[1] === "string" &&
+            isQualifiedAttribute(entry[0]) &&
+            !hasPrefix(entry[0], camundaPrefixes) &&
+            !hasPrefix(entry[0], zeebePrefixes),
+    );
+}
+
+function isQualifiedAttribute(name: string): boolean {
+    return name.includes(":") && name !== "xmlns" && !name.startsWith("xmlns:");
+}
+
+function trackedProcessVisuals(root: ModdleElement): Map<ModdleElement, string> {
+    const visuals = new Map<ModdleElement, string>();
+    walkContainment(root, (element) => {
+        if (!isType(element, "bpmn:Participant") || !element.id) return;
+        const processRef = element.processRef;
+        if (isModdleElement(processRef)) visuals.set(processRef, element.id);
+    });
+    return visuals;
+}
+
+function trackedId(
+    element: ModdleElement,
+    processVisuals: Map<ModdleElement, string>,
+): string | undefined {
+    if (isType(element, "bpmn:DataObject")) return undefined;
+    if (isType(element, "bpmn:Process")) return processVisuals.get(element) ?? element.id;
+    const tracked = [
+        "bpmn:Participant",
+        "bpmn:Collaboration",
+        "bpmn:FlowElement",
+        "bpmn:SequenceFlow",
+        "bpmn:MessageFlow",
+        "bpmn:Lane",
+        "bpmn:DataAssociation",
+    ].some((type) => isType(element, type));
+    return tracked ? element.id : undefined;
+}
+
+function isType(element: ModdleElement, type: string): boolean {
+    return element.$type === type || element.$instanceOf?.(type) === true;
+}
+
+function mergeAttributeSnapshots(snapshots: readonly AttributeSnapshot[]): AttributeSnapshot {
+    const merged: AttributeSnapshot = { owners: new Set(), attributes: new Map() };
+    for (const snapshot of snapshots) {
+        for (const owner of snapshot.owners) merged.owners.add(owner);
+        for (const [owner, attributes] of snapshot.attributes) {
+            const owned = merged.attributes.get(owner) ?? new Map<string, string>();
+            for (const [name, value] of attributes) owned.set(name, value);
+            merged.attributes.set(owner, owned);
+        }
+    }
+    return merged;
+}
+
+function changedAttributeOwners(before: AttributeSnapshot, after: AttributeSnapshot): Set<string> {
+    const changed = new Set<string>();
+    for (const owner of before.owners) {
+        if (!after.owners.has(owner)) continue;
+        if (!mapsEqual(before.attributes.get(owner), after.attributes.get(owner)))
+            changed.add(owner);
+    }
+    return changed;
+}
+
+function mapsEqual(left?: Map<string, string>, right?: Map<string, string>): boolean {
+    if ((left?.size ?? 0) !== (right?.size ?? 0)) return false;
+    if (!left) return true;
+    for (const [key, value] of left) if (right?.get(key) !== value) return false;
+    return true;
 }

--- a/libs/bpmn-diff/src/types/execution-moddle.d.ts
+++ b/libs/bpmn-diff/src/types/execution-moddle.d.ts
@@ -1,0 +1,10 @@
+/** Descriptor JSON modules used lazily by the diff parser. */
+declare module "camunda-bpmn-moddle/resources/camunda.json" {
+    const descriptor: unknown;
+    export default descriptor;
+}
+
+declare module "zeebe-bpmn-moddle/resources/zeebe.json" {
+    const descriptor: unknown;
+    export default descriptor;
+}

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -297,6 +297,11 @@ Ids are sorted by BPMN sequence-flow position (start event → end event) rather
 insertion order. `sideView(result, side)` projects the result onto one pane's canvas (blanks `added`
 on `before`, `removed` on `after`).
 
+Execution properties are engine-aware: Camunda 7 attributes and extension elements and Camunda
+8/Zeebe extensions are compared with their moddle-defined types and defaults. Unknown namespaced
+attributes are compared textually by qualified name, including on nested extension elements.
+Attribute order is insignificant; renaming a custom namespace prefix counts as a textual change.
+
 ```ts
 // Node — no DOM required:
 import { computeDiff } from "@miragon/bpmn-modeler/diff";

--- a/packages/bpmn-modeler/scripts/check-diff-node.mjs
+++ b/packages/bpmn-modeler/scripts/check-diff-node.mjs
@@ -8,16 +8,24 @@
 import { computeDiff, sideView } from "../dist/diff.js";
 
 const BEFORE = `<?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Defs_1" targetNamespace="http://bpmn.io/schema/bpmn">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:custom="urn:custom" id="Defs_1" targetNamespace="http://bpmn.io/schema/bpmn">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:serviceTask id="ExecutionTask_1" camunda:class="OldDelegate">
+      <bpmn:extensionElements><zeebe:taskDefinition type="old-job" /></bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:task id="CustomTask_1" custom:value="old" />
   </bpmn:process>
 </bpmn:definitions>`;
 
 const AFTER = `<?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Defs_1" targetNamespace="http://bpmn.io/schema/bpmn">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:custom="urn:custom" id="Defs_1" targetNamespace="http://bpmn.io/schema/bpmn">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:serviceTask id="ExecutionTask_1" camunda:class="NewDelegate">
+      <bpmn:extensionElements><zeebe:taskDefinition type="new-job" /></bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:task id="CustomTask_1" custom:value="new" />
     <bpmn:task id="Task_1" />
   </bpmn:process>
 </bpmn:definitions>`;
@@ -34,6 +42,8 @@ for (const key of ["added", "removed", "changed", "layoutChanged", "navigationOr
 }
 if (typeof result.counts?.added !== "number") fail("result.counts.added is not a number");
 if (!result.added.includes("Task_1")) fail("expected the added Task_1 in result.added");
+if (!result.changed.includes("ExecutionTask_1")) fail("expected execution properties to change");
+if (!result.changed.includes("CustomTask_1")) fail("expected the custom attribute to change");
 
 const before = sideView(result, "before");
 if (before.added.length !== 0) fail("sideView(before).added should be blank");

--- a/packages/bpmn-modeler/scripts/smoke-consumer.mjs
+++ b/packages/bpmn-modeler/scripts/smoke-consumer.mjs
@@ -69,22 +69,32 @@ for (const subpath of SUBPATHS) {
 const { computeDiff, sideView } = await import(`${PKG}/diff`);
 
 const BEFORE = `<?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Defs_1" targetNamespace="http://bpmn.io/schema/bpmn">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:custom="urn:custom" id="Defs_1" targetNamespace="http://bpmn.io/schema/bpmn">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:serviceTask id="ExecutionTask_1" camunda:class="OldDelegate">
+      <bpmn:extensionElements><zeebe:taskDefinition type="old-job" /></bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:task id="CustomTask_1" custom:value="old" />
   </bpmn:process>
 </bpmn:definitions>`;
 
 const AFTER = `<?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Defs_1" targetNamespace="http://bpmn.io/schema/bpmn">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:custom="urn:custom" id="Defs_1" targetNamespace="http://bpmn.io/schema/bpmn">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:serviceTask id="ExecutionTask_1" camunda:class="NewDelegate">
+      <bpmn:extensionElements><zeebe:taskDefinition type="new-job" /></bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:task id="CustomTask_1" custom:value="new" />
     <bpmn:task id="Task_1" />
   </bpmn:process>
 </bpmn:definitions>`;
 
 const result = await computeDiff(BEFORE, AFTER);
 if (!result.added.includes("Task_1")) fail("expected the added Task_1 in computeDiff result.added");
+if (!result.changed.includes("ExecutionTask_1")) fail("expected execution properties to change");
+if (!result.changed.includes("CustomTask_1")) fail("expected the custom attribute to change");
 const after = sideView(result, "after");
 if (!after.added.includes("Task_1")) fail("sideView(after).added should carry Task_1");
 

--- a/packages/bpmn-modeler/src/diff/index.spec.ts
+++ b/packages/bpmn-modeler/src/diff/index.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { ALL_EXECUTION_PROPERTY_FIXTURES } from "../../../../libs/bpmn-diff/src/__fixtures__/execution-properties";
+import { computeDiff } from "./index";
+
+describe("public diff wrapper execution properties", () => {
+    it.each(ALL_EXECUTION_PROPERTY_FIXTURES)("compares $name", async (fixture) => {
+        await expect(computeDiff(fixture.before, fixture.after)).resolves.toEqual(fixture.expected);
+    });
+});

--- a/packages/bpmn-modeler/vite.config.mts
+++ b/packages/bpmn-modeler/vite.config.mts
@@ -40,6 +40,15 @@ const INLINED_LIB_SRC = [
     "../../libs/flow-navigation/src",
 ];
 
+// These descriptor JSON files are lazy imports of the inlined diff library.
+// Turn exactly these two into JavaScript chunks so the published Node entry
+// never relies on JSON import attributes. All other npm dependencies remain
+// external.
+const INLINED_DESCRIPTOR_JSON = new Set([
+    "camunda-bpmn-moddle/resources/camunda.json",
+    "zeebe-bpmn-moddle/resources/zeebe.json",
+]);
+
 function isInlined(id: string): boolean {
     return INLINED_LIBS.some((name) => id === name || id.startsWith(`${name}/`));
 }
@@ -53,6 +62,7 @@ function isExternal(id: string): boolean {
     if (id.startsWith(".") || isAbsolute(id)) return false;
     if (id.endsWith(".css")) return false;
     if (isInlined(id)) return false;
+    if (INLINED_DESCRIPTOR_JSON.has(id)) return false;
     if (id === "@oxc-project/runtime" || id.startsWith("@oxc-project/runtime/")) return false;
     return true;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3935,8 +3935,10 @@ __metadata:
   dependencies:
     bpmn-js-differ: "npm:3.2.0"
     bpmn-moddle: "npm:10.2.0"
+    camunda-bpmn-moddle: "npm:7.0.2"
     typescript: "npm:6.0.3"
     vitest: "npm:4.1.11"
+    zeebe-bpmn-moddle: "npm:1.18.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Issue

Closes #1487

## Description

Detect Camunda 7 execution attributes, Camunda 8 extensions, and custom namespaced attributes using isolated engine comparisons while preserving the public diff API and Node-safe lazy loading, as documented in [ADR 0029](docs/adr/0029-compare-execution-properties-with-isolated-moddle-descriptors.md).
Add shared regression fixtures, a browser regression page, Node and consumer smoke coverage, descriptor dependency declarations, and comparison-policy documentation.
Validation: 275 tests passed (3 skipped), full package build including `check:diff-node`, diff library typecheck, lint checks, and Knip.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (package architecture tests passed)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (not run)
