### PR TITLE
fix(properties-panel): reconcile selection made before panel subscribes

### DIFF
--- a/.yarn/patches/bpmn-js-properties-panel-npm-5.65.0-7e66ff7b5f.patch
+++ b/.yarn/patches/bpmn-js-properties-panel-npm-5.65.0-7e66ff7b5f.patch
@@ -1,0 +1,36 @@
+diff --git a/dist/index.esm.js b/dist/index.esm.js
+index 392f9e053f77841b1775bdd2500eafdd20289336..cc63875fc5ff32358a804941e36748bca72b7405 100644
+--- a/dist/index.esm.js
++++ b/dist/index.esm.js
+@@ -1543,6 +1543,13 @@ function BpmnPropertiesPanel(props) {
+       _update(newElement || rootElement);
+     };
+     eventBus.on('selection.changed', onSelectionChanged);
++    const selection = injector.get('selection', false);
++    const currentSelection = selection && selection.get();
++    if (currentSelection && currentSelection.length) {
++      onSelectionChanged({
++        newSelection: currentSelection
++      });
++    }
+     return () => {
+       eventBus.off('selection.changed', onSelectionChanged);
+     };
+diff --git a/dist/index.js b/dist/index.js
+index ce3e014617627530012a0ca5cee1b887dba407db..6a68d455f6db32fb38f5b0a4f0072f5961d63535 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1545,6 +1545,13 @@ function BpmnPropertiesPanel(props) {
+       _update(newElement || rootElement);
+     };
+     eventBus.on('selection.changed', onSelectionChanged);
++    const selection = injector.get('selection', false);
++    const currentSelection = selection && selection.get();
++    if (currentSelection && currentSelection.length) {
++      onSelectionChanged({
++        newSelection: currentSelection
++      });
++    }
+     return () => {
+       eventBus.off('selection.changed', onSelectionChanged);
+     };

--- a/libs/properties-panel/src/render/PropertiesPanel.tsx
+++ b/libs/properties-panel/src/render/PropertiesPanel.tsx
@@ -7,6 +7,10 @@
  * groups as the deterministic last transform — disabling every entry and
  * stripping ListGroup add/remove affordances — so a `NavigatedViewer` shows the
  * full neutral panel without any write path.
+ *
+ * Delta (#1492): the `selection.changed` effect reconciles against the current
+ * selection when it subscribes, so a selection made before the effect ran (e.g.
+ * `selectElementsByIds` right after the create factory resolved) is not lost.
  */
 import { useState, useMemo, useEffect, useCallback } from "@bpmn-io/properties-panel/preact/hooks";
 
@@ -98,6 +102,16 @@ export default function BpmnPropertiesPanel(props: any) {
         };
 
         eventBus.on("selection.changed", onSelectionChanged);
+
+        // Reconcile against a selection.changed that fired before this effect
+        // subscribed (e.g. selectElementsByIds right after the create factory
+        // resolved) — otherwise the panel keeps editing the root (#1492).
+        const selection = injector.get("selection", false);
+        const currentSelection = selection && selection.get();
+
+        if (currentSelection && currentSelection.length) {
+            onSelectionChanged({ newSelection: currentSelection });
+        }
 
         return () => {
             eventBus.off("selection.changed", onSelectionChanged);

--- a/libs/properties-panel/src/render/propertiesPanelSelectionReconcile.spec.tsx
+++ b/libs/properties-panel/src/render/propertiesPanelSelectionReconcile.spec.tsx
@@ -1,0 +1,168 @@
+/** @jsxImportSource @bpmn-io/properties-panel/preact */
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { act } from "@bpmn-io/properties-panel/preact/test-utils";
+import EventBus from "diagram-js/lib/core/EventBus";
+
+import PropertiesPanelRenderer from "./PropertiesPanelRenderer";
+import NeutralPropertiesProvider from "../provider/NeutralPropertiesProvider";
+
+/**
+ * Regression proof for #1492: a selection made before the panel's
+ * `selection.changed` effect subscribes (e.g. `selectElementsByIds` right after
+ * the create factory resolves) must still reach the panel. bpmn-js cannot lay
+ * out an SVG canvas in jsdom (see createViewer.spec.ts), so this drives the real
+ * {@link PropertiesPanelRenderer} + {@link NeutralPropertiesProvider} with a real
+ * diagram-js `EventBus`, a stubbed injector, and a mutable `selection` stub.
+ */
+
+function processElement(): any {
+    const store: any = { isExecutable: true, documentation: [] };
+    const bo: any = {
+        ...store,
+        $model: { ids: { assigned: () => null } },
+        $instanceOf: (t: string) => ["bpmn:Process", "bpmn:FlowElementsContainer"].includes(t),
+        get: (k: string) => store[k],
+    };
+    return { id: "Process_1", type: "bpmn:Process", businessObject: bo };
+}
+
+function taskElement(id: string): any {
+    const store: any = { name: "", documentation: [] };
+    const bo: any = {
+        ...store,
+        $model: { ids: { assigned: () => null } },
+        $instanceOf: (t: string) =>
+            ["bpmn:Task", "bpmn:Activity", "bpmn:FlowNode", "bpmn:FlowElement"].includes(t),
+        get: (k: string) => store[k],
+    };
+    return { id, type: "bpmn:Task", businessObject: bo };
+}
+
+function setup({
+    selection,
+    withSelectionService = true,
+}: {
+    selection?: any;
+    withSelectionService?: boolean;
+}) {
+    const eventBus = new EventBus();
+    const root = processElement();
+
+    const elements: Record<string, any> = { [root.id]: root };
+    let currentSelection = selection;
+
+    const services: Record<string, any> = {
+        canvas: { getRootElement: () => root },
+        elementRegistry: { get: (id: string) => elements[id] },
+        eventBus,
+        translate: (text: string) => text,
+        debounceInput: (fn: any) => fn,
+        modeling: { updateProperties: vi.fn() },
+        commandStack: undefined,
+    };
+
+    if (withSelectionService) {
+        services.selection = { get: () => currentSelection };
+    }
+
+    const injector = { get: (name: string, _strict?: boolean) => services[name] };
+    const renderer: any = new PropertiesPanelRenderer({}, injector, eventBus);
+    new NeutralPropertiesProvider(renderer, injector);
+
+    const registerTask = (task: any) => {
+        elements[task.id] = task;
+        return task;
+    };
+
+    const updates: any[] = [];
+    eventBus.on("propertiesPanel.updated", (e: any) => updates.push(e.element));
+
+    return {
+        eventBus,
+        renderer,
+        root,
+        registerTask,
+        updates,
+        container: () => renderer._container as HTMLElement,
+        setSelection: (s: any) => {
+            currentSelection = s;
+        },
+    };
+}
+
+// act() flushes the sticky-header layout effect synchronously, which reads
+// IntersectionObserver — absent in jsdom.
+beforeAll(() => {
+    class IntersectionObserverStub {
+        observe = vi.fn();
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+    }
+    (globalThis as any).IntersectionObserver = IntersectionObserverStub;
+});
+
+describe("PropertiesPanel selection reconcile (#1492)", () => {
+    it("targets a single element selected before the effect subscribes", async () => {
+        const ctx = setup({ selection: undefined });
+        const task = ctx.registerTask(taskElement("Task_1"));
+        ctx.setSelection([task]);
+
+        await act(() => {
+            ctx.renderer._render(ctx.root);
+        });
+
+        expect(ctx.updates[ctx.updates.length - 1]).toBe(task);
+    });
+
+    it("targets a multi-selection made before the effect subscribes", async () => {
+        const ctx = setup({ selection: undefined });
+        const taskA = ctx.registerTask(taskElement("Task_A"));
+        const taskB = ctx.registerTask(taskElement("Task_B"));
+        ctx.setSelection([taskA, taskB]);
+
+        await act(() => {
+            ctx.renderer._render(ctx.root);
+        });
+
+        const last = ctx.updates[ctx.updates.length - 1];
+        expect(Array.isArray(last)).toBe(true);
+        expect(last).toHaveLength(2);
+    });
+
+    it("stays on the root and fires no update for an empty selection", async () => {
+        const ctx = setup({ selection: [] });
+
+        await act(() => {
+            ctx.renderer._render(ctx.root);
+        });
+
+        expect(ctx.updates).toHaveLength(0);
+        expect(ctx.container().querySelector(".bio-properties-panel")).not.toBeNull();
+    });
+
+    it("renders the root without crashing when no selection service exists", async () => {
+        const ctx = setup({ withSelectionService: false });
+
+        await act(() => {
+            ctx.renderer._render(ctx.root);
+        });
+
+        expect(ctx.updates).toHaveLength(0);
+        expect(ctx.container().querySelector(".bio-properties-panel")).not.toBeNull();
+    });
+
+    it("still reacts to selection.changed fired after mount", async () => {
+        const ctx = setup({ selection: [] });
+        const task = ctx.registerTask(taskElement("Task_1"));
+
+        await act(() => {
+            ctx.renderer._render(ctx.root);
+        });
+
+        await act(() => {
+            ctx.eventBus.fire("selection.changed", { newSelection: [task] });
+        });
+
+        expect(ctx.updates[ctx.updates.length - 1]).toBe(task);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "resolutions": {
         "preact": "10.29.8",
         "webpack": "5.108.1",
-        "webpack-cli": "7.2.2"
+        "webpack-cli": "7.2.2",
+        "bpmn-js-properties-panel": "patch:bpmn-js-properties-panel@npm%3A5.65.0#~/.yarn/patches/bpmn-js-properties-panel-npm-5.65.0-7e66ff7b5f.patch"
     },
     "packageManager": "yarn@4.17.0"
 }

--- a/packages/bpmn-modeler/package.json
+++ b/packages/bpmn-modeler/package.json
@@ -96,7 +96,7 @@
         "bpmn-js-create-append-anything": "2.0.0",
         "bpmn-js-differ": "3.2.0",
         "bpmn-js-native-copy-paste": "0.3.0",
-        "bpmn-js-properties-panel": "patch:bpmn-js-properties-panel@npm%3A5.65.0#~/.yarn/patches/bpmn-js-properties-panel-npm-5.65.0-7e66ff7b5f.patch",
+        "bpmn-js-properties-panel": "5.65.0",
         "bpmn-js-token-simulation": "0.40.0",
         "bpmn-moddle": "10.2.0",
         "bpmnlint": "11.13.0",

--- a/packages/bpmn-modeler/package.json
+++ b/packages/bpmn-modeler/package.json
@@ -96,7 +96,7 @@
         "bpmn-js-create-append-anything": "2.0.0",
         "bpmn-js-differ": "3.2.0",
         "bpmn-js-native-copy-paste": "0.3.0",
-        "bpmn-js-properties-panel": "5.65.0",
+        "bpmn-js-properties-panel": "patch:bpmn-js-properties-panel@npm%3A5.65.0#~/.yarn/patches/bpmn-js-properties-panel-npm-5.65.0-7e66ff7b5f.patch",
         "bpmn-js-token-simulation": "0.40.0",
         "bpmn-moddle": "10.2.0",
         "bpmnlint": "11.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4194,7 +4194,7 @@ __metadata:
     bpmn-js-create-append-anything: "npm:2.0.0"
     bpmn-js-differ: "npm:3.2.0"
     bpmn-js-native-copy-paste: "npm:0.3.0"
-    bpmn-js-properties-panel: "patch:bpmn-js-properties-panel@npm%3A5.65.0#~/.yarn/patches/bpmn-js-properties-panel-npm-5.65.0-7e66ff7b5f.patch"
+    bpmn-js-properties-panel: "npm:5.65.0"
     bpmn-js-token-simulation: "npm:0.40.0"
     bpmn-moddle: "npm:10.2.0"
     bpmnlint: "npm:11.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4194,7 +4194,7 @@ __metadata:
     bpmn-js-create-append-anything: "npm:2.0.0"
     bpmn-js-differ: "npm:3.2.0"
     bpmn-js-native-copy-paste: "npm:0.3.0"
-    bpmn-js-properties-panel: "npm:5.65.0"
+    bpmn-js-properties-panel: "patch:bpmn-js-properties-panel@npm%3A5.65.0#~/.yarn/patches/bpmn-js-properties-panel-npm-5.65.0-7e66ff7b5f.patch"
     bpmn-js-token-simulation: "npm:0.40.0"
     bpmn-moddle: "npm:10.2.0"
     bpmnlint: "npm:11.13.0"
@@ -9808,6 +9808,24 @@ __metadata:
     camunda-bpmn-js-behaviors: ">= 0.4"
     diagram-js: ">= 11.9"
   checksum: 10c0/17348ee364908a2dc947b556e7e6f3ccf4ff4eb343351454f391679a1e74a359f471e1ca36a4e230c31d81f2a6ff445c61acaf22a77ffb624d09452e632ebc80
+  languageName: node
+  linkType: hard
+
+"bpmn-js-properties-panel@patch:bpmn-js-properties-panel@npm%3A5.65.0#~/.yarn/patches/bpmn-js-properties-panel-npm-5.65.0-7e66ff7b5f.patch":
+  version: 5.65.0
+  resolution: "bpmn-js-properties-panel@patch:bpmn-js-properties-panel@npm%3A5.65.0#~/.yarn/patches/bpmn-js-properties-panel-npm-5.65.0-7e66ff7b5f.patch::version=5.65.0&hash=625c47"
+  dependencies:
+    "@bpmn-io/extract-process-variables": "npm:^2.2.1"
+    array-move: "npm:^4.0.0"
+    ids: "npm:^3.0.2"
+    min-dash: "npm:^5.0.0"
+    min-dom: "npm:^5.3.0"
+  peerDependencies:
+    "@bpmn-io/properties-panel": ">= 3.42.0"
+    bpmn-js: ">= 11.5"
+    camunda-bpmn-js-behaviors: ">= 0.4"
+    diagram-js: ">= 11.9"
+  checksum: 10c0/b4541fb53ef21fff9a9d3f3f73187f328bcfbee7b0a87f972874da6440be145124d425fc2d78588e198fd09dbafd43a1b8c787c219928b8b939b74207ea3b2a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issue

Closes #1492

## Description

The panel's `selection.changed` effect subscribes after Preact's first paint, so a selection made right after `createModeler`/`createViewer` resolved (e.g. `selectElementsByIds` or `applyViewState` on a fresh surface) was lost and the panel kept editing the process root. The fork now reconciles against the current selection when the effect subscribes, routed through the existing handler so multi-selection, label unwrapping, and the implicit-root guard are reused. The Implement surface renders the upstream `bpmn-js-properties-panel` bundled by camunda-bpmn-js, so the same one-hunk fix ships as a yarn patch of 5.65.0 (both dist entries), resolved for all descriptors via root resolutions. External npm consumers of `@miragon/bpmn-modeler` still resolve the unpatched upstream — the fix should be contributed upstream and the patch dropped once it releases. A new jsdom spec drives the real renderer with a mutable selection stub, covering pre-mount single/multi selection, the empty-selection no-op, a missing selection service, and post-mount updates.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
