### PR TITLE
fix(bpmn-modeler): stop debounced callbacks firing after destroy

### DIFF
--- a/libs/code-link/src/CodeLinkMapClient.spec.ts
+++ b/libs/code-link/src/CodeLinkMapClient.spec.ts
@@ -94,6 +94,29 @@ describe("CodeLinkMapClient — syncing", () => {
         expect(port.syncActivities).toHaveBeenCalledTimes(1);
     });
 
+    it("cancels the pending debounce on diagram.destroy", () => {
+        vi.useFakeTimers();
+        const { fire, port } = setup([serviceTask("Activity_1", "com.example.A")]);
+
+        fire("commandStack.changed");
+        fire("diagram.destroy");
+        vi.advanceTimersByTime(400);
+
+        expect(port.syncActivities).not.toHaveBeenCalled();
+    });
+
+    it("ignores further events once destroyed", () => {
+        vi.useFakeTimers();
+        const { fire, port } = setup([serviceTask("Activity_1", "com.example.A")]);
+
+        fire("diagram.destroy");
+        fire("commandStack.changed");
+        fire("import.done");
+        vi.advanceTimersByTime(400);
+
+        expect(port.syncActivities).not.toHaveBeenCalled();
+    });
+
     it("syncs again once a binding actually changes", () => {
         vi.useFakeTimers();
         const element = serviceTask("Activity_1", "com.example.A");

--- a/libs/code-link/src/CodeLinkMapClient.ts
+++ b/libs/code-link/src/CodeLinkMapClient.ts
@@ -71,6 +71,11 @@ export class CodeLinkMapClient {
 
     private syncTimer: ReturnType<typeof setTimeout> | undefined;
 
+    // The client is a bpmn-js DI singleton with no facade handle, so the only
+    // teardown channel is the `diagram.destroy` event; without it the trailing
+    // debounce timer outlives the modeler and pushes stale data to the host.
+    private destroyed = false;
+
     constructor(
         eventBus: EventBus,
         elementRegistry: ElementRegistryLike,
@@ -88,6 +93,13 @@ export class CodeLinkMapClient {
         });
         eventBus.on("contextPad.close", () => {
             this.currentPadTarget = undefined;
+        });
+        eventBus.on("diagram.destroy", () => {
+            this.destroyed = true;
+            if (this.syncTimer !== undefined) {
+                clearTimeout(this.syncTimer);
+                this.syncTimer = undefined;
+            }
         });
     }
 
@@ -129,6 +141,9 @@ export class CodeLinkMapClient {
     }
 
     private sendDebounced(): void {
+        if (this.destroyed) {
+            return;
+        }
         if (this.syncTimer !== undefined) {
             clearTimeout(this.syncTimer);
         }
@@ -139,6 +154,9 @@ export class CodeLinkMapClient {
     }
 
     private sendNow(): void {
+        if (this.destroyed) {
+            return;
+        }
         const entries: ImplementationEntry[] = collectImplementations(this.elementRegistry);
         const signature = JSON.stringify(entries);
         if (signature === this.lastSentSignature) {

--- a/packages/bpmn-modeler/src/rootElement.spec.ts
+++ b/packages/bpmn-modeler/src/rootElement.spec.ts
@@ -11,10 +11,16 @@ function setup(currentRootId: string, elements: Record<string, unknown> = {}) {
     const elementRegistry = {
         get: vi.fn((id: string) => elements[id]),
     };
-    const listeners: Record<string, (event: any) => void> = {};
+    const listeners: Record<string, ((event: any) => void)[]> = {};
     const eventBus = {
         on: (event: string, handler: (event: any) => void) => {
-            listeners[event] = handler;
+            (listeners[event] ??= []).push(handler);
+        },
+        off: (event: string, handler: (event: any) => void) => {
+            const handlers = listeners[event];
+            if (!handlers) return;
+            const index = handlers.indexOf(handler);
+            if (index !== -1) handlers.splice(index, 1);
         },
     };
     const manager = new RootElementManager((name: string) => {
@@ -24,8 +30,9 @@ function setup(currentRootId: string, elements: Record<string, unknown> = {}) {
         throw new Error(`unexpected service: ${name}`);
     });
     const emitRootSet = (elementId: string) =>
-        listeners["root.set"]?.({ element: { id: elementId } });
-    return { manager, canvas, elementRegistry, setRootElement, emitRootSet };
+        (listeners["root.set"] ?? []).forEach((handler) => handler({ element: { id: elementId } }));
+    const listenerCount = (event: string) => (listeners[event] ?? []).length;
+    return { manager, canvas, elementRegistry, setRootElement, emitRootSet, listenerCount };
 }
 
 afterEach(() => {
@@ -107,5 +114,17 @@ describe("RootElementManager.onRootChanged", () => {
         emitRootSet("__implicitrootbase");
 
         expect(cb).toHaveBeenCalledWith(undefined);
+    });
+
+    it("detaches its listener on dispose", () => {
+        const { manager, emitRootSet, listenerCount } = setup("Process_1");
+        const cb = vi.fn();
+
+        const dispose = manager.onRootChanged(cb);
+        dispose();
+        emitRootSet("SubProcess_1_plane");
+
+        expect(cb).not.toHaveBeenCalled();
+        expect(listenerCount("root.set")).toBe(0);
     });
 });

--- a/packages/bpmn-modeler/src/rootElement.ts
+++ b/packages/bpmn-modeler/src/rootElement.ts
@@ -71,11 +71,16 @@ export class RootElementManager {
      * @param cb Callback invoked with the new root element's ID (or
      *   `undefined` for the implicit root) whenever the active plane
      *   changes — e.g. drill-down into a collapsed sub-process.
+     * @returns a disposer that detaches the listener — call it when tearing the
+     *   surface down so repeated subscribe cycles don't accumulate listeners.
      */
-    onRootChanged(cb: (rootElementId: string | undefined) => void): void {
-        this.getService<any>("eventBus").on("root.set", (event: any) => {
+    onRootChanged(cb: (rootElementId: string | undefined) => void): () => void {
+        const eventBus = this.getService<any>("eventBus");
+        const handler = (event: any): void => {
             const id = event.element?.id;
             cb(id && !id.startsWith(IMPLICIT_ROOT_PREFIX) ? id : undefined);
-        });
+        };
+        eventBus.on("root.set", handler);
+        return () => eventBus.off("root.set", handler);
     }
 }

--- a/packages/bpmn-modeler/src/selection.spec.ts
+++ b/packages/bpmn-modeler/src/selection.spec.ts
@@ -10,12 +10,28 @@ function setup(elements: Record<string, unknown>) {
     const registry = { get: (id: string) => elements[id] };
     const select = vi.fn();
     const selection = { select, get: () => [] };
+    const listeners: Record<string, ((event: any) => void)[]> = {};
+    const eventBus = {
+        on: (event: string, handler: (event: any) => void) => {
+            (listeners[event] ??= []).push(handler);
+        },
+        off: (event: string, handler: (event: any) => void) => {
+            const handlers = listeners[event];
+            if (!handlers) return;
+            const index = handlers.indexOf(handler);
+            if (index !== -1) handlers.splice(index, 1);
+        },
+    };
     const manager = new SelectionManager((name: string) => {
         if (name === "elementRegistry") return registry as any;
         if (name === "selection") return selection as any;
+        if (name === "eventBus") return eventBus as any;
         throw new Error(`unexpected service: ${name}`);
     });
-    return { manager, select };
+    const emit = (event: string, payload?: any) =>
+        (listeners[event] ?? []).forEach((handler) => handler(payload));
+    const listenerCount = (event: string) => (listeners[event] ?? []).length;
+    return { manager, select, emit, listenerCount };
 }
 
 describe("SelectionManager.selectElementsByIds", () => {
@@ -42,5 +58,29 @@ describe("SelectionManager.selectElementsByIds", () => {
         manager.selectElementsByIds(["Task_1", "gone"]);
 
         expect(select).toHaveBeenCalledWith([task]);
+    });
+});
+
+describe("SelectionManager.onSelectionChanged", () => {
+    it("reports the mapped ids of the new selection", () => {
+        const { manager, emit } = setup({});
+        const cb = vi.fn();
+        manager.onSelectionChanged(cb);
+
+        emit("selection.changed", { newSelection: [{ id: "Task_1" }, { id: "Task_2" }] });
+
+        expect(cb).toHaveBeenCalledWith(["Task_1", "Task_2"]);
+    });
+
+    it("detaches its listener on dispose", () => {
+        const { manager, emit, listenerCount } = setup({});
+        const cb = vi.fn();
+
+        const dispose = manager.onSelectionChanged(cb);
+        dispose();
+        emit("selection.changed", { newSelection: [{ id: "Task_1" }] });
+
+        expect(cb).not.toHaveBeenCalled();
+        expect(listenerCount("selection.changed")).toBe(0);
     });
 });

--- a/packages/bpmn-modeler/src/selection.ts
+++ b/packages/bpmn-modeler/src/selection.ts
@@ -27,10 +27,17 @@ export class SelectionManager {
         this.getService<any>("selection").select(elements);
     }
 
-    onSelectionChanged(cb: (elementIds: string[]) => void): void {
-        this.getService<any>("eventBus").on("selection.changed", (event: any) => {
+    /**
+     * @returns a disposer that detaches the listener — call it when tearing the
+     *   surface down so repeated subscribe cycles don't accumulate listeners.
+     */
+    onSelectionChanged(cb: (elementIds: string[]) => void): () => void {
+        const eventBus = this.getService<any>("eventBus");
+        const handler = (event: any): void => {
             const ids = (event.newSelection ?? []).map((el: any) => el.id);
             cb(ids);
-        });
+        };
+        eventBus.on("selection.changed", handler);
+        return () => eventBus.off("selection.changed", handler);
     }
 }

--- a/packages/bpmn-modeler/src/viewport.spec.ts
+++ b/packages/bpmn-modeler/src/viewport.spec.ts
@@ -14,10 +14,16 @@ function setup(inner: Rect, outer: { width: number; height: number }) {
     const viewbox = vi.fn((box?: unknown) => (box ? undefined : { inner, outer }));
     const zoom = vi.fn();
     const canvas = { viewbox, zoom, getContainer: () => container };
-    const listeners: Record<string, (event: any) => void> = {};
+    const listeners: Record<string, ((event: any) => void)[]> = {};
     const eventBus = {
         on: (event: string, handler: (event: any) => void) => {
-            listeners[event] = handler;
+            (listeners[event] ??= []).push(handler);
+        },
+        off: (event: string, handler: (event: any) => void) => {
+            const handlers = listeners[event];
+            if (!handlers) return;
+            const index = handlers.indexOf(handler);
+            if (index !== -1) handlers.splice(index, 1);
         },
     };
     const manager = new ViewportManager((name: string) => {
@@ -25,10 +31,13 @@ function setup(inner: Rect, outer: { width: number; height: number }) {
         if (name === "eventBus") return eventBus as any;
         throw new Error(`unexpected service: ${name}`);
     });
+    const emit = (event: string, payload?: any) =>
+        (listeners[event] ?? []).forEach((handler) => handler(payload));
     /** Fires a `canvas.viewbox.changed` event at the manager's subscriber. */
     const emitViewboxChanged = (box: Partial<Rect>) =>
-        listeners["canvas.viewbox.changed"]({ viewbox: box });
-    return { manager, viewbox, zoom, emitViewboxChanged, container };
+        emit("canvas.viewbox.changed", { viewbox: box });
+    const listenerCount = (event: string) => (listeners[event] ?? []).length;
+    return { manager, viewbox, zoom, emitViewboxChanged, emit, listenerCount, container };
 }
 
 type Rect = { x: number; y: number; width: number; height: number; scale?: number };
@@ -317,6 +326,47 @@ describe("ViewportManager.onViewportChanged", () => {
 
         expect(cb).not.toHaveBeenCalled();
         vi.useRealTimers();
+    });
+
+    it("cancels a pending debounce on diagram.destroy", () => {
+        vi.useFakeTimers();
+        const { manager, emitViewboxChanged, emit } = setup(inner, { width: 1000, height: 800 });
+        const cb = vi.fn();
+        manager.onViewportChanged(cb);
+
+        emitViewboxChanged({ x: 1, y: 2, width: 300, height: 200, scale: 2.5 });
+        emit("diagram.destroy");
+        vi.advanceTimersByTime(100);
+
+        expect(cb).not.toHaveBeenCalled();
+        vi.useRealTimers();
+    });
+
+    it("cancels a pending debounce when the disposer is called", () => {
+        vi.useFakeTimers();
+        const { manager, emitViewboxChanged } = setup(inner, { width: 1000, height: 800 });
+        const cb = vi.fn();
+        const dispose = manager.onViewportChanged(cb);
+
+        emitViewboxChanged({ x: 1, y: 2, width: 300, height: 200, scale: 2.5 });
+        dispose();
+        vi.advanceTimersByTime(100);
+
+        expect(cb).not.toHaveBeenCalled();
+        vi.useRealTimers();
+    });
+
+    it("detaches its listeners on dispose and tolerates a double dispose", () => {
+        const { manager, listenerCount } = setup(inner, { width: 1000, height: 800 });
+
+        for (let i = 0; i < 3; i++) {
+            const dispose = manager.onViewportChanged(vi.fn());
+            dispose();
+            dispose();
+        }
+
+        expect(listenerCount("canvas.viewbox.changed")).toBe(0);
+        expect(listenerCount("diagram.destroy")).toBe(0);
     });
 });
 

--- a/packages/bpmn-modeler/src/viewport.ts
+++ b/packages/bpmn-modeler/src/viewport.ts
@@ -233,10 +233,15 @@ export class ViewportManager {
      * since every later rebuild of that tab would restore an unusable box.
      *
      * @param cb Callback invoked with the new {@link ViewportData} after each change.
+     * @returns a disposer that unsubscribes the listener and cancels any pending
+     *   debounced callback — call it when tearing the surface down.
      */
-    onViewportChanged(cb: (viewport: ViewportData) => void): void {
+    onViewportChanged(cb: (viewport: ViewportData) => void): () => void {
         let timer: ReturnType<typeof setTimeout> | undefined;
-        this.getService<any>("eventBus").on("canvas.viewbox.changed", (event: any) => {
+        // Capture the bus so the disposer works after facade destroy, when the
+        // service accessor would throw NoModelerError.
+        const eventBus = this.getService<any>("eventBus");
+        const handler = (event: any): void => {
             clearTimeout(timer);
             timer = setTimeout(() => {
                 const { x, y, width, height, scale } = event.viewbox;
@@ -245,6 +250,16 @@ export class ViewportManager {
                     cb(viewport);
                 }
             }, 100);
-        });
+        };
+        const dispose = (): void => {
+            clearTimeout(timer);
+            eventBus.off("canvas.viewbox.changed", handler);
+            eventBus.off("diagram.destroy", dispose);
+        };
+        eventBus.on("canvas.viewbox.changed", handler);
+        // Self-hook teardown so the trailing debounce is cancelled even when the
+        // host never unsubscribes.
+        eventBus.on("diagram.destroy", dispose);
+        return dispose;
     }
 }


### PR DESCRIPTION
## Issue

Closes #1494

## Description

Debounced notification paths kept running after the modeler surface was destroyed, so hosts could receive stale data for a document they had already replaced. `CodeLinkMapClient` now cancels its 400 ms sync timer and guards both send paths with a `destroyed` flag set on `diagram.destroy`. `ViewportManager.onViewportChanged` returns a disposer that clears the 100 ms debounce and unsubscribes, and self-registers it on `diagram.destroy` so the trailing callback is cancelled even when the host never unsubscribes. `onSelectionChanged` and `onRootChanged` also return disposers, so repeated subscribe cycles no longer accumulate event-bus listeners; the `void` → `() => void` return-type widening is additive for all existing callers.

## Author checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <subject>`; breaking changes marked with `!`)
- [x] Tests added or updated (or N/A)
- [x] Docs (or N/A)
- [x] ADR added under `docs/adr/` (see the rules in [`docs/adr/0001`](../docs/adr/0001-record-architecture-decisions.md)) (or N/A)
- [x] Self-reviewed the diff
- [x] No new architecture-test violations (`architecture.spec.ts`, part of `corepack yarn test`)
- [x] Verified in the affected hosts — VS Code / IntelliJ / standalone (or N/A)
