### PR TITLE
fix(bpmn-modeler): destroy partially initialised surfaces when a factory fails

### DIFF
--- a/apps/bpmn-webview/src/bootstrap.spec.ts
+++ b/apps/bpmn-webview/src/bootstrap.spec.ts
@@ -823,6 +823,35 @@ describe("bootstrap mode switching", () => {
         expect(mocks.createModeler).toHaveBeenCalledOnce();
     });
 
+    it("reports rejected element templates as one info box plus per-error log lines", async () => {
+        mocks.createModeler.mockResolvedValue(makeModeler());
+        const host = makeHost(new BpmnFileQuery("<tagged />", "c7", "modeler", 1));
+
+        boot(host);
+        await drainAsyncWork();
+
+        const options = mocks.createModeler.mock.calls[0][1] as {
+            onElementTemplatesErrors: (errors: unknown[]) => void;
+        };
+        host.postMessage.mockClear();
+        options.onElementTemplatesErrors([new Error("bad"), "worse"]);
+
+        const sent = host.postMessage.mock.calls.map(
+            ([m]) => m as { type: string; message?: string },
+        );
+        expect(sent.filter((m) => m.type === "LogWarningCommand").map((m) => m.message)).toEqual([
+            "Element template rejected: bad",
+            "Element template rejected: worse",
+        ]);
+        expect(sent.filter((m) => m.type === "ShowInfoCommand").map((m) => m.message)).toEqual([
+            "2 element templates were rejected and are ignored. See the log for details.",
+        ]);
+
+        host.postMessage.mockClear();
+        options.onElementTemplatesErrors([]);
+        expect(host.postMessage).not.toHaveBeenCalled();
+    });
+
     it("recreates from Implement to View, carrying the diagram and view state over", async () => {
         const modeler = makeModeler();
         const viewer = makeViewer();

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -35,6 +35,7 @@ import {
     PropertiesPanelStateQuery,
     Query,
     ReleaseDocumentFlushQuery,
+    ShowInfoCommand,
     SetClipboardCommand,
     SetLintingEnabledCommand,
     SetPropertiesPanelStateCommand,
@@ -755,10 +756,21 @@ function startSession(
                     onWarning: (warning: string) =>
                         host.postMessage(new LogWarningCommand(warning)),
                     onElementTemplatesErrors: (errors: unknown[]) => {
-                        for (const error of errors ?? []) {
-                            const message = error instanceof Error ? error.message : String(error);
+                        const messages = (errors ?? []).map((error) =>
+                            error instanceof Error ? error.message : String(error),
+                        );
+                        for (const message of messages) {
                             host.postMessage(
                                 new LogWarningCommand(`Element template rejected: ${message}`),
+                            );
+                        }
+                        if (messages.length > 0) {
+                            host.postMessage(
+                                new ShowInfoCommand(
+                                    messages.length === 1
+                                        ? "An element template was rejected and is ignored. See the log for details."
+                                        : `${messages.length} element templates were rejected and are ignored. See the log for details.`,
+                                ),
                             );
                         }
                     },

--- a/apps/modeler-bridge/src/composition/editorSessionFeature.ts
+++ b/apps/modeler-bridge/src/composition/editorSessionFeature.ts
@@ -1,7 +1,11 @@
 import { basename } from "node:path";
 
 import { Command, Query, SyncDocumentCommand } from "@miragon/bpmn-modeler-shared";
-import { BpmnModelerService, registerWebviewLogHandlers } from "@miragon/bpmn-modeler-core";
+import {
+    BpmnModelerService,
+    registerWebviewLogHandlers,
+    registerWebviewNotificationHandlers,
+} from "@miragon/bpmn-modeler-core";
 
 import { RpcEditorHandle } from "../adapters";
 import { METHODS } from "../protocol/descriptor";
@@ -79,6 +83,7 @@ export function register(
         }
     };
     registerWebviewLogHandlers(deps.router, deps.notifier, resolveSource);
+    registerWebviewNotificationHandlers(deps.router, deps.notifier);
 
     const disposeRegisteredSession = (editorId: string, entry: RegisteredHandle): void => {
         bpmnService.disposeSession(editorId);

--- a/apps/vscode-plugin/src/composition/editorFeature.ts
+++ b/apps/vscode-plugin/src/composition/editorFeature.ts
@@ -5,6 +5,7 @@ import { ExtensionContext } from "vscode";
 import { PropertiesPanelStateRepository } from "../modeler/bpmn/infrastructure/PropertiesPanelStateRepository";
 import { WebviewMessageRouter } from "@miragon/bpmn-modeler-core";
 import { registerWebviewLogHandlers } from "@miragon/bpmn-modeler-core";
+import { registerWebviewNotificationHandlers } from "@miragon/bpmn-modeler-core";
 import { BpmnModelerService } from "@miragon/bpmn-modeler-core";
 import { DocumentFlushService, documentFlushedHandler } from "@miragon/bpmn-modeler-core";
 import { BpmnClipboardMediator } from "@miragon/bpmn-modeler-core";
@@ -291,6 +292,7 @@ export function register(
     // Route the webview's own Log*Commands into the output channel; without this
     // the router drops them as unknown types and webview diagnostics never surface.
     registerWebviewLogHandlers(bpmnMessageRouter, deps.notifier, resolveSource);
+    registerWebviewNotificationHandlers(bpmnMessageRouter, deps.notifier);
     const dmnMessageRouter = new WebviewMessageRouter()
         .on("GetDmnFileCommand", getDmnFileHandler(dmnService, deps.notifier))
         .on("GetDmnModelerSettingCommand", getDmnModelerSettingHandler(dmnSettingsBroadcaster))
@@ -299,6 +301,7 @@ export function register(
         .on("SyncDocumentCommand", syncDmnDocumentHandler(dmnService))
         .on("DocumentFlushedCommand", documentFlushedHandler(flushSvc));
     registerWebviewLogHandlers(dmnMessageRouter, deps.notifier, resolveSource);
+    registerWebviewNotificationHandlers(dmnMessageRouter, deps.notifier);
     const formMessageRouter = new WebviewMessageRouter()
         .on("GetFormFileCommand", getFormFileHandler(formService, deps.notifier))
         .on("GetFormInputValuesCommand", getFormInputValuesHandler(formValues))
@@ -306,6 +309,7 @@ export function register(
         .on("SyncDocumentCommand", syncFormDocumentHandler(formService))
         .on("DocumentFlushedCommand", documentFlushedHandler(flushSvc));
     registerWebviewLogHandlers(formMessageRouter, deps.notifier, resolveSource);
+    registerWebviewNotificationHandlers(formMessageRouter, deps.notifier);
 
     new ModelerEditorController(deps.editorStore, deps.notifier, {
         viewType: BPMN_VIEW_TYPE,

--- a/libs/modeler-core/src/index.ts
+++ b/libs/modeler-core/src/index.ts
@@ -24,6 +24,7 @@ export * from "./shared/service/DocumentFlushService";
 export * from "./shared/infrastructure/EditorSessionStore";
 export * from "./shared/infrastructure/WebviewMessageRouter";
 export * from "./shared/infrastructure/webviewLogHandlers";
+export * from "./shared/infrastructure/webviewNotificationHandlers";
 export * from "./shared/infrastructure/helpers";
 
 // ── modeler ─────────────────────────────────────────────────────────────────

--- a/libs/modeler-core/src/shared/infrastructure/webviewNotificationHandlers.spec.ts
+++ b/libs/modeler-core/src/shared/infrastructure/webviewNotificationHandlers.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { LogInfoCommand, ShowInfoCommand } from "@miragon/bpmn-modeler-shared";
+
+import { NotifierPort } from "../domain/hostPorts";
+import { WebviewMessageRouter } from "./WebviewMessageRouter";
+import { registerWebviewNotificationHandlers } from "./webviewNotificationHandlers";
+
+const EDITOR = "file:///w/a.bpmn";
+
+function setup() {
+    const notifier = { showInfo: vi.fn() };
+    const router = new WebviewMessageRouter();
+    registerWebviewNotificationHandlers(router, notifier as unknown as NotifierPort);
+    return { notifier, router };
+}
+
+describe("registerWebviewNotificationHandlers", () => {
+    it("surfaces a ShowInfoCommand via the notifier", async () => {
+        const { notifier, router } = setup();
+
+        await router.dispatch(new ShowInfoCommand("templates rejected"), EDITOR);
+
+        expect(notifier.showInfo).toHaveBeenCalledWith("templates rejected");
+    });
+
+    it("does not notify for a log command", async () => {
+        const { notifier, router } = setup();
+
+        await router.dispatch(new LogInfoCommand("i"), EDITOR);
+
+        expect(notifier.showInfo).not.toHaveBeenCalled();
+    });
+});

--- a/libs/modeler-core/src/shared/infrastructure/webviewNotificationHandlers.ts
+++ b/libs/modeler-core/src/shared/infrastructure/webviewNotificationHandlers.ts
@@ -1,0 +1,19 @@
+import { Command, ShowInfoCommand } from "@miragon/bpmn-modeler-shared";
+
+import { NotifierPort } from "../domain/hostPorts";
+import { WebviewMessageRouter } from "./WebviewMessageRouter";
+
+/**
+ * Registers the webview's {@link ShowInfoCommand} on `router`, surfacing it as
+ * a user-facing notification via the host's {@link NotifierPort}. Counterpart
+ * to {@link registerWebviewLogHandlers}: log commands stay in the output
+ * channel, this one reaches the user directly.
+ */
+export function registerWebviewNotificationHandlers(
+    router: WebviewMessageRouter,
+    notifier: NotifierPort,
+): void {
+    router.on("ShowInfoCommand", (message: Command) => {
+        notifier.showInfo((message as ShowInfoCommand).message);
+    });
+}

--- a/libs/shared/src/lib/messages.ts
+++ b/libs/shared/src/lib/messages.ts
@@ -13,6 +13,8 @@
  * - {@link LogDebugCommand} / {@link LogInfoCommand} / {@link LogWarningCommand} /
  *   {@link LogErrorCommand} — webview forwards a levelled log entry to the host's
  *   output channel
+ * - {@link ShowInfoCommand} — webview asks the host to surface a user-facing
+ *   information notification
  *
  * @see modeler.ts for the modeler-specific Query and Command implementations that
  * extend these base classes.
@@ -145,4 +147,19 @@ export class LogWarningCommand extends LogMessageCommand {
 
 export class LogErrorCommand extends LogMessageCommand {
     public override readonly type: string = "LogErrorCommand";
+}
+
+/**
+ * A user-facing information notification (VS Code toast / IntelliJ balloon).
+ * Unlike the `Log*Command`s, which only reach the host's log sink, this is for
+ * messages the user must see without opening the output channel — the sandboxed
+ * webview has no notification UI of its own.
+ */
+export class ShowInfoCommand extends Command {
+    public readonly message: string;
+
+    constructor(message: string) {
+        super("ShowInfoCommand");
+        this.message = message;
+    }
 }

--- a/packages/bpmn-modeler/README.md
+++ b/packages/bpmn-modeler/README.md
@@ -417,6 +417,17 @@ a host capability (see [Capabilities](#capabilities--default-overrides)).
 | `additionalModules` / `moddleExtensions`                                                                             | `unknown[]` / `Record<string, object>` | —             | bpmn-js [escape hatches](#escape-hatches).                                       |
 | `onContentSaved` / `onLintResults` / `onLintingToggled` / `onWarning` / `onElementTemplatesErrors` / `onModeChanged` | callbacks                              | —             | Outbound notifications. `onModeChanged(mode)` fires once per actual mode change. |
 
+### Creation failures & `onElementTemplatesErrors`
+
+The factory owns the instance until it resolves: if anything after allocation fails, it destroys
+the partial instance (owned DOM and document listeners removed) before rejecting, so the same
+container and panel roots can be reused for a retry. The same guarantee holds for `createViewer`
+and `createDesigner`.
+
+During creation, `onElementTemplatesErrors` is your control point over a bad `elementTemplates`
+set: return normally to continue (valid templates are applied, invalid ones skipped), or throw to
+abort — the factory rejects with the thrown error and nothing is left mounted.
+
 ### `BpmnModelerHandle`
 
 | Method                                                                                         | Meaning                                                                               |

--- a/packages/bpmn-modeler/src/createModeler.spec.ts
+++ b/packages/bpmn-modeler/src/createModeler.spec.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    extend: vi.fn(),
+    setLanguage: vi.fn(),
+    extras: { overlay: true },
+    instances: [] as Array<Record<string, ReturnType<typeof vi.fn>>>,
+    impls: {} as Record<string, () => void | Promise<void>>,
+}));
+
+vi.mock("@miragon/bpmn-modeler-i18n", () => ({
+    i18n: { extend: mocks.extend, setLanguage: mocks.setLanguage },
+}));
+vi.mock("@miragon/bpmn-modeler-i18n-extras", () => ({ extras: mocks.extras }));
+vi.mock("./modeler", () => ({
+    BpmnModeler: class {
+        init = vi.fn(() => Promise.resolve(mocks.impls.init?.()));
+        setElementTemplates = vi.fn(() => mocks.impls.setElementTemplates?.());
+        setSettings = vi.fn(() => mocks.impls.setSettings?.());
+        setTheme = vi.fn(() => mocks.impls.setTheme?.());
+        destroy = vi.fn(() => mocks.impls.destroy?.());
+        constructor(
+            public readonly container: HTMLElement,
+            public readonly options: unknown,
+        ) {
+            mocks.instances.push(this as unknown as Record<string, ReturnType<typeof vi.fn>>);
+        }
+    },
+}));
+
+import { createModeler } from "./createModeler";
+
+const baseOptions = () => ({
+    propertiesPanel: { parent: document.createElement("aside") },
+    elementTemplates: [{}],
+    settings: {},
+    locale: "de",
+});
+
+function lastInstance() {
+    return mocks.instances[mocks.instances.length - 1];
+}
+
+afterEach(() => {
+    mocks.impls = {};
+    mocks.instances.length = 0;
+    vi.clearAllMocks();
+});
+
+describe("createModeler", () => {
+    it("applies templates, settings, theme and locale and returns the handle", async () => {
+        const container = document.createElement("main");
+
+        const handle = await createModeler(container, baseOptions() as never);
+
+        expect(handle).toBe(lastInstance());
+        expect(lastInstance().setElementTemplates).toHaveBeenCalledOnce();
+        expect(lastInstance().setSettings).toHaveBeenCalledOnce();
+        expect(lastInstance().setTheme).toHaveBeenCalledWith("automatic");
+        expect(mocks.setLanguage).toHaveBeenCalledWith("de");
+        expect(lastInstance().destroy).not.toHaveBeenCalled();
+    });
+
+    const phases = ["init", "setElementTemplates", "setSettings", "setTheme"] as const;
+
+    it.each(phases)("destroys and rejects with the original error when %s fails", async (phase) => {
+        const error = new Error(`${phase} boom`);
+        mocks.impls[phase] = () => {
+            throw error;
+        };
+
+        await expect(
+            createModeler(document.createElement("main"), baseOptions() as never),
+        ).rejects.toBe(error);
+        expect(lastInstance().destroy).toHaveBeenCalledOnce();
+    });
+
+    it("destroys and rejects when setting the locale fails", async () => {
+        const error = new Error("locale boom");
+        mocks.setLanguage.mockImplementationOnce(() => {
+            throw error;
+        });
+
+        await expect(
+            createModeler(document.createElement("main"), baseOptions() as never),
+        ).rejects.toBe(error);
+        expect(lastInstance().destroy).toHaveBeenCalledOnce();
+    });
+
+    it("surfaces the original error even when destroy also throws", async () => {
+        const error = new Error("init boom");
+        mocks.impls.init = () => {
+            throw error;
+        };
+        mocks.impls.destroy = () => {
+            throw new Error("teardown failure");
+        };
+
+        await expect(
+            createModeler(document.createElement("main"), baseOptions() as never),
+        ).rejects.toBe(error);
+        expect(lastInstance().destroy).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/bpmn-modeler/src/createModeler.ts
+++ b/packages/bpmn-modeler/src/createModeler.ts
@@ -2,6 +2,7 @@ import { i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
 import { extras as i18nExtras } from "@miragon/bpmn-modeler-i18n-extras";
 import type { ModelerOptions } from "./publicApi";
 import { BpmnModeler } from "./modeler";
+import { destroyOnFailure } from "./destroyOnFailure";
 
 export interface CreateModelerOptions extends ModelerOptions {
     /**
@@ -22,20 +23,20 @@ export async function createModeler(
     i18n.extend(i18nExtras);
 
     const modeler = new BpmnModeler(container, options);
-    await modeler.init();
+    return destroyOnFailure(modeler, async () => {
+        await modeler.init();
 
-    if (options.elementTemplates) {
-        modeler.setElementTemplates(options.elementTemplates);
-    }
-    if (options.settings) {
-        modeler.setSettings(options.settings);
-    }
-    // Apply the default on the first frame, even when the caller omitted a theme.
-    modeler.setTheme(options.theme ?? "automatic");
-    // Locale is page-global; an omitted option must preserve the host's existing language.
-    if (options.locale) {
-        i18n.setLanguage(options.locale as SupportedLocale);
-    }
-
-    return modeler;
+        if (options.elementTemplates) {
+            modeler.setElementTemplates(options.elementTemplates);
+        }
+        if (options.settings) {
+            modeler.setSettings(options.settings);
+        }
+        // Apply the default on the first frame, even when the caller omitted a theme.
+        modeler.setTheme(options.theme ?? "automatic");
+        // Locale is page-global; an omitted option must preserve the host's existing language.
+        if (options.locale) {
+            i18n.setLanguage(options.locale as SupportedLocale);
+        }
+    });
 }

--- a/packages/bpmn-modeler/src/design/createDesigner.spec.ts
+++ b/packages/bpmn-modeler/src/design/createDesigner.spec.ts
@@ -1,34 +1,126 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 /**
- * Runtime spec for the engine-neutral design surface — currently skipped.
+ * Two specs live here. The mocked matrix below proves the failure contract
+ * (`createDesigner` destroys a partially-initialised surface when a
+ * post-allocation step throws, #1495) without a live bpmn-js instance.
  *
- * Since #1441 the panel is our own inlined fork
- * (`@miragon/bpmn-modeler-properties-panel`, TS source), so the old blocker —
- * upstream `bpmn-js-properties-panel`'s dist tripping Vitest's runner on
- * extensionless deep ESM imports — is gone; the fork's readonly derivation now
- * has a real runtime proof in `libs/properties-panel/src/render/
- * propertiesPanelRenderer.spec.tsx`. Two walls remain here, though. First,
- * `createDesigner` pulls the i18n overlay (`@miragon/bpmn-modeler-i18n-extras`),
- * which the package's Vitest project does not resolve — importing the module
- * poisons collection. Second, even past that, a full bpmn-js Modeler lays out an
- * SVG canvas that jsdom cannot (the same wall `createViewer.spec.ts` documents,
- * ADR 0011), so a rendered-diagram assertion would still throw.
- *
- * The tests dynamic-import inside skipped bodies so they document the intended
- * runtime contract and are ready to un-skip if both walls are ever lifted. The
- * real runtime proof lives in the demo page `apps/demo-webapp/bpmn/design.html`
- * (the epic's acceptance check) and the type-level conformance in
- * `publicApi.spec.ts`.
+ * The runtime `describe.skip` documents the editable-services contract and is
+ * ready to un-skip once the remaining wall lifts. The old i18n-extras blocker is
+ * gone — `vitest.aliases.ts` resolves `@miragon/bpmn-modeler-i18n-extras` for
+ * this project — but a full bpmn-js Modeler still lays out an SVG canvas jsdom
+ * cannot (the wall `createViewer.spec.ts` documents, ADR 0011), so a
+ * rendered-diagram assertion would throw. The real runtime proof lives in the
+ * demo page `apps/demo-webapp/bpmn/design.html` and the type-level conformance
+ * in `publicApi.spec.ts`.
  */
-describe.skip("createDesigner (runtime, jsdom — blocked by the i18n-extras resolution + SVG-layout walls)", () => {
+
+const mocks = vi.hoisted(() => ({
+    extend: vi.fn(),
+    setLanguage: vi.fn(),
+    extras: { overlay: true },
+    instances: [] as Array<Record<string, ReturnType<typeof vi.fn>>>,
+    impls: {} as Record<string, () => void | Promise<void>>,
+}));
+
+vi.mock("@miragon/bpmn-modeler-i18n", () => ({
+    i18n: { extend: mocks.extend, setLanguage: mocks.setLanguage },
+}));
+vi.mock("@miragon/bpmn-modeler-i18n-extras", () => ({ extras: mocks.extras }));
+vi.mock("./designer", () => ({
+    BpmnDesigner: class {
+        init = vi.fn(() => Promise.resolve(mocks.impls.init?.()));
+        setTheme = vi.fn(() => mocks.impls.setTheme?.());
+        destroy = vi.fn(() => mocks.impls.destroy?.());
+        constructor(
+            public readonly container: HTMLElement,
+            public readonly options: unknown,
+        ) {
+            mocks.instances.push(this as unknown as Record<string, ReturnType<typeof vi.fn>>);
+        }
+    },
+}));
+
+import { createDesigner } from "./createDesigner";
+
+const baseOptions = () => ({
+    propertiesPanel: { parent: document.createElement("aside") },
+    locale: "de",
+});
+
+function lastInstance() {
+    return mocks.instances[mocks.instances.length - 1];
+}
+
+afterEach(() => {
+    mocks.impls = {};
+    mocks.instances.length = 0;
+    vi.clearAllMocks();
+});
+
+describe("createDesigner (mocked failure contract, #1495)", () => {
+    it("engages theming and locale and returns the handle on success", async () => {
+        const handle = await createDesigner(document.createElement("main"), baseOptions() as never);
+
+        expect(handle).toBe(lastInstance());
+        expect(lastInstance().setTheme).toHaveBeenCalledWith("automatic");
+        expect(mocks.setLanguage).toHaveBeenCalledWith("de");
+        expect(lastInstance().destroy).not.toHaveBeenCalled();
+    });
+
+    const phases = ["init", "setTheme"] as const;
+
+    it.each(phases)("destroys and rejects with the original error when %s fails", async (phase) => {
+        const error = new Error(`${phase} boom`);
+        mocks.impls[phase] = () => {
+            throw error;
+        };
+
+        await expect(
+            createDesigner(document.createElement("main"), baseOptions() as never),
+        ).rejects.toBe(error);
+        expect(lastInstance().destroy).toHaveBeenCalledOnce();
+    });
+
+    it("destroys and rejects when setting the locale fails", async () => {
+        const error = new Error("locale boom");
+        mocks.setLanguage.mockImplementationOnce(() => {
+            throw error;
+        });
+
+        await expect(
+            createDesigner(document.createElement("main"), baseOptions() as never),
+        ).rejects.toBe(error);
+        expect(lastInstance().destroy).toHaveBeenCalledOnce();
+    });
+
+    it("surfaces the original error even when destroy also throws", async () => {
+        const error = new Error("init boom");
+        mocks.impls.init = () => {
+            throw error;
+        };
+        mocks.impls.destroy = () => {
+            throw new Error("teardown failure");
+        };
+
+        await expect(
+            createDesigner(document.createElement("main"), baseOptions() as never),
+        ).rejects.toBe(error);
+        expect(lastInstance().destroy).toHaveBeenCalledOnce();
+    });
+});
+
+describe.skip("createDesigner (runtime, jsdom — blocked by the SVG-layout wall)", () => {
     it("exposes the editable core services (inverse of the viewer's readonly proof)", async () => {
-        const { createDesigner } = await import("./createDesigner");
+        const { createDesigner: realCreateDesigner } =
+            await vi.importActual<typeof import("./createDesigner")>("./createDesigner");
         const container = document.createElement("div");
         const panel = document.createElement("div");
         document.body.append(container, panel);
 
-        const designer = await createDesigner(container, { propertiesPanel: { parent: panel } });
+        const designer = await realCreateDesigner(container, {
+            propertiesPanel: { parent: panel },
+        });
 
         // Editable: the modelling services a viewer never registers ARE present.
         expect(designer.getService("modeling")).toBeDefined();
@@ -43,12 +135,15 @@ describe.skip("createDesigner (runtime, jsdom — blocked by the i18n-extras res
     });
 
     it("creates a new diagram and exports XML with no execution platform", async () => {
-        const { createDesigner } = await import("./createDesigner");
+        const { createDesigner: realCreateDesigner } =
+            await vi.importActual<typeof import("./createDesigner")>("./createDesigner");
         const container = document.createElement("div");
         const panel = document.createElement("div");
         document.body.append(container, panel);
 
-        const designer = await createDesigner(container, { propertiesPanel: { parent: panel } });
+        const designer = await realCreateDesigner(container, {
+            propertiesPanel: { parent: panel },
+        });
         await designer.newDiagram();
         const xml = await designer.exportDiagram();
         // The mode marker: a fresh Design diagram carries no execution platform.

--- a/packages/bpmn-modeler/src/design/createDesigner.ts
+++ b/packages/bpmn-modeler/src/design/createDesigner.ts
@@ -2,6 +2,7 @@ import { i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
 import { extras as i18nExtras } from "@miragon/bpmn-modeler-i18n-extras";
 import { BpmnDesigner } from "./designer";
 import type { DesignerOptions } from "./publicApi";
+import { destroyOnFailure } from "../destroyOnFailure";
 
 /**
  * Stands up one independent engine-neutral designer bound to `container` and its
@@ -22,17 +23,17 @@ export async function createDesigner(
     i18n.extend(i18nExtras);
 
     const designer = new BpmnDesigner(container, options);
-    await designer.init();
+    return destroyOnFailure(designer, async () => {
+        await designer.init();
 
-    // Always engage theming so the per-instance `data-bpmn-theme` attribute is
-    // set from the first frame; `"automatic"` then follows `prefers-color-scheme`.
-    designer.setTheme(options.theme ?? "automatic");
-    // The i18n instance is a page-global singleton, so a locale set here is
-    // page-wide; only touch it when the caller is explicit, or a default call
-    // would stomp a language the host already set.
-    if (options.locale) {
-        i18n.setLanguage(options.locale as SupportedLocale);
-    }
-
-    return designer;
+        // Always engage theming so the per-instance `data-bpmn-theme` attribute is
+        // set from the first frame; `"automatic"` then follows `prefers-color-scheme`.
+        designer.setTheme(options.theme ?? "automatic");
+        // The i18n instance is a page-global singleton, so a locale set here is
+        // page-wide; only touch it when the caller is explicit, or a default call
+        // would stomp a language the host already set.
+        if (options.locale) {
+            i18n.setLanguage(options.locale as SupportedLocale);
+        }
+    });
 }

--- a/packages/bpmn-modeler/src/design/publicApi.ts
+++ b/packages/bpmn-modeler/src/design/publicApi.ts
@@ -248,6 +248,10 @@ export interface BpmnDesignerHandle {
  * editable designer bound to `container` and resolve its
  * {@link BpmnDesignerHandle}. Async for API-stability symmetry with
  * {@link createModeler}.
+ *
+ * On any initialisation failure after allocation the factory destroys the
+ * partial instance (owned DOM and document listeners removed) before rejecting,
+ * so the same container and panel roots can be reused for a retry.
  */
 export type CreateDesigner = (
     container: HTMLElement,

--- a/packages/bpmn-modeler/src/destroyOnFailure.spec.ts
+++ b/packages/bpmn-modeler/src/destroyOnFailure.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { destroyOnFailure } from "./destroyOnFailure";
+
+describe("destroyOnFailure", () => {
+    it("returns the handle without destroying it on success", async () => {
+        const destroy = vi.fn();
+        const handle = { destroy };
+
+        await expect(destroyOnFailure(handle, () => {})).resolves.toBe(handle);
+        expect(destroy).not.toHaveBeenCalled();
+    });
+
+    it("destroys once and rethrows the original error on a synchronous failure", async () => {
+        const destroy = vi.fn();
+        const error = new Error("boom");
+
+        await expect(
+            destroyOnFailure({ destroy }, () => {
+                throw error;
+            }),
+        ).rejects.toBe(error);
+        expect(destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("destroys once and rethrows the original error on an asynchronous failure", async () => {
+        const destroy = vi.fn();
+        const error = new Error("boom");
+
+        await expect(destroyOnFailure({ destroy }, () => Promise.reject(error))).rejects.toBe(
+            error,
+        );
+        expect(destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("surfaces the original error even when destroy also throws", async () => {
+        const error = new Error("root cause");
+        const destroy = vi.fn(() => {
+            throw new Error("teardown failure");
+        });
+
+        await expect(
+            destroyOnFailure({ destroy }, () => {
+                throw error;
+            }),
+        ).rejects.toBe(error);
+        expect(destroy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/bpmn-modeler/src/destroyOnFailure.ts
+++ b/packages/bpmn-modeler/src/destroyOnFailure.ts
@@ -1,0 +1,21 @@
+/**
+ * Runs `apply` against an already-allocated `handle`; if it rejects, destroys the
+ * partial instance before rethrowing so a failed factory leaves its container and
+ * document exactly as it found them.
+ */
+export async function destroyOnFailure<T extends { destroy(): void }>(
+    handle: T,
+    apply: () => void | Promise<void>,
+): Promise<T> {
+    try {
+        await apply();
+        return handle;
+    } catch (error) {
+        try {
+            handle.destroy();
+        } catch {
+            // A secondary teardown failure must not mask the root cause.
+        }
+        throw error;
+    }
+}

--- a/packages/bpmn-modeler/src/publicApi.ts
+++ b/packages/bpmn-modeler/src/publicApi.ts
@@ -232,7 +232,15 @@ export interface ModelerOptions {
     /** A non-fatal warning (element-not-found, missing inline script) for the host log. */
     onWarning?: (message: string) => void;
 
-    /** The element-templates loader reported validation errors. */
+    /**
+     * The element-templates loader reported validation errors.
+     *
+     * During {@link createModeler}, this is the consumer's control point over a
+     * bad template set: return normally to continue creation (valid templates
+     * are applied, invalid ones skipped), or throw to abort — the partially
+     * initialised instance is destroyed and the factory rejects with the thrown
+     * error, so nothing is leaked.
+     */
     onElementTemplatesErrors?: (errors: unknown[]) => void;
 
     /** The design/implement mode changed — fired once per actual change (never on a redundant `setMode`). */
@@ -405,6 +413,10 @@ export interface CoreModelerServices {
  * resolve its {@link BpmnModelerHandle}. Async for API stability (a host that
  * learns the engine late simply calls this late); the lint stack is now injected
  * synchronously rather than awaited internally.
+ *
+ * On any initialisation failure after allocation the factory destroys the
+ * partial instance (owned DOM and document listeners removed) before rejecting,
+ * so the same container and panel roots can be reused for a retry.
  */
 export type CreateModeler = (
     container: HTMLElement,

--- a/packages/bpmn-modeler/src/viewer/createViewer.spec.ts
+++ b/packages/bpmn-modeler/src/viewer/createViewer.spec.ts
@@ -276,6 +276,47 @@ describe("createViewer (runtime, jsdom)", () => {
         });
     });
 
+    describe("leaves no residue when initialisation fails (#1495)", () => {
+        it("destroys the partial viewer and restores the container and document", async () => {
+            container = mount();
+            const parent = mount();
+
+            const realMatchMedia = window.matchMedia;
+            // `setTheme("automatic")` reads matchMedia on the first frame — the
+            // post-allocation failure the guard has to clean up after.
+            (window as any).matchMedia = () => {
+                throw new Error("matchMedia boom");
+            };
+            const addSpy = vi.spyOn(document, "addEventListener");
+            const removeSpy = vi.spyOn(document, "removeEventListener");
+
+            try {
+                await expect(
+                    createViewer(container, { propertiesPanel: { parent } }),
+                ).rejects.toThrow("matchMedia boom");
+
+                expect(container.querySelector(".bjs-container")).toBeNull();
+                expect(container.querySelector(".canvas-focus-indicator")).toBeNull();
+                expect(parent.getAttribute("data-bpmn-theme")).toBeNull();
+
+                const keydownAdds = addSpy.mock.calls.filter(([type]) => type === "keydown").length;
+                const keydownRemoves = removeSpy.mock.calls.filter(
+                    ([type]) => type === "keydown",
+                ).length;
+                expect(keydownRemoves).toBe(keydownAdds);
+            } finally {
+                addSpy.mockRestore();
+                removeSpy.mockRestore();
+                (window as any).matchMedia = realMatchMedia;
+            }
+
+            // The same roots must be reusable once the failure condition is gone.
+            viewer = await createViewer(container, { propertiesPanel: { parent } });
+            expect(viewer.getService("canvas")).toBeDefined();
+            parent.remove();
+        });
+    });
+
     // Render-dependent: jsdom has no SVG layout, so bpmn-js's viewbox transform
     // throws on import. Covered manually via the demo page + Playwright.
     it.skip("loads a diagram, selects an element, and round-trips XML/SVG", async () => {

--- a/packages/bpmn-modeler/src/viewer/createViewer.ts
+++ b/packages/bpmn-modeler/src/viewer/createViewer.ts
@@ -1,5 +1,6 @@
 import { BpmnViewer } from "./viewer";
 import type { ViewerOptions } from "./publicApi";
+import { destroyOnFailure } from "../destroyOnFailure";
 
 /**
  * Stands up one independent readonly viewer bound to `container`, then engages
@@ -14,11 +15,11 @@ export async function createViewer(
     options: ViewerOptions = {},
 ): Promise<BpmnViewer> {
     const viewer = new BpmnViewer(container, options);
-    await viewer.init();
+    return destroyOnFailure(viewer, async () => {
+        await viewer.init();
 
-    // Always engage theming so the per-instance `data-bpmn-theme` attribute is
-    // set from the first frame; `"automatic"` then follows `prefers-color-scheme`.
-    viewer.setTheme(options.theme ?? "automatic");
-
-    return viewer;
+        // Always engage theming so the per-instance `data-bpmn-theme` attribute is
+        // set from the first frame; `"automatic"` then follows `prefers-color-scheme`.
+        viewer.setTheme(options.theme ?? "automatic");
+    });
 }

--- a/packages/bpmn-modeler/src/viewer/publicApi.ts
+++ b/packages/bpmn-modeler/src/viewer/publicApi.ts
@@ -167,6 +167,10 @@ export interface BpmnViewerHandle {
  * The `@miragon/bpmn-modeler/viewer` entry point: stand up one readonly viewer
  * bound to `container` and resolve its {@link BpmnViewerHandle}. Async for API
  * stability symmetry with {@link createModeler}.
+ *
+ * On any initialisation failure after allocation the factory destroys the
+ * partial instance (owned DOM and document listeners removed) before rejecting,
+ * so the same container can be reused for a retry.
  */
 export type CreateViewer = (
     container: HTMLElement,

--- a/packages/dmn-modeler/src/createModeler.spec.ts
+++ b/packages/dmn-modeler/src/createModeler.spec.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
     setLanguage: vi.fn(),
     extras: { overlay: true },
     instances: [] as Array<{ container: HTMLElement; options: unknown }>,
+    themeImpl: (() => {}) as (theme: string) => void,
 }));
 
 vi.mock("@miragon/bpmn-modeler-i18n", () => ({
@@ -13,7 +14,8 @@ vi.mock("@miragon/bpmn-modeler-i18n", () => ({
 vi.mock("@miragon/bpmn-modeler-i18n-extras", () => ({ extras: mocks.extras }));
 vi.mock("./modeler", () => ({
     DmnModeler: class {
-        setTheme = vi.fn();
+        setTheme = vi.fn(mocks.themeImpl);
+        destroy = vi.fn();
         constructor(
             public readonly container: HTMLElement,
             public readonly options: unknown,
@@ -83,5 +85,22 @@ describe("createModeler", () => {
         await createModeler(container, options);
 
         expect(mocks.setLanguage).not.toHaveBeenCalled();
+    });
+
+    it("destroys the modeler and rethrows when setTheme fails", async () => {
+        const container = document.createElement("main");
+        const options = { propertiesPanel: { parent: document.createElement("aside") } };
+        const error = new Error("theme boom");
+        mocks.themeImpl = () => {
+            throw error;
+        };
+
+        await expect(createModeler(container, options)).rejects.toBe(error);
+
+        const failed = mocks.instances[mocks.instances.length - 1] as unknown as {
+            destroy: ReturnType<typeof vi.fn>;
+        };
+        expect(failed.destroy).toHaveBeenCalledTimes(1);
+        mocks.themeImpl = () => {};
     });
 });

--- a/packages/dmn-modeler/src/createModeler.ts
+++ b/packages/dmn-modeler/src/createModeler.ts
@@ -11,10 +11,19 @@ export async function createModeler(
 ): Promise<DmnModelerHandle> {
     i18n.extend(i18nExtras);
     const modeler = new DmnModeler(container, options);
-    modeler.setTheme(options.theme ?? "automatic");
-    // Preserve the page-global locale unless explicitly overridden.
-    if (options.locale) {
-        i18n.setLanguage(options.locale as SupportedLocale);
+    try {
+        modeler.setTheme(options.theme ?? "automatic");
+        // Preserve the page-global locale unless explicitly overridden.
+        if (options.locale) {
+            i18n.setLanguage(options.locale as SupportedLocale);
+        }
+    } catch (error) {
+        try {
+            modeler.destroy();
+        } catch {
+            // A secondary teardown failure must not mask the root cause.
+        }
+        throw error;
     }
     return modeler;
 }


### PR DESCRIPTION
## Issue

Closes #1495

## Description

`createModeler`, `createDesigner`, and `createViewer` ran construct → `init()` → configure without a guard, so any failure after allocation rejected the promise while canvas DOM, properties panel, and document listeners stayed mounted with no handle to `destroy()` — retrying stacked a second instance. Everything after allocation is now wrapped in a new `destroyOnFailure` helper that tears the partial instance down (suppressing secondary teardown errors) before rethrowing, so a rejected factory leaves the container and document clean and the same roots can be reused; the DMN `createModeler` gets the same guard inline. A throwing `onElementTemplatesErrors` callback remains the consumer's abort signal, while returning normally continues creation with the valid templates applied — documented in `publicApi.ts` and the README. Invalid element templates now also surface a user-facing info notification (VS Code toast / IntelliJ balloon) via a new `ShowInfoCommand` routed through `NotifierPort.showInfo`, while the per-error lines stay in the output channel. New mock-based factory specs cover every post-allocation failure phase, the viewer spec gains runtime DOM/listener-cleanup assertions, and the stale-walled designer spec is partially un-skipped.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A) — N/A: bugfix, no API surface change
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A) — N/A: covered by package specs

