### PR TITLE
fix(append-menu): honor the bpmn type chosen for a multi-type template

### DIFF
--- a/libs/append-menu/src/AppendMenuOverride.ts
+++ b/libs/append-menu/src/AppendMenuOverride.ts
@@ -10,6 +10,7 @@
 import { render, h } from "preact";
 import { AppendMenuOverlay } from "./components/AppendMenuOverlay";
 import { classifyEntries, executeEntryAction } from "./types";
+import { executeTemplateTypeAction } from "./templateTypeAction";
 import type { PopupMenuEntry, PopupMenuEntryAction } from "./types";
 import type { ElementTemplate } from "@miragon/bpmn-modeler-element-template-chooser";
 
@@ -122,16 +123,16 @@ class AppendMenuOverride {
                 container.remove();
             };
 
-            const handleSelect = (action: PopupMenuEntryAction | undefined, event: Event) => {
+            // Close the overlay, run the chosen action, then return focus to the
+            // canvas so keyboard-driven modelling chains without the mouse
+            // (A → nav → Enter → A → …); on unmount focus would otherwise fall to
+            // <body>. Deferred a microtask and gated on directEditing so we never
+            // steal the caret from a label-edit session that creating may open.
+            const finishSelection = (run: () => void) => {
                 close();
                 customMenuOpen = false;
                 closeCustomMenu = null;
-                executeEntryAction(action, event);
-                // Return focus to the canvas so keyboard-driven modelling chains
-                // without the mouse (A → nav → Enter → A → …); on unmount focus
-                // would otherwise fall to <body>. Deferred a microtask and
-                // gated on directEditing so we never steal the caret from a
-                // label-edit session that appending may open.
+                run();
                 queueMicrotask(() => {
                     const directEditing = injector.get("directEditing", false);
                     if (directEditing?.isActive?.()) {
@@ -139,6 +140,35 @@ class AppendMenuOverride {
                     }
                     canvas.focus();
                 });
+            };
+
+            const handleSelect = (action: PopupMenuEntryAction | undefined, event: Event) => {
+                finishSelection(() => executeEntryAction(action, event));
+            };
+
+            const handleTemplateTypeSelect = (
+                template: ElementTemplate,
+                bpmnType: string,
+                event: Event,
+            ) => {
+                const create = injector.get("create", false);
+                if (!elementTemplates || !create) {
+                    return;
+                }
+                finishSelection(() =>
+                    executeTemplateTypeAction(
+                        {
+                            elementTemplates,
+                            autoPlace: injector.get("autoPlace", false) || undefined,
+                            create,
+                            mouse: injector.get("mouse", false) || undefined,
+                        },
+                        { providerId: providerId as "bpmn-append" | "bpmn-create", target },
+                        template,
+                        bpmnType,
+                        event,
+                    ),
+                );
             };
 
             const handleCancel = () => {
@@ -161,6 +191,7 @@ class AppendMenuOverride {
                         bottom: canvasBounds.bottom,
                     },
                     onSelect: handleSelect,
+                    onTemplateTypeSelect: handleTemplateTypeSelect,
                     onCancel: handleCancel,
                 }),
                 container,

--- a/libs/append-menu/src/components/AppendMenuOverlay.tsx
+++ b/libs/append-menu/src/components/AppendMenuOverlay.tsx
@@ -240,6 +240,9 @@ export function AppendMenuOverlay({
                 onSelect(enriched.entry.action, event);
             } else {
                 setSelectedTemplate(enriched);
+                // The search that located the template would otherwise keep
+                // hiding every palette entry in the type-pick step.
+                setSearch("");
             }
         },
         [onSelect],

--- a/libs/append-menu/src/components/AppendMenuOverlay.tsx
+++ b/libs/append-menu/src/components/AppendMenuOverlay.tsx
@@ -263,7 +263,7 @@ export function AppendMenuOverlay({
                     onTemplateTypeSelect(selectedTemplate.template, bpmnType, event);
                     return;
                 }
-                // Non-matching entries are disabled, so this shouldn't happen;
+                // Non-matching entries are hidden, so this shouldn't happen;
                 // fall back to the template's baked (first-type) action.
                 onSelect(selectedTemplate.entry.action, event);
                 return;

--- a/libs/append-menu/src/components/AppendMenuOverlay.tsx
+++ b/libs/append-menu/src/components/AppendMenuOverlay.tsx
@@ -12,12 +12,19 @@
  * ↑/↓ move a highlight in the active column, ←/→ switch columns, Enter selects.
  */
 import { useState, useEffect, useCallback, useMemo, useRef } from "preact/hooks";
-import type { EnrichedTemplateEntry, BpmnElementGroup, PopupMenuEntryAction } from "../types";
+import type {
+    EnrichedTemplateEntry,
+    BpmnElementGroup,
+    PopupMenuEntry,
+    PopupMenuEntryAction,
+} from "../types";
+import type { ElementTemplate } from "@miragon/bpmn-modeler-element-template-chooser";
 import {
     filterTemplates,
     extractCategories,
     processPaletteGroups,
     flattenPaletteItems,
+    resolveSelectedType,
 } from "../filtering";
 import {
     initialHighlight,
@@ -36,6 +43,7 @@ interface AppendMenuOverlayProps {
     position: { x: number; y: number };
     canvasBounds: { right: number; bottom: number };
     onSelect: (action: PopupMenuEntryAction | undefined, event: Event) => void;
+    onTemplateTypeSelect: (template: ElementTemplate, bpmnType: string, event: Event) => void;
     onCancel: () => void;
 }
 
@@ -84,6 +92,7 @@ export function AppendMenuOverlay({
     position,
     canvasBounds,
     onSelect,
+    onTemplateTypeSelect,
     onCancel,
 }: AppendMenuOverlayProps) {
     const hasTemplates = templateEntries.length > 0;
@@ -236,17 +245,29 @@ export function AppendMenuOverlay({
         [onSelect],
     );
 
-    // With a multi-type template selected, creates the element via the template's
-    // action; otherwise creates a plain BPMN element.
+    // With a multi-type template selected, the clicked palette entry names the
+    // concrete BPMN type to instantiate the template as; otherwise it's a plain
+    // BPMN element creation.
     const handleBpmnSelect = useCallback(
-        (action: PopupMenuEntryAction | undefined, event: Event) => {
-            if (selectedTemplate) {
+        (item: { id: string; entry: PopupMenuEntry }, event: Event) => {
+            if (selectedTemplate?.template) {
+                const bpmnType = resolveSelectedType(
+                    item.id,
+                    item.entry.label,
+                    selectedTemplate.template.appliesTo,
+                );
+                if (bpmnType) {
+                    onTemplateTypeSelect(selectedTemplate.template, bpmnType, event);
+                    return;
+                }
+                // Non-matching entries are disabled, so this shouldn't happen;
+                // fall back to the template's baked (first-type) action.
                 onSelect(selectedTemplate.entry.action, event);
-            } else {
-                onSelect(action, event);
+                return;
             }
+            onSelect(item.entry.action, event);
         },
-        [onSelect, selectedTemplate],
+        [onSelect, onTemplateTypeSelect, selectedTemplate],
     );
 
     /**
@@ -265,7 +286,7 @@ export function AppendMenuOverlay({
             } else {
                 const item = paletteNav[highlight.index];
                 if (item && !item.disabled) {
-                    handleBpmnSelect(item.entry.action, event);
+                    handleBpmnSelect(item, event);
                 }
             }
         },

--- a/libs/append-menu/src/components/BpmnElementPalette.tsx
+++ b/libs/append-menu/src/components/BpmnElementPalette.tsx
@@ -7,7 +7,6 @@
  * buttons and reflects the highlighted key.
  */
 import { useEffect, useRef } from "preact/hooks";
-import type { PopupMenuEntryAction } from "../types";
 import type { ProcessedEntry, ProcessedGroup } from "../filtering";
 
 interface BpmnElementPaletteProps {
@@ -19,7 +18,7 @@ interface BpmnElementPaletteProps {
     onToggleExpand: () => void;
     /** Reports hover-peek state so the parent can transiently expand the palette on hover. */
     onPeekChange?: (peek: boolean) => void;
-    onSelect: (action: PopupMenuEntryAction | undefined, event: Event) => void;
+    onSelect: (entry: ProcessedEntry, event: Event) => void;
 }
 
 /**
@@ -88,7 +87,8 @@ export function BpmnElementPalette({
                     <div class="am-bpmn-group am-bpmn-group--favourites">
                         {expanded && <h4 class="am-bpmn-group-title">Favourites</h4>}
                         <div class={`am-bpmn-grid ${expanded ? "" : "am-bpmn-grid--compact"}`}>
-                            {favouriteEntries.map(({ id, entry, disabled, hidden }) => {
+                            {favouriteEntries.map((processed) => {
+                                const { id, entry, disabled, hidden } = processed;
                                 if (hidden) return null;
                                 const navKey = `fav:${id}`;
                                 const isDisabled = disabled || !!entry.disabled;
@@ -99,9 +99,7 @@ export function BpmnElementPalette({
                                         data-nav-key={navKey}
                                         class={`am-bpmn-button ${isDisabled ? "am-bpmn-button--disabled" : ""} ${isFocused ? "am-bpmn-button--focused" : ""} ${expanded ? "" : "am-bpmn-button--icon-only"}`}
                                         disabled={isDisabled}
-                                        onClick={(e) =>
-                                            onSelect(entry.action, e as unknown as Event)
-                                        }
+                                        onClick={(e) => onSelect(processed, e as unknown as Event)}
                                         title={entry.label}
                                         type="button"
                                     >
@@ -128,7 +126,8 @@ export function BpmnElementPalette({
                         <div key={group.id} class="am-bpmn-group">
                             {expanded && <h4 class="am-bpmn-group-title">{group.name}</h4>}
                             <div class={`am-bpmn-grid ${expanded ? "" : "am-bpmn-grid--compact"}`}>
-                                {visibleEntries.map(({ id, entry, disabled }) => {
+                                {visibleEntries.map((processed) => {
+                                    const { id, entry, disabled } = processed;
                                     const navKey = `grp:${group.id}:${id}`;
                                     const isDisabled = disabled || !!entry.disabled;
                                     const isFocused = navKey === highlightedKey;
@@ -139,7 +138,7 @@ export function BpmnElementPalette({
                                             class={`am-bpmn-button ${isDisabled ? "am-bpmn-button--disabled" : ""} ${isFocused ? "am-bpmn-button--focused" : ""} ${expanded ? "" : "am-bpmn-button--icon-only"}`}
                                             disabled={isDisabled}
                                             onClick={(e) =>
-                                                onSelect(entry.action, e as unknown as Event)
+                                                onSelect(processed, e as unknown as Event)
                                             }
                                             title={entry.label}
                                             type="button"

--- a/libs/append-menu/src/filtering.spec.ts
+++ b/libs/append-menu/src/filtering.spec.ts
@@ -5,6 +5,7 @@ import {
     filterTemplates,
     flattenPaletteItems,
     processPaletteGroups,
+    resolveSelectedType,
 } from "./filtering";
 import type { BpmnElementGroup, EnrichedTemplateEntry, PopupMenuEntry } from "./types";
 
@@ -151,5 +152,37 @@ describe("flattenPaletteItems", () => {
         const item = flattenPaletteItems(processed).find((i) => i.key.startsWith("grp:"))!;
         expect(item.disabled).toBe(true); // fails the appliesTo filter
         expect(item.hidden).toBe(true); // fails the search
+    });
+
+    it("exposes the raw entry id alongside the namespaced key", () => {
+        const processed = processPaletteGroups(groups, ["bpmn:ServiceTask"], "", null);
+        const items = flattenPaletteItems(processed);
+        expect(items.map((i) => i.id)).toEqual(["create.service-task", "create.service-task"]);
+    });
+});
+
+describe("resolveSelectedType", () => {
+    const appliesTo = ["bpmn:ServiceTask", "bpmn:SendTask"];
+
+    it("resolves the type by normalized label", () => {
+        expect(resolveSelectedType("append-send-task", "Send task", appliesTo)).toBe(
+            "bpmn:SendTask",
+        );
+    });
+
+    it("resolves the type by entry id when the label does not match", () => {
+        expect(resolveSelectedType("append-send-task", "Mail", appliesTo)).toBe("bpmn:SendTask");
+    });
+
+    it("prefers the exact label match over an id substring, avoiding type shadowing", () => {
+        // `append-user-task` contains "task", which would match bpmn:Task via
+        // id-substring, but the label pins bpmn:UserTask.
+        expect(
+            resolveSelectedType("append-user-task", "User task", ["bpmn:Task", "bpmn:UserTask"]),
+        ).toBe("bpmn:UserTask");
+    });
+
+    it("returns undefined when no type matches", () => {
+        expect(resolveSelectedType("append-gateway", "Gateway", appliesTo)).toBeUndefined();
     });
 });

--- a/libs/append-menu/src/filtering.spec.ts
+++ b/libs/append-menu/src/filtering.spec.ts
@@ -110,14 +110,13 @@ describe("processPaletteGroups", () => {
         expect(flags.every(([d, h]) => !d && !h)).toBe(true);
     });
 
-    it("disables entries that fail the appliesTo filter but keeps them visible", () => {
+    it("hides entries that fail the appliesTo filter", () => {
         const p = processPaletteGroups(groups, [], "", new Set(["bpmn:ServiceTask"]));
         const service = p.groups[0].entries.find((e) => e.entry.label === "Service Task")!;
         const user = p.groups[0].entries.find((e) => e.entry.label === "User Task")!;
-        expect(service.disabled).toBe(false);
-        expect(user.disabled).toBe(true);
-        // disabled is not hidden — the button still renders greyed out.
-        expect(user.hidden).toBe(false);
+        expect(service.hidden).toBe(false);
+        expect(user.hidden).toBe(true);
+        expect(user.disabled).toBe(false);
     });
 
     it("hides entries that fail the search but leaves them enabled", () => {
@@ -147,11 +146,11 @@ describe("flattenPaletteItems", () => {
         ]);
     });
 
-    it("carries disabled/hidden flags through to the flattened items", () => {
+    it("carries the hidden flag through to the flattened items", () => {
         const processed = processPaletteGroups(groups, [], "gateway", new Set(["bpmn:UserTask"]));
         const item = flattenPaletteItems(processed).find((i) => i.key.startsWith("grp:"))!;
-        expect(item.disabled).toBe(true); // fails the appliesTo filter
-        expect(item.hidden).toBe(true); // fails the search
+        expect(item.hidden).toBe(true); // fails both the appliesTo filter and the search
+        expect(item.disabled).toBe(false);
     });
 
     it("exposes the raw entry id alongside the namespaced key", () => {

--- a/libs/append-menu/src/filtering.ts
+++ b/libs/append-menu/src/filtering.ts
@@ -95,9 +95,9 @@ export function extractCategories(entries: EnrichedTemplateEntry[]): TemplateCat
 
 /** A palette entry annotated with its filter state. */
 export interface ProcessedEntry extends BpmnElementEntry {
-    /** Greyed out (fails the selected multi-type template's `appliesTo`). */
+    /** Greyed out (the entry itself is marked disabled upstream). */
     disabled: boolean;
-    /** Not rendered (fails the current search). */
+    /** Not rendered (fails the current search or the selected template's `appliesTo`). */
     hidden: boolean;
 }
 
@@ -190,7 +190,7 @@ function findFavouriteEntry(entries: ProcessedEntry[], type: string): ProcessedE
  * @param groups BPMN element entries grouped by category.
  * @param favourites Ordered BPMN type strings to pin at the top.
  * @param search The raw search query.
- * @param appliesToFilter Set of BPMN types to keep enabled, or null for all.
+ * @param appliesToFilter Set of BPMN types to keep visible, or null for all.
  * @returns The favourites row plus annotated groups.
  */
 export function processPaletteGroups(
@@ -205,8 +205,10 @@ export function processPaletteGroups(
         ...group,
         entries: group.entries.map((entry) => ({
             ...entry,
-            disabled: appliesToFilter ? !entryMatchesFilter(entry, appliesToFilter) : false,
-            hidden: query ? !entryMatchesSearch(entry, query) : false,
+            disabled: false,
+            hidden:
+                (appliesToFilter ? !entryMatchesFilter(entry, appliesToFilter) : false) ||
+                (query ? !entryMatchesSearch(entry, query) : false),
         })),
     }));
 

--- a/libs/append-menu/src/filtering.ts
+++ b/libs/append-menu/src/filtering.ts
@@ -115,21 +115,54 @@ export interface ProcessedPalette {
 }
 
 /**
+ * Fuzzy-matches a BPMN type against a palette entry's normalized label or id,
+ * the same heuristic the palette uses to map types↔entries in both directions.
+ */
+function typeMatchesEntry(bpmnType: string, id: string, label: string): boolean {
+    const shortName = bpmnType.split(":")[1]?.toLowerCase() ?? "";
+    const normalizedLabel = label.toLowerCase().replace(/[\s-]/g, "");
+    if (normalizedLabel === shortName) {
+        return true;
+    }
+    const normalizedId = id.toLowerCase().replace(/[\s-]/g, "");
+    return normalizedId.includes(shortName);
+}
+
+/**
  * Checks whether a BPMN palette entry matches any type in a filter set.
  */
 function entryMatchesFilter(entry: BpmnElementEntry, filter: Set<string>): boolean {
     for (const bpmnType of filter) {
-        const shortName = bpmnType.split(":")[1]?.toLowerCase() ?? "";
-        const normalizedLabel = entry.entry.label.toLowerCase().replace(/[\s-]/g, "");
-        if (normalizedLabel === shortName) {
-            return true;
-        }
-        const normalizedId = entry.id.toLowerCase().replace(/[\s-]/g, "");
-        if (normalizedId.includes(shortName)) {
+        if (typeMatchesEntry(bpmnType, entry.id, entry.entry.label)) {
             return true;
         }
     }
     return false;
+}
+
+/**
+ * Resolves which `appliesTo` type a clicked palette entry represents.
+ *
+ * The match order matters: exact-normalized-label equality is checked against
+ * *all* candidate types first, then id-substring — otherwise `bpmn:Task` would
+ * shadow `bpmn:UserTask` via `id.includes("task")`.
+ */
+export function resolveSelectedType(
+    id: string,
+    label: string,
+    appliesTo: string[],
+): string | undefined {
+    const normalizedLabel = label.toLowerCase().replace(/[\s-]/g, "");
+    const byLabel = appliesTo.find(
+        (bpmnType) => (bpmnType.split(":")[1]?.toLowerCase() ?? "") === normalizedLabel,
+    );
+    if (byLabel) {
+        return byLabel;
+    }
+    const normalizedId = id.toLowerCase().replace(/[\s-]/g, "");
+    return appliesTo.find((bpmnType) =>
+        normalizedId.includes(bpmnType.split(":")[1]?.toLowerCase() ?? ""),
+    );
 }
 
 /**
@@ -147,13 +180,7 @@ function entryMatchesSearch(entry: BpmnElementEntry, query: string): boolean {
  * fuzzy matching the palette originally used.
  */
 function findFavouriteEntry(entries: ProcessedEntry[], type: string): ProcessedEntry | undefined {
-    const shortName = type.split(":")[1]?.toLowerCase() ?? "";
-    return entries.find((e) => {
-        const normalizedLabel = e.entry.label.toLowerCase().replace(/[\s-]/g, "");
-        if (normalizedLabel === shortName) return true;
-        const normalizedId = e.id.toLowerCase().replace(/[\s-]/g, "");
-        return normalizedId.includes(shortName);
-    });
+    return entries.find((e) => typeMatchesEntry(type, e.id, e.entry.label));
 }
 
 /**
@@ -206,6 +233,8 @@ export function processPaletteGroups(
  */
 export interface PaletteNavItem {
     key: string;
+    /** The raw palette entry id (used to resolve the chosen type), unlike the namespaced `key`. */
+    id: string;
     entry: PopupMenuEntry;
     disabled: boolean;
     hidden: boolean;
@@ -224,6 +253,7 @@ export function flattenPaletteItems(processed: ProcessedPalette): PaletteNavItem
     for (const e of processed.favouriteEntries) {
         items.push({
             key: `fav:${e.id}`,
+            id: e.id,
             entry: e.entry,
             disabled: e.disabled || !!e.entry.disabled,
             hidden: e.hidden,
@@ -233,6 +263,7 @@ export function flattenPaletteItems(processed: ProcessedPalette): PaletteNavItem
         for (const e of group.entries) {
             items.push({
                 key: `grp:${group.id}:${e.id}`,
+                id: e.id,
                 entry: e.entry,
                 disabled: e.disabled || !!e.entry.disabled,
                 hidden: e.hidden,

--- a/libs/append-menu/src/templateTypeAction.spec.ts
+++ b/libs/append-menu/src/templateTypeAction.spec.ts
@@ -1,0 +1,107 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { executeTemplateTypeAction } from "./templateTypeAction";
+import type { ElementTemplate } from "@miragon/bpmn-modeler-element-template-chooser";
+
+const template = {
+    id: "t1",
+    name: "Multi",
+    appliesTo: ["bpmn:ServiceTask", "bpmn:SendTask"],
+    properties: [],
+} as unknown as ElementTemplate;
+
+function services() {
+    const newElement = { id: "created" };
+    return {
+        newElement,
+        elementTemplates: { createElement: vi.fn((_t: ElementTemplate) => newElement) },
+        autoPlace: { append: vi.fn() },
+        create: { start: vi.fn() },
+        mouse: { getLastMoveEvent: vi.fn(() => new Event("mousemove")) },
+    };
+}
+
+// The modeler runs in browsers where KeyboardEvent is global; the node test env
+// has none, so provide a minimal stand-in for the `instanceof` branch.
+class FakeKeyboardEvent {}
+beforeAll(() => {
+    (globalThis as { KeyboardEvent?: unknown }).KeyboardEvent = FakeKeyboardEvent;
+});
+afterAll(() => {
+    delete (globalThis as { KeyboardEvent?: unknown }).KeyboardEvent;
+});
+
+describe("executeTemplateTypeAction", () => {
+    it("clones the template with the chosen elementType before creating", () => {
+        const s = services();
+        executeTemplateTypeAction(
+            s,
+            { providerId: "bpmn-append", target: {} },
+            template,
+            "bpmn:SendTask",
+            new Event("click"),
+        );
+        const passed = s.elementTemplates.createElement.mock.calls[0]![0];
+        expect(passed.elementType).toEqual({ value: "bpmn:SendTask" });
+        expect(passed.id).toBe("t1");
+        // The original template is left untouched.
+        expect(template.elementType).toBeUndefined();
+    });
+
+    it("auto-places on the append path when autoPlace is available", () => {
+        const s = services();
+        const target = { id: "source" };
+        executeTemplateTypeAction(
+            s,
+            { providerId: "bpmn-append", target },
+            template,
+            "bpmn:SendTask",
+            new Event("click"),
+        );
+        expect(s.autoPlace.append).toHaveBeenCalledWith(target, s.newElement);
+        expect(s.create.start).not.toHaveBeenCalled();
+    });
+
+    it("falls back to interactive create for bpmn:BoundaryEvent (not auto-placeable)", () => {
+        const s = services();
+        const target = { id: "source" };
+        const event = new Event("click");
+        executeTemplateTypeAction(
+            s,
+            { providerId: "bpmn-append", target },
+            template,
+            "bpmn:BoundaryEvent",
+            event,
+        );
+        expect(s.autoPlace.append).not.toHaveBeenCalled();
+        expect(s.create.start).toHaveBeenCalledWith(event, s.newElement, { source: target });
+    });
+
+    it("starts create without a source on the bpmn-create path", () => {
+        const s = services();
+        const event = new Event("click");
+        executeTemplateTypeAction(
+            s,
+            { providerId: "bpmn-create", target: {} },
+            template,
+            "bpmn:SendTask",
+            event,
+        );
+        expect(s.create.start).toHaveBeenCalledWith(event, s.newElement, undefined);
+    });
+
+    it("uses the last mouse move event when triggered by keyboard", () => {
+        const s = services();
+        const moveEvent = new Event("mousemove");
+        s.mouse.getLastMoveEvent.mockReturnValue(moveEvent);
+        executeTemplateTypeAction(
+            { ...s, autoPlace: undefined },
+            { providerId: "bpmn-create", target: {} },
+            template,
+            "bpmn:SendTask",
+            new FakeKeyboardEvent() as unknown as Event,
+        );
+        expect(s.mouse.getLastMoveEvent).toHaveBeenCalled();
+        expect(s.create.start).toHaveBeenCalledWith(moveEvent, s.newElement, undefined);
+    });
+});

--- a/libs/append-menu/src/templateTypeAction.spec.ts
+++ b/libs/append-menu/src/templateTypeAction.spec.ts
@@ -32,7 +32,7 @@ afterAll(() => {
 });
 
 describe("executeTemplateTypeAction", () => {
-    it("clones the template with the chosen elementType before creating", () => {
+    it("clones the template with appliesTo narrowed to the chosen type", () => {
         const s = services();
         executeTemplateTypeAction(
             s,
@@ -42,10 +42,13 @@ describe("executeTemplateTypeAction", () => {
             new Event("click"),
         );
         const passed = s.elementTemplates.createElement.mock.calls[0]![0];
-        expect(passed.elementType).toEqual({ value: "bpmn:SendTask" });
+        expect(passed.appliesTo).toEqual(["bpmn:SendTask"]);
+        // elementType must not be set — C7's changeTemplate handler would
+        // bpmnReplace the still-detached shape and crash.
+        expect(passed.elementType).toBeUndefined();
         expect(passed.id).toBe("t1");
         // The original template is left untouched.
-        expect(template.elementType).toBeUndefined();
+        expect(template.appliesTo).toEqual(["bpmn:ServiceTask", "bpmn:SendTask"]);
     });
 
     it("auto-places on the append path when autoPlace is available", () => {

--- a/libs/append-menu/src/templateTypeAction.ts
+++ b/libs/append-menu/src/templateTypeAction.ts
@@ -1,0 +1,58 @@
+/**
+ * Places an element-template element as a specific BPMN type chosen from the
+ * template's `appliesTo` list.
+ *
+ * The upstream template action bakes in `elementType.value || appliesTo[0]`, so
+ * a multi-type template always yields the first type. Cloning the template with
+ * an explicit `elementType` makes `elementTemplates.createElement` produce the
+ * chosen type with the template bound, in a single create command (one undo
+ * step), then places it exactly as the upstream append/create providers do.
+ */
+import type { ElementTemplate } from "@miragon/bpmn-modeler-element-template-chooser";
+
+export interface TemplateTypeActionServices {
+    elementTemplates: { createElement(template: ElementTemplate): unknown };
+    autoPlace?: { append(source: unknown, element: unknown): void };
+    create: { start(event: Event, element: unknown, context?: { source?: unknown }): void };
+    mouse?: { getLastMoveEvent(): Event };
+}
+
+export interface TemplateTypeActionContext {
+    providerId: "bpmn-append" | "bpmn-create";
+    target: unknown;
+}
+
+// `bpmn:BoundaryEvent` cannot be auto-placed (it must attach to a host), so it
+// always falls through to interactive `create.start`, matching upstream's
+// `canAutoPlaceElement`.
+const NON_AUTO_PLACEABLE = new Set(["bpmn:BoundaryEvent"]);
+
+export function executeTemplateTypeAction(
+    services: TemplateTypeActionServices,
+    context: TemplateTypeActionContext,
+    template: ElementTemplate,
+    bpmnType: string,
+    event: Event,
+): void {
+    const { elementTemplates, autoPlace, create, mouse } = services;
+    const { providerId, target } = context;
+
+    const typed: ElementTemplate = { ...template, elementType: { value: bpmnType } };
+    const newElement = elementTemplates.createElement(typed);
+
+    if (providerId === "bpmn-append" && autoPlace && !NON_AUTO_PLACEABLE.has(bpmnType)) {
+        autoPlace.append(target, newElement);
+        return;
+    }
+
+    // `KeyboardEvent` guarded with `typeof` because the modeler runs in browsers
+    // where it is global, but not in the node test environment.
+    const isKeyboard = typeof KeyboardEvent !== "undefined" && event instanceof KeyboardEvent;
+    const startEvent = isKeyboard ? (mouse?.getLastMoveEvent() ?? event) : event;
+
+    create.start(
+        startEvent,
+        newElement,
+        providerId === "bpmn-append" ? { source: target } : undefined,
+    );
+}

--- a/libs/append-menu/src/templateTypeAction.ts
+++ b/libs/append-menu/src/templateTypeAction.ts
@@ -4,9 +4,14 @@
  *
  * The upstream template action bakes in `elementType.value || appliesTo[0]`, so
  * a multi-type template always yields the first type. Cloning the template with
- * an explicit `elementType` makes `elementTemplates.createElement` produce the
- * chosen type with the template bound, in a single create command (one undo
- * step), then places it exactly as the upstream append/create providers do.
+ * `appliesTo` narrowed to the chosen type makes `elementTemplates.createElement`
+ * produce that type with the template bound, then places it exactly as the
+ * upstream append/create providers do.
+ *
+ * The clone deliberately narrows `appliesTo` instead of setting `elementType`:
+ * C7's `changeTemplate` handler compares `element.$type` (undefined on a shape)
+ * against `elementType.value` and would `bpmnReplace` the still-detached shape,
+ * crashing in the ordering provider.
  */
 import type { ElementTemplate } from "@miragon/bpmn-modeler-element-template-chooser";
 
@@ -37,7 +42,8 @@ export function executeTemplateTypeAction(
     const { elementTemplates, autoPlace, create, mouse } = services;
     const { providerId, target } = context;
 
-    const typed: ElementTemplate = { ...template, elementType: { value: bpmnType } };
+    const { elementType: _dropped, ...rest } = template;
+    const typed: ElementTemplate = { ...rest, appliesTo: [bpmnType] };
     const newElement = elementTemplates.createElement(typed);
 
     if (providerId === "bpmn-append" && autoPlace && !NON_AUTO_PLACEABLE.has(bpmnType)) {

--- a/libs/element-template-chooser/src/types.ts
+++ b/libs/element-template-chooser/src/types.ts
@@ -33,6 +33,7 @@ export interface ElementTemplate {
     description?: string;
     documentationRef?: string;
     appliesTo: string[];
+    elementType?: { value: string; eventDefinition?: string };
     category?: {
         id: string;
         name: string;

--- a/package.json
+++ b/package.json
@@ -92,5 +92,5 @@
         "webpack-cli": "7.2.2",
         "bpmn-js-properties-panel": "patch:bpmn-js-properties-panel@npm%3A5.65.0#~/.yarn/patches/bpmn-js-properties-panel-npm-5.65.0-7e66ff7b5f.patch"
     },
-    "packageManager": "yarn@4.17.0"
+    "packageManager": "yarn@4.18.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20094,20 +20094,20 @@ __metadata:
 
 "resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>":
   version: 1.22.11
-  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=9bd1a5"
   dependencies:
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/ee5b182f2e37cb1165465e58c6abc797fec0a80b5ba3231607beb4677db0c9291ac010c47cf092b6daa2b7f518d69a0e21888e7e2b633f68d501a874212a8c63
+  checksum: 10c0/55f7a298977b1aacf6dbec6dcfc81100ba98675bced193b57d3ac58ced65acc40c3a38927853cea86b7f75edb3c20e1f099a09d48b0d8ceccc25d466993eec47
   languageName: node
   linkType: hard
 
 "resolve@patch:resolve@npm%3A^1.12.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.11#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.2#optional!builtin<compat/resolve>":
   version: 1.22.12
-  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5"
   dependencies:
     es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
@@ -20115,7 +20115,7 @@ __metadata:
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/fc6519984ae1f894d877c0060ba8b1f5ba3bc0e85a02f74e141929c118c23d74d9735619a9cc2965397387e514884245c65d72a40731dcb6cfc84c7bcdc8321e
+  checksum: 10c0/e12af106e16e652bd83060e8afacece4ee3dcbd0f4cf028e3d9ad178e6ced9ecb1c87ee60158b239582313902a717f8adc57a9b76ea54b1994141ba15f420c65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issue

Closes #1491

## Description

In the append/create menu, picking a concrete BPMN type for a multi-type element template (e.g. `appliesTo: ["bpmn:ServiceTask", "bpmn:SendTask"]`) was ignored: the template entry's baked action always created `elementType.value || appliesTo[0]`. The overlay now resolves the clicked (or keyboard-selected) palette entry back to its `appliesTo` type, and `AppendMenuOverride` creates the element from a template clone with an explicit `elementType` via `elementTemplates.createElement`, placing it like the upstream append/create providers (auto-place or interactive create, single undo step). Both engines expose `createElement`, so the fix covers C7 and C8; single-type templates and plain BPMN entries keep their existing path. New unit tests cover the type resolution (including the `bpmn:Task` vs `bpmn:UserTask` substring-shadowing case) and the placement action.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [ ] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
