### PR TITLE
fix(bpmn-modeler): make text clipboard polyfill per-instance and disposable

### DIFF
--- a/.agents/skills/bpmn-js/SKILL.md
+++ b/.agents/skills/bpmn-js/SKILL.md
@@ -139,7 +139,7 @@ For Cmd/Ctrl+C it reads `window.getSelection()` and writes via the injected `tex
 
 ### Layer 3: FEEL Editor Polyfill + Select-All Guard (`propertiesPanelClipboard.ts`)
 
-The C8 properties panel's FEEL expression editor is **CodeMirror 6**, which lives *outside* the bpmn-js DI context — so the two DI modules above can't reach it. `installContentEditableClipboardPolyfill(requestTextClipboard, writeTextClipboard)` (still webview-local in `apps/bpmn-webview/src/app/propertiesPanelClipboard.ts`, installed from `main.ts`) fills that gap: a capture-phase `keydown` listener that bridges Cmd/Ctrl+C/V on any contenteditable/text-editing surface through the host **text** clipboard.
+The C8 properties panel's FEEL expression editor is **CodeMirror 6**, which lives *outside* the bpmn-js DI context — so the two DI modules above can't reach it. `installContentEditableClipboardPolyfill(roots, { requestClipboard, writeClipboard })` (in `packages/bpmn-modeler/src/propertiesPanelClipboard.ts`, installed by `BpmnModeler.init()` / `BpmnDesigner.init()`) fills that gap: a capture-phase `keydown` listener that bridges Cmd/Ctrl+C/V on any contenteditable/text-editing surface through the host **text** clipboard. It is a per-instance root registry — each `init()` registers its `[container, propertiesPanel.parent]` roots and returns a disposer that `destroy()` (and the next `init()`) calls; the document listeners and the `execCommand` patch install on the first registration and tear down on the last. Clipboard operations resolve against the root containing `document.activeElement`, so sibling instances route to their own bridge. Direct-editing labels (`.djs-direct-editing-content`) are excluded from the capture keydown so `LabelClipboardModule` owns them without a double paste.
 
 It also guards **Cmd/Ctrl+A**: without it, bpmn-js's `Keyboard` service steals Ctrl+A in a text field and selects all diagram shapes. The polyfill lets Ctrl+A select text within the focused editable element (canvas Ctrl+A stays owned by bpmn-js's `SelectionKeyBindings`).
 
@@ -177,6 +177,6 @@ through `@miragon/dmn-modeler` with a `data-dmn-theme` attribute — ADR 0026.)
 - **Webview entry** (installs the clipboard modules): `apps/bpmn-webview/src/main.ts`
 - **Element clipboard module** (priority 2051, `createReviver`): `libs/bpmn-clipboard/src/BridgedClipboardModule.ts` (built via `createClipboardModules`)
 - **Label overlay clipboard module**: `libs/bpmn-clipboard/src/LabelClipboardModule.ts`
-- **FEEL editor + Ctrl+A polyfill**: `apps/bpmn-webview/src/app/propertiesPanelClipboard.ts`
+- **FEEL editor + Ctrl+A polyfill** (per-instance root registry + disposer): `packages/bpmn-modeler/src/propertiesPanelClipboard.ts`
 - **Barrel exports**: `apps/bpmn-webview/src/app/index.ts`
 - **Host API wrapper + dev mock** (`getHostApi`/`MockHost`): `apps/bpmn-webview/src/app/host.ts`

--- a/packages/bpmn-modeler/src/design/designer.ts
+++ b/packages/bpmn-modeler/src/design/designer.ts
@@ -59,6 +59,9 @@ export class BpmnDesigner {
 
     private focusDisposers: Array<() => void> = [];
 
+    // Separate from focusDisposers: the polyfill registers at the top of init() before the canvas exists.
+    private disposeClipboardPolyfill?: () => void;
+
     // Retain the debouncer so destroy can cancel a pending export.
     private contentSaved?: AsyncDebounced<() => Promise<void>>;
 
@@ -125,6 +128,8 @@ export class BpmnDesigner {
     /** @internal */
     async init(): Promise<void> {
         this.disposeFocusFeatures();
+        this.disposeClipboardPolyfill?.();
+        this.disposeClipboardPolyfill = undefined;
 
         // Register NativeCopyPaste even with a bridge: the bridge module expects to disable it.
         const clip = this.options.clipboard;
@@ -134,9 +139,14 @@ export class BpmnDesigner {
         if (clip) {
             // The FEEL editor sits outside bpmn-js DI and needs the document-level text bridge.
             const textBridge = clip.text ?? clip.bridge;
-            installContentEditableClipboardPolyfill(
-                () => textBridge.requestClipboard(),
-                (text) => textBridge.writeClipboard(text),
+            this.disposeClipboardPolyfill = installContentEditableClipboardPolyfill(
+                [this.container, this.options.propertiesPanel.parent],
+                {
+                    requestClipboard: () => textBridge.requestClipboard(),
+                    writeClipboard: (text) => {
+                        void textBridge.writeClipboard(text);
+                    },
+                },
             );
         }
         const extra = (this.options.additionalModules as any[]) ?? [];
@@ -367,6 +377,8 @@ export class BpmnDesigner {
         this.stopObservingSize = undefined;
         this.themeController?.dispose();
         this.disposeFocusFeatures();
+        this.disposeClipboardPolyfill?.();
+        this.disposeClipboardPolyfill = undefined;
         this.modeler?.destroy();
         this.modeler = undefined;
         this._viewport = undefined;

--- a/packages/bpmn-modeler/src/labelClipboard.spec.ts
+++ b/packages/bpmn-modeler/src/labelClipboard.spec.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// LabelClipboard is not exported from the package barrel; reach the class through the DI tuple.
+import { LabelClipboardModule } from "../../../libs/bpmn-clipboard/src/LabelClipboardModule";
+
+type Bridge = {
+    requestClipboard: () => Promise<string>;
+    writeClipboard: (text: string) => void;
+};
+
+const LabelClipboard = LabelClipboardModule.labelClipboard[1] as new (
+    bridge: Bridge,
+    eventBus: unknown,
+    directEditing: unknown,
+) => unknown;
+
+let handlers: Record<string, Array<() => void>>;
+
+function makeEventBus() {
+    handlers = {};
+    return {
+        on: (event: string, cb: () => void) => {
+            (handlers[event] ??= []).push(cb);
+        },
+    };
+}
+
+function emit(event: string): void {
+    (handlers[event] ?? []).forEach((cb) => cb());
+}
+
+function ctrl(key: string): KeyboardEvent {
+    return new KeyboardEvent("keydown", { key, ctrlKey: true, bubbles: true, cancelable: true });
+}
+
+let bridge: {
+    requestClipboard: ReturnType<typeof vi.fn>;
+    writeClipboard: ReturnType<typeof vi.fn>;
+};
+let content: HTMLDivElement;
+let directEditing: { _textbox: { content: HTMLDivElement } };
+
+beforeEach(() => {
+    bridge = {
+        // Empty result skips the synthetic-paste dispatch (jsdom lacks ClipboardEvent);
+        // the assertion only cares that the bridge read was requested.
+        requestClipboard: vi.fn().mockResolvedValue(""),
+        writeClipboard: vi.fn(),
+    };
+    content = document.createElement("div");
+    content.contentEditable = "true";
+    document.body.appendChild(content);
+    directEditing = { _textbox: { content } };
+    new LabelClipboard(bridge as unknown as Bridge, makeEventBus(), directEditing);
+});
+
+describe("LabelClipboard", () => {
+    it("routes Ctrl+V through the bridge and prevents default while editing", () => {
+        emit("directEditing.activate");
+
+        const event = ctrl("v");
+        content.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(bridge.requestClipboard).toHaveBeenCalledTimes(1);
+    });
+
+    it("copies the current selection through the bridge on Ctrl+C", () => {
+        emit("directEditing.activate");
+        vi.spyOn(window, "getSelection").mockReturnValue({
+            toString: () => "label text",
+        } as unknown as Selection);
+
+        content.dispatchEvent(ctrl("c"));
+
+        expect(bridge.writeClipboard).toHaveBeenCalledWith("label text");
+    });
+
+    it("selects the textbox contents on Ctrl+A without leaking to bpmn-js", () => {
+        emit("directEditing.activate");
+        const addRange = vi.fn();
+        vi.spyOn(window, "getSelection").mockReturnValue({
+            removeAllRanges: vi.fn(),
+            addRange,
+        } as unknown as Selection);
+
+        const event = ctrl("a");
+        content.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(addRange).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not attach when the textbox has no content element", () => {
+        directEditing._textbox = undefined as unknown as { content: HTMLDivElement };
+        emit("directEditing.activate");
+
+        content.dispatchEvent(ctrl("v"));
+
+        expect(bridge.requestClipboard).not.toHaveBeenCalled();
+    });
+
+    it("detaches the handler on deactivate", () => {
+        emit("directEditing.activate");
+        emit("directEditing.deactivate");
+
+        content.dispatchEvent(ctrl("v"));
+
+        expect(bridge.requestClipboard).not.toHaveBeenCalled();
+    });
+});

--- a/packages/bpmn-modeler/src/modeler.ts
+++ b/packages/bpmn-modeler/src/modeler.ts
@@ -90,6 +90,9 @@ export class BpmnModeler {
 
     private focusDisposers: Array<() => void> = [];
 
+    // Separate from focusDisposers: the polyfill registers at the top of init() before the canvas exists.
+    private disposeClipboardPolyfill?: () => void;
+
     // Retain the debouncer so destroy can cancel a pending export.
     private contentSaved?: AsyncDebounced<() => Promise<void>>;
 
@@ -170,6 +173,8 @@ export class BpmnModeler {
     async init(): Promise<void> {
         const engine = this.options.engine;
         this.disposeFocusFeatures();
+        this.disposeClipboardPolyfill?.();
+        this.disposeClipboardPolyfill = undefined;
 
         // Inject the panel root so script controls cannot target a sibling modeler's panel.
         const propertiesPanelRootModule = {
@@ -203,9 +208,14 @@ export class BpmnModeler {
             // FEEL editors sit outside bpmn-js DI and need the document-level text bridge.
             // Wrap callbacks to preserve the bridge's this binding.
             const textBridge = clip.text ?? clip.bridge;
-            installContentEditableClipboardPolyfill(
-                () => textBridge.requestClipboard(),
-                (text) => textBridge.writeClipboard(text),
+            this.disposeClipboardPolyfill = installContentEditableClipboardPolyfill(
+                [this.container, this.options.propertiesPanel.parent],
+                {
+                    requestClipboard: () => textBridge.requestClipboard(),
+                    writeClipboard: (text) => {
+                        void textBridge.writeClipboard(text);
+                    },
+                },
             );
         }
         const extra = (this.options.additionalModules as any[]) ?? [];
@@ -389,6 +399,8 @@ export class BpmnModeler {
         this.container.removeAttribute(MODE_ATTRIBUTE);
         this.options.propertiesPanel.parent.removeAttribute(MODE_ATTRIBUTE);
         this.disposeFocusFeatures();
+        this.disposeClipboardPolyfill?.();
+        this.disposeClipboardPolyfill = undefined;
         this.modeler?.destroy();
         this.modeler = undefined;
         this._viewport = undefined;

--- a/packages/bpmn-modeler/src/propertiesPanelClipboard.spec.ts
+++ b/packages/bpmn-modeler/src/propertiesPanelClipboard.spec.ts
@@ -1,11 +1,15 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import { installContentEditableClipboardPolyfill } from "./propertiesPanelClipboard";
 
-const mocks = {
-    requestClipboard: vi.fn().mockResolvedValue(""),
-    writeClipboard: vi.fn<(text: string) => void>(),
-};
+function makeBridge() {
+    return {
+        requestClipboard: vi.fn<() => Promise<string>>().mockResolvedValue(""),
+        writeClipboard: vi.fn<(text: string) => void>(),
+    };
+}
+
+type Bridge = ReturnType<typeof makeBridge>;
 
 /**
  * Bubble-phase spy that stands in for bpmn-js's `Keyboard` service: if the
@@ -13,72 +17,74 @@ const mocks = {
  * through, this records the keystroke as bpmn-js would have seen it.
  */
 const bpmnJsKeyboardSpy = vi.fn<(e: KeyboardEvent) => void>();
+const onBpmnJsKeydown = (e: KeyboardEvent): void => bpmnJsKeyboardSpy(e);
 
 /**
  * Bubble-phase spy on `window` that stands in for Theia's webview
- * pre-bootstrap forwarder. The real forwarder lives on the inner iframe's
- * window in bubble phase and posts the keystroke to the outer Theia shell
- * unconditionally (no `defaultPrevented` gate); if it fires, the outer
- * shell runs SELECT_ALL = `document.execCommand("selectAll")` against the
- * whole Theia chrome. The Ctrl+A guard must stop the bubble at `document`
- * so this never sees the event — for *every* surface, canvas included.
+ * pre-bootstrap forwarder: it fires only if the Ctrl+A guard failed to stop
+ * the bubble at `document`, for *every* surface, canvas included.
  */
 const theiaForwarderSpy = vi.fn<(e: KeyboardEvent) => void>();
+const onTheiaKeydown = (e: KeyboardEvent): void => theiaForwarderSpy(e);
 
-beforeAll(() => {
-    vi.useFakeTimers();
-    installContentEditableClipboardPolyfill(
-        () => mocks.requestClipboard(),
-        (text) => mocks.writeClipboard(text),
-    );
-    document.addEventListener("keydown", (e) => bpmnJsKeyboardSpy(e));
-    window.addEventListener("keydown", (e) => theiaForwarderSpy(e));
-});
+let disposers: Array<() => void>;
+let nativeExecCommandSpy: Mock;
 
-afterAll(() => {
-    vi.useRealTimers();
-});
+// jsdom ships no execCommand, so define a stub the install captures as its native delegate.
+const originalExecCommand = Object.getOwnPropertyDescriptor(Document.prototype, "execCommand");
 
-beforeEach(() => {
-    vi.runAllTimers();
-    mocks.requestClipboard.mockReset().mockResolvedValue("");
-    mocks.writeClipboard.mockReset();
-    bpmnJsKeyboardSpy.mockReset();
-    theiaForwarderSpy.mockReset();
-    document.body.innerHTML = "";
-});
+// The guard is added during install; these must register *after* it so the
+// guard's stopImmediatePropagation can suppress the bpmn-js spy.
+function addGuardSpies(): void {
+    document.addEventListener("keydown", onBpmnJsKeydown);
+    window.addEventListener("keydown", onTheiaKeydown);
+}
 
-afterEach(() => {
-    vi.restoreAllMocks();
-});
+function removeGuardSpies(): void {
+    document.removeEventListener("keydown", onBpmnJsKeydown);
+    window.removeEventListener("keydown", onTheiaKeydown);
+}
 
-function focusedInput(): HTMLInputElement {
+function install(roots: HTMLElement[], bridge: Bridge): () => void {
+    const dispose = installContentEditableClipboardPolyfill(roots, bridge);
+    disposers.push(dispose);
+    return dispose;
+}
+
+function makeRoot(): HTMLElement {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    return root;
+}
+
+function focusedInput(parent: HTMLElement = document.body): HTMLInputElement {
     const el = document.createElement("input");
-    document.body.appendChild(el);
+    parent.appendChild(el);
     el.focus();
     return el;
 }
 
-function focusedTextarea(): HTMLTextAreaElement {
+function focusedTextarea(parent: HTMLElement = document.body): HTMLTextAreaElement {
     const el = document.createElement("textarea");
-    document.body.appendChild(el);
+    parent.appendChild(el);
     el.focus();
     return el;
 }
 
-function focusedEditor(): HTMLDivElement {
+function focusedEditor(parent: HTMLElement = document.body, className?: string): HTMLDivElement {
     const el = document.createElement("div");
     el.contentEditable = "true";
     el.tabIndex = -1;
-    document.body.appendChild(el);
+    if (className) el.className = className;
+    parent.appendChild(el);
     el.focus();
     return el;
 }
 
-function focusedDiv(): HTMLDivElement {
+function focusedDiv(parent: HTMLElement = document.body): HTMLDivElement {
     const el = document.createElement("div");
     el.tabIndex = 0;
-    document.body.appendChild(el);
+    parent.appendChild(el);
     el.focus();
     return el;
 }
@@ -87,8 +93,40 @@ function ctrl(key: string): KeyboardEvent {
     return new KeyboardEvent("keydown", { key, ctrlKey: true, bubbles: true });
 }
 
+beforeEach(() => {
+    vi.useFakeTimers();
+    disposers = [];
+    bpmnJsKeyboardSpy.mockReset();
+    theiaForwarderSpy.mockReset();
+    nativeExecCommandSpy = vi.fn().mockReturnValue(false);
+    Object.defineProperty(Document.prototype, "execCommand", {
+        value: nativeExecCommandSpy,
+        writable: true,
+        configurable: true,
+    });
+});
+
+afterEach(() => {
+    // Dispose first so the polyfill removes its own document.execCommand before we restore the prototype.
+    for (const dispose of disposers.splice(0)) dispose();
+    vi.runAllTimers();
+    removeGuardSpies();
+    if (originalExecCommand) {
+        Object.defineProperty(Document.prototype, "execCommand", originalExecCommand);
+    } else {
+        delete (Document.prototype as { execCommand?: unknown }).execCommand;
+    }
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+});
+
 describe("Ctrl+A guard: text-editing surfaces own their selection", () => {
-    it("does not let Ctrl+A in a properties-panel <input> reach bpmn-js", () => {
+    beforeEach(() => {
+        install([makeRoot()], makeBridge());
+        addGuardSpies();
+    });
+
+    it("does not let Ctrl+A in an <input> reach bpmn-js", () => {
         focusedInput().dispatchEvent(ctrl("a"));
         expect(bpmnJsKeyboardSpy).not.toHaveBeenCalled();
     });
@@ -98,7 +136,7 @@ describe("Ctrl+A guard: text-editing surfaces own their selection", () => {
         expect(bpmnJsKeyboardSpy).not.toHaveBeenCalled();
     });
 
-    it("does not let Ctrl+A in a contenteditable (label / FEEL editor) reach bpmn-js", () => {
+    it("does not let Ctrl+A in a contenteditable reach bpmn-js", () => {
         focusedEditor().dispatchEvent(ctrl("a"));
         expect(bpmnJsKeyboardSpy).not.toHaveBeenCalled();
     });
@@ -110,7 +148,12 @@ describe("Ctrl+A guard: text-editing surfaces own their selection", () => {
 });
 
 describe("Ctrl+A guard: block the Theia outer-shell SELECT_ALL forward", () => {
-    it("stops Ctrl+A on the canvas before it reaches `window`", () => {
+    beforeEach(() => {
+        install([makeRoot()], makeBridge());
+        addGuardSpies();
+    });
+
+    it("stops Ctrl+A on a non-text element before it reaches `window`", () => {
         focusedDiv().dispatchEvent(ctrl("a"));
         expect(theiaForwarderSpy).not.toHaveBeenCalled();
     });
@@ -120,63 +163,299 @@ describe("Ctrl+A guard: block the Theia outer-shell SELECT_ALL forward", () => {
         expect(theiaForwarderSpy).not.toHaveBeenCalled();
     });
 
-    it("stops Ctrl+A in a contenteditable before it reaches `window`", () => {
-        focusedEditor().dispatchEvent(ctrl("a"));
+    it("fires for a text surface outside any registered root (guard stays global)", () => {
+        // The guard is deliberately not root-scoped: every surface while ≥ 1 instance is alive.
+        focusedInput().dispatchEvent(ctrl("a"));
+        expect(bpmnJsKeyboardSpy).not.toHaveBeenCalled();
         expect(theiaForwarderSpy).not.toHaveBeenCalled();
     });
 });
 
-describe("copy and paste in the FEEL expression editor", () => {
-    it("Ctrl+V pastes from the extension-host clipboard into the editor", () => {
-        focusedEditor().dispatchEvent(ctrl("v"));
-        expect(mocks.requestClipboard).toHaveBeenCalled();
+describe("copy and paste inside a registered root", () => {
+    let root: HTMLElement;
+    let bridge: Bridge;
+
+    beforeEach(() => {
+        root = makeRoot();
+        bridge = makeBridge();
+        install([root], bridge);
     });
 
-    it("Ctrl+C copies the selected expression text to the extension-host clipboard", () => {
-        const editor = focusedEditor();
+    it("Ctrl+V pastes from the host clipboard into a contenteditable in the root", () => {
+        focusedEditor(root).dispatchEvent(ctrl("v"));
+        expect(bridge.requestClipboard).toHaveBeenCalledTimes(1);
+    });
+
+    it("Ctrl+C copies the selected text to the host clipboard", () => {
         vi.spyOn(window, "getSelection").mockReturnValue({
             toString: () => "some expression",
         } as unknown as Selection);
-        editor.dispatchEvent(ctrl("c"));
-        expect(mocks.writeClipboard).toHaveBeenCalledWith("some expression");
+        focusedEditor(root).dispatchEvent(ctrl("c"));
+        expect(bridge.writeClipboard).toHaveBeenCalledWith("some expression");
     });
 
-    it("paste does nothing when a plain element (not an editor) is focused", () => {
-        focusedDiv().dispatchEvent(ctrl("v"));
-        expect(mocks.requestClipboard).not.toHaveBeenCalled();
-    });
-});
-
-describe("idempotent install", () => {
-    it("a second install registers no additional handlers", () => {
-        // The polyfill acts on `document` and monkey-patches execCommand, so a
-        // repeat call must be a no-op rather than stack a second handler.
-        const secondRequest = vi.fn().mockResolvedValue("");
-        installContentEditableClipboardPolyfill(
-            () => secondRequest(),
-            () => undefined,
-        );
-
-        focusedEditor().dispatchEvent(ctrl("v"));
-
-        // Only the original install's handler fired; the second install's own
-        // request fn is never wired.
-        expect(secondRequest).not.toHaveBeenCalled();
-        expect(mocks.requestClipboard).toHaveBeenCalledTimes(1);
-    });
-});
-
-describe("paste triggered via the VS Code command palette", () => {
-    it("writes clipboard text into the focused FEEL editor", () => {
-        focusedEditor();
-        document.execCommand("paste");
-        expect(mocks.requestClipboard).toHaveBeenCalled();
+    it("paste does nothing when a plain element is focused", () => {
+        focusedDiv(root).dispatchEvent(ctrl("v"));
+        expect(bridge.requestClipboard).not.toHaveBeenCalled();
     });
 
-    it("paste only happens once when both keyboard shortcut and command palette fire", () => {
-        const editor = focusedEditor();
+    it("serves a command-palette paste on a contenteditable in the root", () => {
+        focusedEditor(root);
+        expect(document.execCommand("paste")).toBe(true);
+        expect(bridge.requestClipboard).toHaveBeenCalledTimes(1);
+    });
+
+    it("pastes only once when keyboard and command palette both fire", () => {
+        const editor = focusedEditor(root);
         editor.dispatchEvent(ctrl("v"));
         document.execCommand("paste");
-        expect(mocks.requestClipboard).toHaveBeenCalledTimes(1);
+        expect(bridge.requestClipboard).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("root scoping", () => {
+    it("ignores a contenteditable outside every registered root", () => {
+        const bridge = makeBridge();
+        install([makeRoot()], bridge);
+
+        const outsider = focusedEditor(document.body);
+        const event = ctrl("v");
+        outsider.dispatchEvent(event);
+
+        expect(bridge.requestClipboard).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("delegates execCommand to native for a contenteditable outside every root", () => {
+        install([makeRoot()], makeBridge());
+
+        focusedEditor(document.body);
+        document.execCommand("paste");
+
+        expect(nativeExecCommandSpy).toHaveBeenCalledWith("paste", undefined, undefined);
+    });
+});
+
+describe("multiple instances route to their own bridge", () => {
+    let rootA: HTMLElement;
+    let rootB: HTMLElement;
+    let bridgeA: Bridge;
+    let bridgeB: Bridge;
+
+    beforeEach(() => {
+        rootA = makeRoot();
+        rootB = makeRoot();
+        bridgeA = makeBridge();
+        bridgeB = makeBridge();
+        install([rootA], bridgeA);
+        install([rootB], bridgeB);
+    });
+
+    it("Ctrl+V in root A hits only bridge A", () => {
+        focusedEditor(rootA).dispatchEvent(ctrl("v"));
+        expect(bridgeA.requestClipboard).toHaveBeenCalledTimes(1);
+        expect(bridgeB.requestClipboard).not.toHaveBeenCalled();
+    });
+
+    it("Ctrl+V in root B hits only bridge B", () => {
+        focusedEditor(rootB).dispatchEvent(ctrl("v"));
+        expect(bridgeB.requestClipboard).toHaveBeenCalledTimes(1);
+        expect(bridgeA.requestClipboard).not.toHaveBeenCalled();
+    });
+
+    it("command-palette copy in root B hits only bridge B", () => {
+        vi.spyOn(window, "getSelection").mockReturnValue({
+            toString: () => "b-text",
+        } as unknown as Selection);
+        focusedEditor(rootB);
+        document.execCommand("copy");
+        expect(bridgeB.writeClipboard).toHaveBeenCalledWith("b-text");
+        expect(bridgeA.writeClipboard).not.toHaveBeenCalled();
+    });
+});
+
+describe("disposal", () => {
+    it("leaves the first instance inert while the second stays live and the guard active", () => {
+        const rootA = makeRoot();
+        const rootB = makeRoot();
+        const bridgeA = makeBridge();
+        const bridgeB = makeBridge();
+        const disposeA = install([rootA], bridgeA);
+        install([rootB], bridgeB);
+        addGuardSpies();
+
+        disposeA();
+
+        focusedEditor(rootA).dispatchEvent(ctrl("v"));
+        expect(bridgeA.requestClipboard).not.toHaveBeenCalled();
+
+        focusedEditor(rootB).dispatchEvent(ctrl("v"));
+        expect(bridgeB.requestClipboard).toHaveBeenCalledTimes(1);
+
+        // The spy sees every keydown that bubbles to document; only the Ctrl+A guard is under test here.
+        bpmnJsKeyboardSpy.mockClear();
+        focusedInput().dispatchEvent(ctrl("a"));
+        expect(bpmnJsKeyboardSpy).not.toHaveBeenCalled();
+    });
+
+    it("removes all document hooks after the last instance is disposed", () => {
+        const rootA = makeRoot();
+        const rootB = makeRoot();
+        const disposeA = install([rootA], makeBridge());
+        const disposeB = install([rootB], makeBridge());
+        addGuardSpies();
+
+        disposeA();
+        disposeB();
+
+        focusedInput().dispatchEvent(ctrl("a"));
+        expect(bpmnJsKeyboardSpy).toHaveBeenCalledTimes(1);
+        expect(Object.getOwnPropertyDescriptor(document, "execCommand")).toBeUndefined();
+    });
+
+    it("removes hooks regardless of disposal order (last-out wins)", () => {
+        const rootA = makeRoot();
+        const rootB = makeRoot();
+        const disposeA = install([rootA], makeBridge());
+        const disposeB = install([rootB], makeBridge());
+        addGuardSpies();
+
+        disposeB();
+        disposeA();
+
+        focusedInput().dispatchEvent(ctrl("a"));
+        expect(bpmnJsKeyboardSpy).toHaveBeenCalledTimes(1);
+        expect(Object.getOwnPropertyDescriptor(document, "execCommand")).toBeUndefined();
+    });
+
+    it("re-registers a fresh bridge on recreation", () => {
+        const root = makeRoot();
+        const disposeOld = install([root], makeBridge());
+        disposeOld();
+
+        const freshBridge = makeBridge();
+        install([root], freshBridge);
+
+        focusedEditor(root).dispatchEvent(ctrl("v"));
+        expect(freshBridge.requestClipboard).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("disposer idempotence and ownership", () => {
+    it("a second call to the same disposer is a no-op", () => {
+        const root = makeRoot();
+        const bridge = makeBridge();
+        const dispose = install([root], bridge);
+
+        dispose();
+        dispose();
+
+        install([root], bridge);
+        focusedEditor(root).dispatchEvent(ctrl("v"));
+        expect(bridge.requestClipboard).toHaveBeenCalledTimes(1);
+    });
+
+    it("a stale disposer cannot evict a live re-registration of the same root", () => {
+        const root = makeRoot();
+        const staleDispose = install([root], makeBridge());
+
+        const liveBridge = makeBridge();
+        install([root], liveBridge);
+
+        staleDispose();
+
+        focusedEditor(root).dispatchEvent(ctrl("v"));
+        expect(liveBridge.requestClipboard).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("label exclusion for the direct-editing textbox", () => {
+    let root: HTMLElement;
+    let polyfillBridge: Bridge;
+    let labelBridge: Bridge;
+
+    function attachLabelModule(editor: HTMLElement): void {
+        editor.addEventListener(
+            "keydown",
+            (e) => {
+                if (!(e.metaKey || e.ctrlKey)) return;
+                if (e.key === "v") {
+                    e.preventDefault();
+                    void labelBridge.requestClipboard();
+                } else if (e.key === "c") {
+                    labelBridge.writeClipboard("label");
+                }
+            },
+            true,
+        );
+    }
+
+    beforeEach(() => {
+        root = makeRoot();
+        polyfillBridge = makeBridge();
+        labelBridge = makeBridge();
+        install([root], polyfillBridge);
+    });
+
+    it("lets the label module handle Ctrl+V while the polyfill stands down", () => {
+        const editor = focusedEditor(root, "djs-direct-editing-content");
+        attachLabelModule(editor);
+
+        editor.dispatchEvent(ctrl("v"));
+
+        expect(labelBridge.requestClipboard).toHaveBeenCalledTimes(1);
+        expect(polyfillBridge.requestClipboard).not.toHaveBeenCalled();
+    });
+
+    it("lets the label module handle Ctrl+C while the polyfill stands down", () => {
+        const editor = focusedEditor(root, "djs-direct-editing-content");
+        attachLabelModule(editor);
+
+        editor.dispatchEvent(ctrl("c"));
+
+        expect(labelBridge.writeClipboard).toHaveBeenCalledWith("label");
+        expect(polyfillBridge.writeClipboard).not.toHaveBeenCalled();
+    });
+
+    it("suppresses the keydown-adjacent command-palette paste via the dedup flag", () => {
+        const editor = focusedEditor(root, "djs-direct-editing-content");
+        attachLabelModule(editor);
+
+        editor.dispatchEvent(ctrl("v"));
+        document.execCommand("paste");
+
+        expect(polyfillBridge.requestClipboard).not.toHaveBeenCalled();
+    });
+
+    it("still serves a standalone command-palette paste during label editing", () => {
+        const editor = focusedEditor(root, "djs-direct-editing-content");
+        attachLabelModule(editor);
+
+        editor.dispatchEvent(ctrl("v"));
+        // Past the dedup window, a fresh command-palette paste must be served — the
+        // execCommand hook carries no label exclusion.
+        vi.advanceTimersByTime(200);
+        document.execCommand("paste");
+
+        expect(polyfillBridge.requestClipboard).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("dedup window resets across teardown and re-install", () => {
+    it("serves the first paste after a re-install even if a stale window was open", () => {
+        const root = makeRoot();
+        const firstBridge = makeBridge();
+        const disposeFirst = install([root], firstBridge);
+
+        // Open the dedup window, then tear down before it elapses.
+        focusedEditor(root).dispatchEvent(ctrl("v"));
+        disposeFirst();
+
+        const secondBridge = makeBridge();
+        install([root], secondBridge);
+
+        focusedEditor(root);
+        document.execCommand("paste");
+        expect(secondBridge.requestClipboard).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/bpmn-modeler/src/propertiesPanelClipboard.ts
+++ b/packages/bpmn-modeler/src/propertiesPanelClipboard.ts
@@ -1,6 +1,11 @@
 /** @internal */
 import { isTextEditingSurface } from "@miragon/bpmn-modeler-types";
 
+export interface TextClipboardCallbacks {
+    requestClipboard(): Promise<string>;
+    writeClipboard(text: string): void;
+}
+
 function handleCopy(writeClipboard: (text: string) => void): void {
     const text = window.getSelection()?.toString() ?? "";
     if (text) writeClipboard(text);
@@ -12,101 +17,158 @@ function handlePaste(el: HTMLElement, requestClipboard: () => Promise<string>): 
     });
 }
 
-// Capture copy/paste before direct editing stops propagation; let text editors handle select-all first.
-let polyfillInstalled = false;
+const rootRegistry = new Map<HTMLElement, TextClipboardCallbacks>();
+let uninstallDocumentHooks: (() => void) | undefined;
+
+// Dedups one physical keystroke against one host execCommand("paste") — a page-level phenomenon,
+// so this flag stays module-global across every registered root.
+let handled = false;
+
+function markHandled(): void {
+    handled = true;
+    setTimeout(() => {
+        handled = false;
+    }, 200);
+}
+
+function resolveCallbacks(target: Element | null): TextClipboardCallbacks | undefined {
+    let node = target instanceof HTMLElement ? target : null;
+    while (node) {
+        const callbacks = rootRegistry.get(node);
+        if (callbacks) return callbacks;
+        node = node.parentElement;
+    }
+    return undefined;
+}
 
 export function installContentEditableClipboardPolyfill(
-    requestClipboard: () => Promise<string>,
-    writeClipboard: (text: string) => void,
-): void {
-    // Document listeners and the execCommand patch are page-global; repeated installs would duplicate handling.
-    if (polyfillInstalled) {
-        return;
+    roots: readonly HTMLElement[],
+    callbacks: TextClipboardCallbacks,
+): () => void {
+    for (const root of roots) {
+        rootRegistry.set(root, callbacks);
     }
-    polyfillInstalled = true;
+    uninstallDocumentHooks ??= installDocumentHooks();
 
-    let handled = false;
-
-    document.addEventListener(
-        "keydown",
-        (e: KeyboardEvent) => {
-            const el = document.activeElement;
-            if (!(el instanceof HTMLElement)) return;
-
-            const isMod = e.metaKey || e.ctrlKey;
-            if (!isMod) return;
-            if (el.contentEditable !== "true") return;
-
-            if (e.key === "v") {
-                handled = true;
-                setTimeout(() => {
-                    handled = false;
-                }, 200);
-                e.preventDefault();
-                handlePaste(el, requestClipboard);
+    let disposed = false;
+    return () => {
+        if (disposed) return;
+        disposed = true;
+        for (const root of roots) {
+            // Ownership check: a stale disposer must not evict a live re-registration of the same root.
+            if (rootRegistry.get(root) === callbacks) {
+                rootRegistry.delete(root);
             }
+        }
+        if (rootRegistry.size === 0) {
+            uninstallDocumentHooks?.();
+            uninstallDocumentHooks = undefined;
+        }
+    };
+}
 
-            if (e.key === "c") {
-                handled = true;
-                setTimeout(() => {
-                    handled = false;
-                }, 200);
-                handleCopy(writeClipboard);
-            }
-        },
-        true,
-    );
+function installDocumentHooks(): () => void {
+    const onClipboardKeydown = (e: KeyboardEvent): void => {
+        const el = document.activeElement;
+        if (!(el instanceof HTMLElement)) return;
 
-    document.addEventListener(
-        "keydown",
-        (e: KeyboardEvent) => {
-            if (!(e.metaKey || e.ctrlKey)) return;
-            if (e.key !== "a") return;
+        const isMod = e.metaKey || e.ctrlKey;
+        if (!isMod) return;
+        if (el.contentEditable !== "true") return;
+        if (e.key !== "v" && e.key !== "c") return;
 
-            // Theia forwards window keydowns even when defaultPrevented, triggering select-all in the outer shell.
-            e.stopPropagation();
+        const callbacks = resolveCallbacks(el);
+        if (!callbacks) return;
 
-            const el = document.activeElement;
-            if (!isTextEditingSurface(el)) {
-                return;
-            }
+        // Mark before the label exclusion bails: in VS Code one Ctrl+V arrives as keydown *and* a
+        // workbench execCommand("paste"). The label module handles the keydown but never sets the
+        // flag, so without this the execCommand patch below would paste a second time.
+        markHandled();
 
-            // Same-node bpmn-js listeners still run after stopPropagation, so text surfaces need this stronger stop.
-            e.stopImmediatePropagation();
+        // LabelClipboardModule owns keydown clipboard on the direct-editing textbox.
+        if (el.closest(".djs-direct-editing-content")) return;
 
-            // Native select-all is unreliable for input/textarea in webviews; contenteditables have their own handlers.
-            if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
-                el.select();
-            }
-        },
-        false,
-    );
+        if (e.key === "v") {
+            e.preventDefault();
+            handlePaste(el, callbacks.requestClipboard);
+        } else {
+            handleCopy(callbacks.writeClipboard);
+        }
+    };
+
+    const onSelectAllKeydown = (e: KeyboardEvent): void => {
+        if (!(e.metaKey || e.ctrlKey)) return;
+        if (e.key !== "a") return;
+
+        // Theia forwards window keydowns even when defaultPrevented, triggering select-all in the outer shell.
+        e.stopPropagation();
+
+        const el = document.activeElement;
+        if (!isTextEditingSurface(el)) {
+            return;
+        }
+
+        // Same-node bpmn-js listeners still run after stopPropagation, so text surfaces need this stronger stop.
+        e.stopImmediatePropagation();
+
+        // Native select-all is unreliable for input/textarea in webviews; contenteditables have their own handlers.
+        if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+            el.select();
+        }
+    };
 
     const nativeExecCommand = Document.prototype.execCommand;
 
-    Object.defineProperty(document, "execCommand", {
-        value: function (command: string, showUI?: boolean, value?: string): boolean {
-            const el = document.activeElement;
+    const patchedExecCommand = function (
+        command: string,
+        showUI?: boolean,
+        value?: string,
+    ): boolean {
+        const el = document.activeElement;
 
-            if (el instanceof HTMLElement && el.contentEditable === "true") {
+        if (el instanceof HTMLElement && el.contentEditable === "true") {
+            const callbacks = resolveCallbacks(el);
+            if (callbacks) {
                 if (command === "paste") {
                     if (handled) return true;
-                    handlePaste(el, requestClipboard);
+                    handlePaste(el, callbacks.requestClipboard);
                     return true;
                 }
 
                 if (command === "copy") {
                     if (handled) return true;
-                    handleCopy(writeClipboard);
+                    handleCopy(callbacks.writeClipboard);
                     return true;
                 }
             }
+        }
 
-            return nativeExecCommand?.call(document, command, showUI, value) ?? false;
-        },
+        return nativeExecCommand?.call(document, command, showUI, value) ?? false;
+    };
+
+    // Capture copy/paste before direct editing stops propagation; let text editors handle select-all first.
+    document.addEventListener("keydown", onClipboardKeydown, true);
+    document.addEventListener("keydown", onSelectAllKeydown, false);
+
+    Object.defineProperty(document, "execCommand", {
+        value: patchedExecCommand,
         writable: true,
         configurable: true,
     });
+
+    return () => {
+        document.removeEventListener("keydown", onClipboardKeydown, true);
+        document.removeEventListener("keydown", onSelectAllKeydown, false);
+
+        // Restore native dispatch by removing our own property, but only if a later foreign patch
+        // has not replaced it — that patch must survive.
+        const descriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
+        if (descriptor?.value === patchedExecCommand) {
+            delete (document as { execCommand?: unknown }).execCommand;
+        }
+
+        handled = false;
+    };
 }
 
 // Synthetic paste has no native insertion default, so unhandled contenteditables need insertText.


### PR DESCRIPTION
## Issue

Closes #1488

## Description

The contenteditable clipboard polyfill was page-global: a module-level flag made every install after the first a no-op, so the `document` listeners and the `execCommand` patch kept the first instance's bridge forever and leaked after destroy, and its capture-phase listener double-handled paste on the direct-editing label textbox that `LabelClipboardModule` owns. The polyfill is now a per-instance root registry: each `init()` registers `[container, propertiesPanel.parent]` with its own bridge and gets a disposer called from `destroy()` and init re-runs, clipboard operations resolve the bridge by walking from `document.activeElement` to the registered root, and the document hooks install on the first registration and tear down (restoring native `execCommand`) on the last. The Theia Ctrl+A guard stays page-global while any instance is alive, and `.djs-direct-editing-content` is excluded from the capture keydown so labels paste exactly once. Also restructures the polyfill spec to per-test install/dispose with coverage for all acceptance criteria, adds a first spec for `LabelClipboardModule`, and fixes the stale polyfill location in the bpmn-js skill doc.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A — internal module, no boundary/API change)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [ ] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
