### PR TITLE
fix(vscode-plugin): edit and save documents on any writable file system, not only file:

### DIFF
--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeEditorHandle.spec.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeEditorHandle.spec.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const applyEditMock = vi.fn();
 
+// `workspace.fs.isWritableFileSystem` decides whether a non-`file:` document may
+// be edited: `true` for a writable provider, `false` for a read-only one,
+// `undefined` when VS Code knows no provider for the scheme.
+const isWritableFileSystemMock = vi.fn<(scheme: string) => boolean | undefined>();
+
 // `WorkspaceEdit.replace` is the only method the subject calls; capturing the
 // args lets us assert the edit targets the full document range.
 const replaceMock = vi.fn();
@@ -9,6 +14,7 @@ const replaceMock = vi.fn();
 vi.mock("vscode", () => ({
     workspace: {
         applyEdit: (...args: unknown[]) => applyEditMock(...args),
+        fs: { isWritableFileSystem: (scheme: string) => isWritableFileSystemMock(scheme) },
         onDidChangeTextDocument: vi.fn(),
         onDidChangeConfiguration: vi.fn(),
     },
@@ -91,20 +97,55 @@ beforeEach(() => {
     vi.clearAllMocks();
 });
 
+function makeSchemeDocument(scheme: string, overrides: Partial<FakeDocument> = {}): FakeDocument {
+    return makeDocument({
+        uri: { scheme, path: "/a.bpmn", fsPath: "/a.bpmn", toString: () => `${scheme}:/a.bpmn` },
+        ...overrides,
+    });
+}
+
 describe("VsCodeEditorHandle.writeContent", () => {
-    it("throws for a non-file scheme without issuing an edit", async () => {
-        const document = makeDocument({
-            uri: {
-                scheme: "git",
-                path: "/a.bpmn",
-                fsPath: "/a.bpmn",
-                toString: () => "git:/a.bpmn",
-            },
-        });
-        const handle = createHandle(makePanel(), document);
+    it("throws for a read-only file system (git:) without issuing an edit", async () => {
+        isWritableFileSystemMock.mockReturnValue(false);
+        const handle = createHandle(makePanel(), makeSchemeDocument("git"));
 
         await expect(handle.writeContent("<new/>")).rejects.toThrow(/git/);
+        expect(isWritableFileSystemMock).toHaveBeenCalledWith("git");
         expect(applyEditMock).not.toHaveBeenCalled();
+    });
+
+    it("throws for a scheme VS Code knows no file system for (untitled:)", async () => {
+        isWritableFileSystemMock.mockReturnValue(undefined);
+        const handle = createHandle(makePanel(), makeSchemeDocument("untitled"));
+
+        await expect(handle.writeContent("<new/>")).rejects.toThrow(/untitled/);
+        expect(applyEditMock).not.toHaveBeenCalled();
+    });
+
+    it("applies an edit to a document on a writable custom file system (a collaborative provider)", async () => {
+        isWritableFileSystemMock.mockReturnValue(true);
+        applyEditMock.mockResolvedValue(true);
+        const document = makeSchemeDocument("bpm-live", { getText: () => "<old/>", lineCount: 3 });
+        const handle = createHandle(makePanel(), document);
+
+        const result = await handle.writeContent("<new/>");
+
+        expect(result).toBe(true);
+        expect(isWritableFileSystemMock).toHaveBeenCalledWith("bpm-live");
+        expect(replaceMock).toHaveBeenCalledWith(
+            document.uri,
+            expect.objectContaining({ startLine: 0, startChar: 0, endLine: 3, endChar: 0 }),
+            "<new/>",
+        );
+    });
+
+    it("never consults the file-system registry for a file: document", async () => {
+        applyEditMock.mockResolvedValue(true);
+        const handle = createHandle(makePanel(), makeDocument());
+
+        await handle.writeContent("<new/>");
+
+        expect(isWritableFileSystemMock).not.toHaveBeenCalled();
     });
 
     it("returns false without an edit when content is unchanged", async () => {
@@ -135,19 +176,22 @@ describe("VsCodeEditorHandle.writeContent", () => {
 });
 
 describe("VsCodeEditorHandle.save", () => {
-    it("throws for a non-file scheme", async () => {
-        const document = makeDocument({
-            uri: {
-                scheme: "untitled",
-                path: "/a.bpmn",
-                fsPath: "/a.bpmn",
-                toString: () => "untitled:/a.bpmn",
-            },
-        });
+    it("throws for a scheme without a writable file system (untitled:)", async () => {
+        isWritableFileSystemMock.mockReturnValue(undefined);
+        const document = makeSchemeDocument("untitled");
         const handle = createHandle(makePanel(), document);
 
         await expect(handle.save()).rejects.toThrow(/untitled/);
         expect(document.save).not.toHaveBeenCalled();
+    });
+
+    it("delegates to document.save on a writable custom file system", async () => {
+        isWritableFileSystemMock.mockReturnValue(true);
+        const document = makeSchemeDocument("bpm-live");
+        const handle = createHandle(makePanel(), document);
+
+        expect(await handle.save()).toBe(true);
+        expect(document.save).toHaveBeenCalledTimes(1);
     });
 
     it("delegates to document.save for a file scheme", async () => {

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeEditorHandle.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeEditorHandle.ts
@@ -84,15 +84,15 @@ export class VsCodeEditorHandle implements EditorHandle {
     }
 
     /**
-     * Refuses non-`file:` schemes (e.g. `git:`) — those documents are owned by a
-     * FileSystemProvider and any `applyEdit` against them either silently no-ops
-     * or bubbles a confusing provider error. Reaching here with a non-file
+     * Refuses documents on a read-only file system (e.g. `git:`, the compare
+     * viewer's provider) — an `applyEdit` against those either silently no-ops
+     * or bubbles a confusing provider error. Reaching here with a read-only
      * document signals a missing viewer-mode branch upstream; fail loudly.
      *
      * @returns `true` if the edit was applied, `false` if content was unchanged.
      */
     async writeContent(content: string, _expectedDocumentRevision?: number): Promise<boolean> {
-        this.assertFileScheme("write to", "editable");
+        this.assertWritableFileSystem("write to", "editable");
 
         if (this.document.getText() === content) {
             return false;
@@ -104,7 +104,7 @@ export class VsCodeEditorHandle implements EditorHandle {
     }
 
     async save(): Promise<boolean> {
-        this.assertFileScheme("save", "persistable");
+        this.assertWritableFileSystem("save", "persistable");
         return this.document.save();
     }
 
@@ -188,11 +188,19 @@ export class VsCodeEditorHandle implements EditorHandle {
         return workspace.onDidChangeConfiguration((event) => callback(event));
     }
 
-    private assertFileScheme(verb: string, adjective: string): void {
-        if (this.document.uri.scheme !== "file") {
+    /**
+     * The gate is the file system's writability, not the `file:` scheme: a
+     * document served by a custom, writable FileSystemProvider (a collaborative
+     * `bpm-live:` model, `memfs:`, …) is as editable as one on disk, and VS Code
+     * answers for every registered provider. `undefined` means no provider is
+     * known for the scheme (e.g. `untitled:`) — refused, as before.
+     */
+    private assertWritableFileSystem(verb: string, adjective: string): void {
+        const scheme = this.document.uri.scheme;
+        if (scheme !== "file" && workspace.fs.isWritableFileSystem(scheme) !== true) {
             throw new Error(
-                `Refusing to ${verb} a ${this.document.uri.scheme}: document ` +
-                    `(${this.document.uri.toString()}). Only file:-scheme documents are ${adjective}.`,
+                `Refusing to ${verb} a ${scheme}: document (${this.document.uri.toString()}). ` +
+                    `Only documents on a writable file system are ${adjective}.`,
             );
         }
     }


### PR DESCRIPTION
## Issue

Closes #1516

## Description

`VsCodeEditorHandle` refused every `writeContent`/`save` on a document whose URI scheme was not `file:`. The guard was written for `git:` (the compare viewer's read-only provider), but it also refuses documents served by a custom, **writable** `FileSystemProvider` — e.g. the bpmiq Live Host's collaborative `bpm-live://` models. The modeler rendered those and followed external changes, while every edit made on the canvas was dropped before it reached the `TextDocument`: co-editing worked in one direction only. Same for the DMN editor.

The gate is now the file system's writability, via `workspace.fs.isWritableFileSystem(scheme)`:

| answer | meaning | result |
| --- | --- | --- |
| `true` | a writable provider (`bpm-live:`, `memfs:`, …) | edit / save allowed |
| `false` | read-only provider (`git:`) | refused, as before |
| `undefined` | no provider known (`untitled:`) | refused, as before |

`file:` documents never consult the registry (unchanged fast path). The error message now says "writable file system" instead of "file:-scheme".

Spec: the read-only (`git:`) and unknown (`untitled:`) cases keep their tests; new cases cover a writable custom provider for both `writeContent` and `save`, and that a `file:` document never asks the registry. No behavior change for files on disk.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A) — N/A, no user-facing docs describe the rule
- [x] ADR added under `docs/adr/` (or N/A) — N/A, no boundary/API change
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`) — 44/44
- [x] Verified in the affected hosts — VS Code: the bpmiq extension's live documents (`Miragon/bpm-iq#170`–`#173`) are the reproduction; IntelliJ / standalone N/A (VS Code adapter only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBttRGA9aXyswjK8UEiZik
